### PR TITLE
feat: add reverse compiler with TypeScript, Python, and Go adapters (M6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Specter will be documented in this file.
 
+## [0.2.0] - 2026-04-03
+
+### Added
+
+- `specter reverse` command — reverse compiler extracts draft .spec.yaml from existing code
+- Plugin adapter architecture with 3 built-in adapters: TypeScript, Python, Go
+- TypeScript adapter: Zod schemas, Jest/Vitest tests, Next.js/Express routes
+- Python adapter: Pydantic models, pytest tests, FastAPI/Django routes
+- Go adapter: struct validate tags, table-driven tests, net/http/gin/chi routes
+- Gap detection: flags constraints without test coverage
+- Auto-detection of language adapter from file extensions
+- spec-reverse.spec.yaml (10 constraints, 14 ACs)
+- 77 total tests (up from 37)
+
 ## [0.1.0-alpha.2] - 2026-04-02
 
 ### Changed

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Hanalyx/specter/internal/parser"
 	"github.com/Hanalyx/specter/internal/resolver"
 	"github.com/Hanalyx/specter/internal/schema"
+	"github.com/Hanalyx/specter/internal/reverse"
 	specsync "github.com/Hanalyx/specter/internal/sync"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,7 @@ func main() {
 	root.AddCommand(checkCmd())
 	root.AddCommand(coverageCmd())
 	root.AddCommand(syncCmd())
+	root.AddCommand(reverseCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -450,5 +452,149 @@ func syncCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().StringVar(&testsGlob, "tests", "", "Glob pattern for test files")
+	return cmd
+}
+
+func reverseCmd() *cobra.Command {
+	var (
+		jsonOutput  bool
+		adapterName string
+		outputDir   string
+		groupBy     string
+		dryRun      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "reverse [path]",
+		Short: "Extract draft .spec.yaml files from existing source code",
+		Long:  "Analyze source code and test files to generate draft .spec.yaml specifications. Uses language-specific adapters (typescript, python, go) to extract constraints from validation schemas, acceptance criteria from test assertions, and gaps where constraints lack test coverage.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			targetPath := "."
+			if len(args) > 0 {
+				targetPath = args[0]
+			}
+
+			// Walk target path and read source files
+			var files []reverse.SourceFile
+			skipDirs := map[string]bool{
+				"node_modules": true, "dist": true, ".git": true,
+				"vendor": true, "__pycache__": true, ".next": true,
+				"testdata": true, "bin": true,
+			}
+
+			_ = filepath.Walk(targetPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return nil
+				}
+				if info.IsDir() && skipDirs[info.Name()] {
+					return filepath.SkipDir
+				}
+				if info.IsDir() {
+					return nil
+				}
+				lang := reverse.DetectLanguage(path)
+				if lang == "" {
+					base := filepath.Base(path)
+					if base != "package.json" && base != "go.mod" && base != "pyproject.toml" {
+						return nil
+					}
+				}
+				data, readErr := os.ReadFile(path)
+				if readErr != nil {
+					return nil
+				}
+				files = append(files, reverse.SourceFile{
+					Path:    path,
+					Content: string(data),
+				})
+				return nil
+			})
+
+			if len(files) == 0 {
+				fmt.Println("No source files found.")
+				os.Exit(1)
+			}
+
+			adapters := []reverse.Adapter{
+				&reverse.TypeScriptAdapter{},
+				&reverse.PythonAdapter{},
+				&reverse.GoAdapter{},
+			}
+
+			date := "2026-04-02"
+
+			input := reverse.ReverseInput{
+				Files:       files,
+				AdapterName: adapterName,
+				GroupBy:     groupBy,
+				Date:        date,
+			}
+
+			result := reverse.Reverse(input, adapters)
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(map[string]interface{}{
+					"specs":       result.Specs,
+					"diagnostics": result.Diagnostics,
+					"summary":     result.Summary,
+				})
+				if result.Summary.SpecsGenerated == 0 {
+					os.Exit(1)
+				}
+				return nil
+			}
+
+			for _, d := range result.Diagnostics {
+				fmt.Fprintf(os.Stderr, "%s [%s] %s\n", d.Severity, d.Kind, d.Message)
+			}
+
+			if result.Summary.SpecsGenerated == 0 {
+				fmt.Println("No specs generated. Check diagnostics above.")
+				os.Exit(1)
+			}
+
+			for _, gs := range result.Specs {
+				if dryRun {
+					fmt.Printf("--- %s (dry-run) ---\n", gs.FileName)
+					fmt.Println(gs.YAML)
+					for _, w := range gs.Warnings {
+						fmt.Fprintf(os.Stderr, "  warning: %s\n", w)
+					}
+					continue
+				}
+
+				outPath := filepath.Join(outputDir, gs.FileName)
+				if mkErr := os.MkdirAll(outputDir, 0755); mkErr != nil {
+					fmt.Fprintf(os.Stderr, "error creating output directory: %v\n", mkErr)
+					os.Exit(1)
+				}
+				if wErr := os.WriteFile(outPath, []byte(gs.YAML), 0644); wErr != nil {
+					fmt.Fprintf(os.Stderr, "error writing %s: %v\n", outPath, wErr)
+					os.Exit(1)
+				}
+				fmt.Printf("GENERATED %s — %s@%s (%d constraints, %d ACs)\n",
+					outPath, gs.Spec.ID, gs.Spec.Version,
+					len(gs.Spec.Constraints), len(gs.Spec.AcceptanceCriteria))
+				for _, w := range gs.Warnings {
+					fmt.Fprintf(os.Stderr, "  warning: %s\n", w)
+				}
+			}
+
+			fmt.Printf("\nSummary: %d spec(s) generated, %d constraint(s), %d assertion(s), %d gap(s)\n",
+				result.Summary.SpecsGenerated, result.Summary.ConstraintsFound,
+				result.Summary.AssertionsFound, result.Summary.GapsDetected)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
+	cmd.Flags().StringVar(&adapterName, "adapter", "", "Language adapter (typescript, python, go). Auto-detects if omitted")
+	cmd.Flags().StringVarP(&outputDir, "output", "o", "specs", "Output directory for generated .spec.yaml files")
+	cmd.Flags().StringVar(&groupBy, "group-by", "file", "Grouping strategy: file or directory")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview output without writing files")
+
 	return cmd
 }

--- a/specter/internal/reverse/adapter_go.go
+++ b/specter/internal/reverse/adapter_go.go
@@ -1,0 +1,274 @@
+package reverse
+
+import (
+	"regexp"
+	"strings"
+)
+
+// GoAdapter extracts spec data from Go source code.
+type GoAdapter struct{}
+
+func (a *GoAdapter) Name() string { return "go" }
+
+func (a *GoAdapter) Detect(path, content string) bool {
+	return strings.HasSuffix(path, ".go")
+}
+
+func (a *GoAdapter) IsTestFile(path string) bool {
+	return strings.HasSuffix(path, "_test.go")
+}
+
+// --- Route Extraction ---
+
+var (
+	httpHandleFuncRE = regexp.MustCompile(`http\.HandleFunc\s*\(\s*"([^"]+)"\s*,\s*(\w+)`)
+	ginRouteRE       = regexp.MustCompile(`(?:r|router|group|g|e)\.(GET|POST|PUT|DELETE|PATCH)\s*\(\s*"([^"]+)"`)
+	chiRouteRE       = regexp.MustCompile(`r\.(Get|Post|Put|Delete|Patch)\s*\(\s*"([^"]+)"`)
+	muxHandleRE      = regexp.MustCompile(`(?:r|router)\.HandleFunc\s*\(\s*"([^"]+)"\s*\)\.Methods\s*\(\s*"([^"]+)"`)
+)
+
+func (a *GoAdapter) ExtractRoutes(path, content string) []ExtractedRoute {
+	var routes []ExtractedRoute
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		if m := httpHandleFuncRE.FindStringSubmatch(line); len(m) > 2 {
+			routes = append(routes, ExtractedRoute{
+				Method: "ANY", Path: m[1], Handler: m[2], File: path, Line: lineNum,
+			})
+		}
+		if m := ginRouteRE.FindStringSubmatch(line); len(m) > 2 {
+			routes = append(routes, ExtractedRoute{
+				Method: strings.ToUpper(m[1]), Path: m[2], Handler: "", File: path, Line: lineNum,
+			})
+		}
+		if m := chiRouteRE.FindStringSubmatch(line); len(m) > 2 {
+			routes = append(routes, ExtractedRoute{
+				Method: strings.ToUpper(m[1]), Path: m[2], Handler: "", File: path, Line: lineNum,
+			})
+		}
+		if m := muxHandleRE.FindStringSubmatch(line); len(m) > 2 {
+			routes = append(routes, ExtractedRoute{
+				Method: strings.ToUpper(m[2]), Path: m[1], Handler: "", File: path, Line: lineNum,
+			})
+		}
+	}
+
+	return routes
+}
+
+// --- Constraint Extraction ---
+
+var (
+	validateTagRE = regexp.MustCompile("(?s)`[^`]*validate:\"([^\"]+)\"[^`]*`")
+	jsonTagRE     = regexp.MustCompile("(?s)`[^`]*json:\"([^\"]+)\"[^`]*`")
+	structFieldRE = regexp.MustCompile(`(\w+)\s+\S+\s+` + "`")
+)
+
+func (a *GoAdapter) ExtractConstraints(path, content string) []ExtractedConstraint {
+	var constraints []ExtractedConstraint
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// Extract field name from struct field line
+		fieldName := ""
+		if m := structFieldRE.FindStringSubmatch(line); len(m) > 1 {
+			fieldName = m[1]
+		}
+		// Try json tag for field name if struct field didn't match
+		if fieldName == "" {
+			if m := jsonTagRE.FindStringSubmatch(line); len(m) > 1 {
+				parts := strings.Split(m[1], ",")
+				if parts[0] != "" && parts[0] != "-" {
+					fieldName = parts[0]
+				}
+			}
+		}
+
+		// Extract validate tag rules
+		if m := validateTagRE.FindStringSubmatch(line); len(m) > 1 {
+			rules := strings.Split(m[1], ",")
+			for _, rule := range rules {
+				rule = strings.TrimSpace(rule)
+				if rule == "" {
+					continue
+				}
+				c := ExtractedConstraint{
+					Field:      fieldName,
+					SourceFile: path,
+					Line:       lineNum,
+				}
+				if parts := strings.SplitN(rule, "=", 2); len(parts) == 2 {
+					c.Rule = parts[0]
+					c.Value = parts[1]
+				} else {
+					c.Rule = rule
+				}
+				constraints = append(constraints, c)
+			}
+		}
+	}
+
+	return constraints
+}
+
+// --- Assertion Extraction ---
+
+var (
+	testFuncRE  = regexp.MustCompile(`func\s+(Test\w+)\s*\(\s*t\s+\*testing\.T\s*\)`)
+	subTestRE   = regexp.MustCompile(`t\.Run\s*\(\s*"([^"]+)"`)
+	tableDriveRE = regexp.MustCompile(`\{\s*name:\s*"([^"]+)"`)
+)
+
+func (a *GoAdapter) ExtractAssertions(path, content string) []ExtractedAssertion {
+	var assertions []ExtractedAssertion
+	lines := strings.Split(content, "\n")
+
+	currentTestFunc := ""
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// Top-level test function
+		if m := testFuncRE.FindStringSubmatch(line); len(m) > 1 {
+			currentTestFunc = m[1]
+		}
+
+		// Sub-tests via t.Run
+		if m := subTestRE.FindStringSubmatch(line); len(m) > 1 {
+			desc := m[1]
+			assertions = append(assertions, ExtractedAssertion{
+				TestName:    currentTestFunc + "/" + desc,
+				Description: desc,
+				IsError:     isErrorDescription(desc),
+				SourceFile:  path,
+				Line:        lineNum,
+			})
+		}
+
+		// Table-driven test entries
+		if m := tableDriveRE.FindStringSubmatch(line); len(m) > 1 {
+			desc := m[1]
+			assertions = append(assertions, ExtractedAssertion{
+				TestName:    currentTestFunc + "/" + desc,
+				Description: desc,
+				IsError:     isErrorDescription(desc),
+				SourceFile:  path,
+				Line:        lineNum,
+			})
+		}
+	}
+
+	// If no sub-tests or table entries were found, use top-level test functions
+	if len(assertions) == 0 {
+		for i, line := range lines {
+			if m := testFuncRE.FindStringSubmatch(line); len(m) > 1 {
+				name := m[1]
+				desc := testNameToDescription(name)
+				assertions = append(assertions, ExtractedAssertion{
+					TestName:    name,
+					Description: desc,
+					IsError:     isErrorDescription(desc),
+					SourceFile:  path,
+					Line:        i + 1,
+				})
+			}
+		}
+	}
+
+	return assertions
+}
+
+// --- Import Extraction ---
+
+var importLineRE = regexp.MustCompile(`^\s*"([^"]+)"`)
+
+func (a *GoAdapter) ExtractImports(path, content string) []ExtractedImport {
+	var imports []ExtractedImport
+	lines := strings.Split(content, "\n")
+	inImportBlock := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "import (") {
+			inImportBlock = true
+			continue
+		}
+		if inImportBlock && trimmed == ")" {
+			inImportBlock = false
+			continue
+		}
+
+		if inImportBlock {
+			if m := importLineRE.FindStringSubmatch(trimmed); len(m) > 1 {
+				imports = append(imports, ExtractedImport{Module: m[1], File: path})
+			}
+		}
+
+		// Single-line import
+		if strings.HasPrefix(trimmed, "import \"") {
+			start := strings.Index(trimmed, "\"") + 1
+			end := strings.LastIndex(trimmed, "\"")
+			if start > 0 && end > start {
+				imports = append(imports, ExtractedImport{Module: trimmed[start:end], File: path})
+			}
+		}
+	}
+
+	return imports
+}
+
+// --- System Name Inference ---
+
+var goModuleRE = regexp.MustCompile(`module\s+(\S+)`)
+
+func (a *GoAdapter) InferSystemName(files []SourceFile) string {
+	for _, f := range files {
+		if strings.HasSuffix(f.Path, "go.mod") || strings.Contains(f.Path, "/go.mod") {
+			if m := goModuleRE.FindStringSubmatch(f.Content); len(m) > 1 {
+				parts := strings.Split(m[1], "/")
+				return parts[len(parts)-1]
+			}
+		}
+	}
+	return ""
+}
+
+// --- Helpers ---
+
+func isErrorDescription(desc string) bool {
+	lower := strings.ToLower(desc)
+	errorKeywords := []string{"error", "fail", "invalid", "reject", "deny", "denied", "unauthorized", "forbidden", "bad", "missing", "empty", "null", "nil"}
+	for _, kw := range errorKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func testNameToDescription(name string) string {
+	// Strip "Test" prefix
+	if strings.HasPrefix(name, "Test") {
+		name = name[4:]
+	}
+	// Insert spaces before capitals
+	var result strings.Builder
+	for i, r := range name {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			prev := rune(name[i-1])
+			if prev >= 'a' && prev <= 'z' {
+				result.WriteRune(' ')
+			}
+		}
+		result.WriteRune(r)
+	}
+	desc := strings.TrimSpace(result.String())
+	// Convert underscores to spaces
+	desc = strings.ReplaceAll(desc, "_", " ")
+	return strings.ToLower(desc)
+}

--- a/specter/internal/reverse/adapter_go_test.go
+++ b/specter/internal/reverse/adapter_go_test.go
@@ -1,0 +1,194 @@
+// @spec spec-reverse
+package reverse
+
+import "testing"
+
+var goAdapter = &GoAdapter{}
+
+// @ac AC-01
+func TestGoAdapter_ExtractConstraints_StructTags(t *testing.T) {
+	content := `package main
+
+type CreateUserRequest struct {
+	Name  string ` + "`" + `json:"name" validate:"required,min=1,max=100"` + "`" + `
+	Email string ` + "`" + `json:"email" validate:"required,email"` + "`" + `
+	Age   int    ` + "`" + `json:"age" validate:"min=18,max=120"` + "`" + `
+}
+`
+	constraints := goAdapter.ExtractConstraints("handler.go", content)
+	if len(constraints) == 0 {
+		t.Fatal("expected constraints, got none")
+	}
+
+	// Check we found required, min, max, email rules
+	rules := make(map[string]bool)
+	for _, c := range constraints {
+		rules[c.Rule] = true
+	}
+
+	for _, expected := range []string{"required", "min", "max", "email"} {
+		if !rules[expected] {
+			t.Errorf("expected rule %q, not found in extracted constraints", expected)
+		}
+	}
+}
+
+// @ac AC-02
+func TestGoAdapter_ExtractAssertions_SubTests(t *testing.T) {
+	content := `package main
+
+import "testing"
+
+func TestCreateUser(t *testing.T) {
+	t.Run("returns 200 on valid input", func(t *testing.T) {
+		// ...
+	})
+	t.Run("returns 400 when name is empty", func(t *testing.T) {
+		// ...
+	})
+}
+`
+	assertions := goAdapter.ExtractAssertions("handler_test.go", content)
+	if len(assertions) != 2 {
+		t.Fatalf("expected 2 assertions, got %d", len(assertions))
+	}
+	if assertions[0].Description != "returns 200 on valid input" {
+		t.Errorf("first assertion description = %q, want %q", assertions[0].Description, "returns 200 on valid input")
+	}
+	if assertions[1].Description != "returns 400 when name is empty" {
+		t.Errorf("second assertion description = %q, want %q", assertions[1].Description, "returns 400 when name is empty")
+	}
+	if !assertions[1].IsError {
+		t.Error("second assertion should be marked as error case")
+	}
+}
+
+func TestGoAdapter_ExtractAssertions_TableDriven(t *testing.T) {
+	content := `package main
+
+import "testing"
+
+func TestValidateAge(t *testing.T) {
+	tests := []struct {
+		name string
+		age  int
+		want bool
+	}{
+		{name: "valid age", age: 25, want: true},
+		{name: "invalid age below minimum", age: 10, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {})
+	}
+}
+`
+	assertions := goAdapter.ExtractAssertions("validate_test.go", content)
+	if len(assertions) != 2 {
+		t.Fatalf("expected 2 assertions, got %d", len(assertions))
+	}
+	if assertions[0].Description != "valid age" {
+		t.Errorf("got %q, want %q", assertions[0].Description, "valid age")
+	}
+	if assertions[1].Description != "invalid age below minimum" {
+		t.Errorf("got %q, want %q", assertions[1].Description, "invalid age below minimum")
+	}
+}
+
+func TestGoAdapter_ExtractRoutes_HttpHandleFunc(t *testing.T) {
+	content := `package main
+
+import "net/http"
+
+func main() {
+	http.HandleFunc("/api/users", handleUsers)
+	http.HandleFunc("/api/health", handleHealth)
+}
+`
+	routes := goAdapter.ExtractRoutes("main.go", content)
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if routes[0].Path != "/api/users" {
+		t.Errorf("first route path = %q, want %q", routes[0].Path, "/api/users")
+	}
+	if routes[0].Handler != "handleUsers" {
+		t.Errorf("first route handler = %q, want %q", routes[0].Handler, "handleUsers")
+	}
+}
+
+func TestGoAdapter_ExtractRoutes_Gin(t *testing.T) {
+	content := `package main
+
+func setupRoutes(r *gin.Engine) {
+	r.GET("/api/users", listUsers)
+	r.POST("/api/users", createUser)
+	r.DELETE("/api/users/:id", deleteUser)
+}
+`
+	routes := goAdapter.ExtractRoutes("routes.go", content)
+	if len(routes) != 3 {
+		t.Fatalf("expected 3 routes, got %d", len(routes))
+	}
+	if routes[0].Method != "GET" || routes[0].Path != "/api/users" {
+		t.Errorf("first route = %s %s, want GET /api/users", routes[0].Method, routes[0].Path)
+	}
+	if routes[2].Method != "DELETE" || routes[2].Path != "/api/users/:id" {
+		t.Errorf("third route = %s %s, want DELETE /api/users/:id", routes[2].Method, routes[2].Path)
+	}
+}
+
+func TestGoAdapter_ExtractImports(t *testing.T) {
+	content := `package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/myorg/mylib/auth"
+)
+`
+	imports := goAdapter.ExtractImports("main.go", content)
+	if len(imports) != 4 {
+		t.Fatalf("expected 4 imports, got %d", len(imports))
+	}
+	modules := make(map[string]bool)
+	for _, imp := range imports {
+		modules[imp.Module] = true
+	}
+	if !modules["github.com/gin-gonic/gin"] {
+		t.Error("expected gin import")
+	}
+	if !modules["net/http"] {
+		t.Error("expected net/http import")
+	}
+}
+
+func TestGoAdapter_InferSystemName(t *testing.T) {
+	files := []SourceFile{
+		{Path: "go.mod", Content: "module github.com/hanalyx/specter\n\ngo 1.22\n"},
+		{Path: "main.go", Content: "package main"},
+	}
+	name := goAdapter.InferSystemName(files)
+	if name != "specter" {
+		t.Errorf("InferSystemName = %q, want %q", name, "specter")
+	}
+}
+
+func TestGoAdapter_Detect(t *testing.T) {
+	if !goAdapter.Detect("main.go", "") {
+		t.Error("expected Detect to return true for .go file")
+	}
+	if goAdapter.Detect("main.py", "") {
+		t.Error("expected Detect to return false for .py file")
+	}
+}
+
+func TestGoAdapter_IsTestFile(t *testing.T) {
+	if !goAdapter.IsTestFile("handler_test.go") {
+		t.Error("expected IsTestFile true for _test.go")
+	}
+	if goAdapter.IsTestFile("handler.go") {
+		t.Error("expected IsTestFile false for .go without _test")
+	}
+}

--- a/specter/internal/reverse/adapter_python.go
+++ b/specter/internal/reverse/adapter_python.go
@@ -1,0 +1,275 @@
+package reverse
+
+import (
+	"regexp"
+	"strings"
+)
+
+// PythonAdapter extracts spec data from Python source code (FastAPI, Django, Flask).
+type PythonAdapter struct{}
+
+func (a *PythonAdapter) Name() string { return "python" }
+
+func (a *PythonAdapter) Detect(path, content string) bool {
+	return strings.HasSuffix(path, ".py")
+}
+
+func (a *PythonAdapter) IsTestFile(path string) bool {
+	base := path
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		base = path[idx+1:]
+	}
+	if strings.HasPrefix(base, "test_") && strings.HasSuffix(base, ".py") {
+		return true
+	}
+	if strings.HasSuffix(base, "_test.py") {
+		return true
+	}
+	if strings.Contains(path, "/tests/") {
+		return true
+	}
+	return false
+}
+
+// --- Route Extraction ---
+
+var (
+	fastapiRouteRE = regexp.MustCompile(`@(?:app|router)\.(get|post|put|delete|patch)\(\s*['"]([^'"]+)['"]`)
+	djangoPathRE   = regexp.MustCompile(`path\(\s*['"]([^'"]+)['"]`)
+	flaskRouteRE   = regexp.MustCompile(`@(?:app|bp)\.route\(\s*['"]([^'"]+)['"]`)
+	flaskMethodsRE = regexp.MustCompile(`methods\s*=\s*\[([^\]]+)\]`)
+)
+
+func (a *PythonAdapter) ExtractRoutes(path, content string) []ExtractedRoute {
+	var routes []ExtractedRoute
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// FastAPI: @app.get("/path") or @router.post("/path")
+		if m := fastapiRouteRE.FindStringSubmatch(line); len(m) > 2 {
+			routes = append(routes, ExtractedRoute{
+				Method: strings.ToUpper(m[1]), Path: m[2], Handler: "", File: path, Line: lineNum,
+			})
+		}
+
+		// Django: path("route", ...)
+		if m := djangoPathRE.FindStringSubmatch(line); len(m) > 1 {
+			routes = append(routes, ExtractedRoute{
+				Method: "ANY", Path: m[1], Handler: "", File: path, Line: lineNum,
+			})
+		}
+
+		// Flask: @app.route("/path", methods=["GET", "POST"])
+		if m := flaskRouteRE.FindStringSubmatch(line); len(m) > 1 {
+			method := "ANY"
+			if mm := flaskMethodsRE.FindStringSubmatch(line); len(mm) > 1 {
+				// Parse first method from the list
+				methods := strings.Split(mm[1], ",")
+				if len(methods) > 0 {
+					method = strings.ToUpper(strings.Trim(strings.TrimSpace(methods[0]), "\"'"))
+				}
+			}
+			routes = append(routes, ExtractedRoute{
+				Method: method, Path: m[1], Handler: "", File: path, Line: lineNum,
+			})
+		}
+	}
+
+	return routes
+}
+
+// --- Constraint Extraction ---
+
+var (
+	pydanticFieldRE    = regexp.MustCompile(`(\w+)\s*:\s*\w+\s*=\s*Field\(([^)]+)\)`)
+	fieldMinLengthRE   = regexp.MustCompile(`min_length\s*=\s*(\d+)`)
+	fieldMaxLengthRE   = regexp.MustCompile(`max_length\s*=\s*(\d+)`)
+	fieldGeRE          = regexp.MustCompile(`ge\s*=\s*(\d+)`)
+	fieldLeRE          = regexp.MustCompile(`le\s*=\s*(\d+)`)
+	fieldRegexRE       = regexp.MustCompile(`regex\s*=\s*['"]([^'"]+)['"]`)
+	requiredFieldRE    = regexp.MustCompile(`(\w+)\s*:\s*(\w+)\s*$`)
+	sqlaNullableRE     = regexp.MustCompile(`(\w+)\s*=\s*Column\(.*nullable\s*=\s*False`)
+)
+
+func (a *PythonAdapter) ExtractConstraints(path, content string) []ExtractedConstraint {
+	var constraints []ExtractedConstraint
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1
+		trimmed := strings.TrimSpace(line)
+
+		// Pydantic Field() with validators
+		if m := pydanticFieldRE.FindStringSubmatch(trimmed); len(m) > 2 {
+			fieldName := m[1]
+			args := m[2]
+
+			if mm := fieldMinLengthRE.FindStringSubmatch(args); len(mm) > 1 {
+				constraints = append(constraints, ExtractedConstraint{
+					Field: fieldName, Rule: "min_length", Value: mm[1],
+					SourceFile: path, Line: lineNum,
+				})
+			}
+			if mm := fieldMaxLengthRE.FindStringSubmatch(args); len(mm) > 1 {
+				constraints = append(constraints, ExtractedConstraint{
+					Field: fieldName, Rule: "max_length", Value: mm[1],
+					SourceFile: path, Line: lineNum,
+				})
+			}
+			if mm := fieldGeRE.FindStringSubmatch(args); len(mm) > 1 {
+				constraints = append(constraints, ExtractedConstraint{
+					Field: fieldName, Rule: "ge", Value: mm[1],
+					SourceFile: path, Line: lineNum,
+				})
+			}
+			if mm := fieldLeRE.FindStringSubmatch(args); len(mm) > 1 {
+				constraints = append(constraints, ExtractedConstraint{
+					Field: fieldName, Rule: "le", Value: mm[1],
+					SourceFile: path, Line: lineNum,
+				})
+			}
+			if mm := fieldRegexRE.FindStringSubmatch(args); len(mm) > 1 {
+				constraints = append(constraints, ExtractedConstraint{
+					Field: fieldName, Rule: "pattern", Value: mm[1],
+					SourceFile: path, Line: lineNum,
+				})
+			}
+			continue
+		}
+
+		// Required field: type annotation without Optional or default value
+		if m := requiredFieldRE.FindStringSubmatch(trimmed); len(m) > 2 {
+			typeName := m[2]
+			if typeName != "Optional" && !strings.Contains(trimmed, "=") && !strings.HasPrefix(trimmed, "#") && !strings.HasPrefix(trimmed, "def ") && !strings.HasPrefix(trimmed, "class ") {
+				constraints = append(constraints, ExtractedConstraint{
+					Field: m[1], Rule: "required",
+					SourceFile: path, Line: lineNum,
+				})
+			}
+		}
+
+		// SQLAlchemy Column(... nullable=False)
+		if m := sqlaNullableRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: m[1], Rule: "required",
+				SourceFile: path, Line: lineNum,
+			})
+		}
+	}
+
+	return constraints
+}
+
+// --- Assertion Extraction ---
+
+var (
+	pytestFuncRE       = regexp.MustCompile(`def\s+test_(\w+)`)
+	pytestRaisesRE     = regexp.MustCompile(`pytest\.raises\((\w+)\)`)
+	assertStatusCodeRE = regexp.MustCompile(`assert\s+response\.status_code\s*==\s*(\d+)`)
+	pytestClassRE      = regexp.MustCompile(`class\s+Test(\w+)\s*:`)
+)
+
+func (a *PythonAdapter) ExtractAssertions(path, content string) []ExtractedAssertion {
+	var assertions []ExtractedAssertion
+	lines := strings.Split(content, "\n")
+
+	currentClass := ""
+	for i, line := range lines {
+		lineNum := i + 1
+		trimmed := strings.TrimSpace(line)
+
+		// Test class
+		if m := pytestClassRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			currentClass = m[1]
+		}
+
+		// Test function
+		if m := pytestFuncRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			funcName := m[1]
+			desc := strings.ReplaceAll(funcName, "_", " ")
+			testName := "test_" + funcName
+			if currentClass != "" {
+				testName = "Test" + currentClass + "::" + testName
+			}
+
+			isError := isErrorDescription(desc)
+
+			// Look ahead for pytest.raises and status code assertions
+			errorDesc := ""
+			for j := i + 1; j < len(lines) && j < i+20; j++ {
+				aheadLine := strings.TrimSpace(lines[j])
+				// Stop at next function or class definition
+				if strings.HasPrefix(aheadLine, "def ") || strings.HasPrefix(aheadLine, "class ") {
+					break
+				}
+				if rm := pytestRaisesRE.FindStringSubmatch(aheadLine); len(rm) > 1 {
+					isError = true
+					errorDesc = rm[1]
+				}
+				if sm := assertStatusCodeRE.FindStringSubmatch(aheadLine); len(sm) > 1 {
+					code := sm[1]
+					if code >= "400" {
+						isError = true
+					}
+				}
+			}
+
+			assertions = append(assertions, ExtractedAssertion{
+				TestName:    testName,
+				Description: desc,
+				IsError:     isError,
+				ErrorDesc:   errorDesc,
+				SourceFile:  path,
+				Line:        lineNum,
+			})
+		}
+	}
+
+	return assertions
+}
+
+// --- Import Extraction ---
+
+var (
+	pyFromImportRE = regexp.MustCompile(`^from\s+(\S+)\s+import`)
+	pyImportRE     = regexp.MustCompile(`^import\s+(\S+)`)
+)
+
+func (a *PythonAdapter) ExtractImports(path, content string) []ExtractedImport {
+	var imports []ExtractedImport
+	lines := strings.Split(content, "\n")
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// from X import ... (takes priority, check first)
+		if m := pyFromImportRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			imports = append(imports, ExtractedImport{Module: m[1], File: path})
+			continue
+		}
+
+		// import X (only if not a "from ... import")
+		if m := pyImportRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			imports = append(imports, ExtractedImport{Module: m[1], File: path})
+		}
+	}
+
+	return imports
+}
+
+// --- System Name Inference ---
+
+var pyProjectNameRE = regexp.MustCompile(`name\s*=\s*"([^"]+)"`)
+
+func (a *PythonAdapter) InferSystemName(files []SourceFile) string {
+	for _, f := range files {
+		if strings.HasSuffix(f.Path, "pyproject.toml") || strings.Contains(f.Path, "/pyproject.toml") {
+			if m := pyProjectNameRE.FindStringSubmatch(f.Content); len(m) > 1 {
+				return m[1]
+			}
+		}
+	}
+	return ""
+}

--- a/specter/internal/reverse/adapter_python_test.go
+++ b/specter/internal/reverse/adapter_python_test.go
@@ -1,0 +1,314 @@
+// @spec spec-reverse
+package reverse
+
+import "testing"
+
+var pythonAdapter = &PythonAdapter{}
+
+// @ac AC-05
+func TestPythonAdapter_ExtractConstraints_PydanticField(t *testing.T) {
+	content := `from pydantic import BaseModel, Field
+
+class CreateUserRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    age: int = Field(ge=18, le=120)
+    email: str = Field(regex="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+$")
+`
+	constraints := pythonAdapter.ExtractConstraints("models.py", content)
+	if len(constraints) == 0 {
+		t.Fatal("expected constraints, got none")
+	}
+
+	// Collect all (field, rule) pairs
+	type fieldRule struct{ field, rule string }
+	found := make(map[fieldRule]bool)
+	for _, c := range constraints {
+		found[fieldRule{c.Field, c.Rule}] = true
+	}
+
+	expected := []fieldRule{
+		{"name", "min_length"},
+		{"name", "max_length"},
+		{"age", "ge"},
+		{"age", "le"},
+		{"email", "pattern"},
+	}
+	for _, e := range expected {
+		if !found[e] {
+			t.Errorf("expected constraint field=%q rule=%q, not found", e.field, e.rule)
+		}
+	}
+
+	// Check specific values
+	for _, c := range constraints {
+		if c.Field == "name" && c.Rule == "min_length" {
+			if c.Value != "1" {
+				t.Errorf("name min_length value = %v, want %q", c.Value, "1")
+			}
+		}
+		if c.Field == "name" && c.Rule == "max_length" {
+			if c.Value != "100" {
+				t.Errorf("name max_length value = %v, want %q", c.Value, "100")
+			}
+		}
+	}
+}
+
+// @ac AC-05
+func TestPythonAdapter_ExtractConstraints_SQLAlchemy(t *testing.T) {
+	content := `from sqlalchemy import Column, String, Integer
+
+class User(Base):
+    username = Column(String(50), nullable=False)
+    bio = Column(String(500), nullable=True)
+`
+	constraints := pythonAdapter.ExtractConstraints("models.py", content)
+
+	foundRequired := false
+	for _, c := range constraints {
+		if c.Field == "username" && c.Rule == "required" {
+			foundRequired = true
+		}
+	}
+	if !foundRequired {
+		t.Error("expected required constraint for username (nullable=False)")
+	}
+
+	// bio should NOT be required
+	for _, c := range constraints {
+		if c.Field == "bio" && c.Rule == "required" {
+			t.Error("bio should not be required (nullable=True)")
+		}
+	}
+}
+
+// @ac AC-06
+func TestPythonAdapter_ExtractAssertions_PytestFunctions(t *testing.T) {
+	content := `import pytest
+
+def test_create_user_success():
+    response = client.post("/users", json={"name": "Alice"})
+    assert response.status_code == 201
+
+def test_create_user_missing_name():
+    response = client.post("/users", json={})
+    assert response.status_code == 422
+`
+	assertions := pythonAdapter.ExtractAssertions("test_users.py", content)
+	if len(assertions) != 2 {
+		t.Fatalf("expected 2 assertions, got %d", len(assertions))
+	}
+
+	if assertions[0].Description != "create user success" {
+		t.Errorf("first assertion description = %q, want %q", assertions[0].Description, "create user success")
+	}
+	if assertions[0].IsError {
+		t.Error("first assertion should not be error case")
+	}
+
+	if assertions[1].Description != "create user missing name" {
+		t.Errorf("second assertion description = %q, want %q", assertions[1].Description, "create user missing name")
+	}
+	if !assertions[1].IsError {
+		t.Error("second assertion should be marked as error case (missing)")
+	}
+}
+
+// @ac AC-06
+func TestPythonAdapter_ExtractAssertions_PytestRaises(t *testing.T) {
+	content := `import pytest
+
+def test_invalid_age_raises_error():
+    with pytest.raises(ValueError):
+        validate_age(-1)
+`
+	assertions := pythonAdapter.ExtractAssertions("test_validation.py", content)
+	if len(assertions) != 1 {
+		t.Fatalf("expected 1 assertion, got %d", len(assertions))
+	}
+	if !assertions[0].IsError {
+		t.Error("expected error case for pytest.raises")
+	}
+	if assertions[0].ErrorDesc != "ValueError" {
+		t.Errorf("ErrorDesc = %q, want %q", assertions[0].ErrorDesc, "ValueError")
+	}
+}
+
+// @ac AC-06
+func TestPythonAdapter_ExtractAssertions_ClassBased(t *testing.T) {
+	content := `import pytest
+
+class TestUserAPI:
+    def test_list_users(self):
+        response = client.get("/users")
+        assert response.status_code == 200
+
+    def test_delete_user_not_found(self):
+        response = client.delete("/users/999")
+        assert response.status_code == 404
+`
+	assertions := pythonAdapter.ExtractAssertions("test_api.py", content)
+	if len(assertions) != 2 {
+		t.Fatalf("expected 2 assertions, got %d", len(assertions))
+	}
+	if assertions[0].TestName != "TestUserAPI::test_list_users" {
+		t.Errorf("first test name = %q, want %q", assertions[0].TestName, "TestUserAPI::test_list_users")
+	}
+	if assertions[1].TestName != "TestUserAPI::test_delete_user_not_found" {
+		t.Errorf("second test name = %q, want %q", assertions[1].TestName, "TestUserAPI::test_delete_user_not_found")
+	}
+}
+
+func TestPythonAdapter_ExtractRoutes_FastAPI(t *testing.T) {
+	content := `from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/api/users")
+async def list_users():
+    pass
+
+@app.post("/api/users")
+async def create_user():
+    pass
+
+@router.delete("/api/users/{user_id}")
+async def delete_user(user_id: int):
+    pass
+`
+	routes := pythonAdapter.ExtractRoutes("main.py", content)
+	if len(routes) != 3 {
+		t.Fatalf("expected 3 routes, got %d", len(routes))
+	}
+	if routes[0].Method != "GET" || routes[0].Path != "/api/users" {
+		t.Errorf("first route = %s %s, want GET /api/users", routes[0].Method, routes[0].Path)
+	}
+	if routes[1].Method != "POST" || routes[1].Path != "/api/users" {
+		t.Errorf("second route = %s %s, want POST /api/users", routes[1].Method, routes[1].Path)
+	}
+	if routes[2].Method != "DELETE" || routes[2].Path != "/api/users/{user_id}" {
+		t.Errorf("third route = %s %s, want DELETE /api/users/{user_id}", routes[2].Method, routes[2].Path)
+	}
+}
+
+func TestPythonAdapter_ExtractRoutes_Flask(t *testing.T) {
+	content := `from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/health")
+def health():
+    return "ok"
+
+@app.route("/api/items", methods=["POST", "PUT"])
+def create_item():
+    pass
+`
+	routes := pythonAdapter.ExtractRoutes("app.py", content)
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if routes[0].Method != "ANY" || routes[0].Path != "/health" {
+		t.Errorf("first route = %s %s, want ANY /health", routes[0].Method, routes[0].Path)
+	}
+	if routes[1].Method != "POST" || routes[1].Path != "/api/items" {
+		t.Errorf("second route = %s %s, want POST /api/items", routes[1].Method, routes[1].Path)
+	}
+}
+
+func TestPythonAdapter_ExtractRoutes_Django(t *testing.T) {
+	content := `from django.urls import path
+
+urlpatterns = [
+    path("api/users/", views.user_list),
+    path("api/users/<int:pk>/", views.user_detail),
+]
+`
+	routes := pythonAdapter.ExtractRoutes("urls.py", content)
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if routes[0].Path != "api/users/" {
+		t.Errorf("first route path = %q, want %q", routes[0].Path, "api/users/")
+	}
+	if routes[0].Method != "ANY" {
+		t.Errorf("django route method = %q, want %q", routes[0].Method, "ANY")
+	}
+}
+
+func TestPythonAdapter_ExtractImports(t *testing.T) {
+	content := `from fastapi import FastAPI
+from pydantic import BaseModel
+import os
+import sys
+from myapp.models import User
+`
+	imports := pythonAdapter.ExtractImports("main.py", content)
+	if len(imports) != 5 {
+		t.Fatalf("expected 5 imports, got %d", len(imports))
+	}
+
+	modules := make(map[string]bool)
+	for _, imp := range imports {
+		modules[imp.Module] = true
+	}
+
+	for _, expected := range []string{"fastapi", "pydantic", "os", "sys", "myapp.models"} {
+		if !modules[expected] {
+			t.Errorf("expected import %q, not found", expected)
+		}
+	}
+}
+
+func TestPythonAdapter_InferSystemName(t *testing.T) {
+	files := []SourceFile{
+		{Path: "pyproject.toml", Content: `[project]
+name = "my-fastapi-app"
+version = "0.1.0"
+`},
+		{Path: "main.py", Content: "from fastapi import FastAPI"},
+	}
+	name := pythonAdapter.InferSystemName(files)
+	if name != "my-fastapi-app" {
+		t.Errorf("InferSystemName = %q, want %q", name, "my-fastapi-app")
+	}
+}
+
+func TestPythonAdapter_InferSystemName_NoToml(t *testing.T) {
+	files := []SourceFile{
+		{Path: "main.py", Content: "from fastapi import FastAPI"},
+	}
+	name := pythonAdapter.InferSystemName(files)
+	if name != "" {
+		t.Errorf("InferSystemName = %q, want empty string", name)
+	}
+}
+
+func TestPythonAdapter_Detect(t *testing.T) {
+	if !pythonAdapter.Detect("main.py", "") {
+		t.Error("expected Detect to return true for .py file")
+	}
+	if pythonAdapter.Detect("main.go", "") {
+		t.Error("expected Detect to return false for .go file")
+	}
+}
+
+func TestPythonAdapter_IsTestFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"test_users.py", true},
+		{"users_test.py", true},
+		{"app/tests/test_api.py", true},
+		{"app/tests/conftest.py", true},
+		{"models.py", false},
+		{"main.py", false},
+	}
+	for _, tt := range tests {
+		got := pythonAdapter.IsTestFile(tt.path)
+		if got != tt.want {
+			t.Errorf("IsTestFile(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}

--- a/specter/internal/reverse/adapter_typescript.go
+++ b/specter/internal/reverse/adapter_typescript.go
@@ -1,0 +1,239 @@
+package reverse
+
+import (
+	"regexp"
+	"strings"
+)
+
+// TypeScriptAdapter extracts spec data from TypeScript/Next.js/Express source code.
+type TypeScriptAdapter struct{}
+
+func (a *TypeScriptAdapter) Name() string { return "typescript" }
+
+func (a *TypeScriptAdapter) Detect(path, content string) bool {
+	return strings.HasSuffix(path, ".ts") ||
+		strings.HasSuffix(path, ".tsx") ||
+		strings.HasSuffix(path, ".js") ||
+		strings.HasSuffix(path, ".jsx")
+}
+
+func (a *TypeScriptAdapter) IsTestFile(path string) bool {
+	if strings.Contains(path, "__tests__/") {
+		return true
+	}
+	for _, suffix := range []string{".test.ts", ".test.tsx", ".spec.ts", ".test.js", ".test.jsx"} {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Route Extraction ---
+
+var (
+	// Next.js App Router: export async function GET|POST|PUT|DELETE|PATCH
+	nextjsRouteRE = regexp.MustCompile(`export\s+async\s+function\s+(GET|POST|PUT|DELETE|PATCH)`)
+	// Express: app.get("/path", ...) or router.post("/path", ...)
+	expressRouteRE = regexp.MustCompile(`(?:app|router)\.(get|post|put|delete|patch)\(\s*['"]([^'"]+)['"]`)
+)
+
+func (a *TypeScriptAdapter) ExtractRoutes(path, content string) []ExtractedRoute {
+	var routes []ExtractedRoute
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// Next.js App Router
+		if m := nextjsRouteRE.FindStringSubmatch(line); len(m) > 1 {
+			method := strings.ToUpper(m[1])
+			apiPath := inferNextJSRoutePath(path)
+			routes = append(routes, ExtractedRoute{
+				Method: method, Path: apiPath, Handler: m[1], File: path, Line: lineNum,
+			})
+		}
+
+		// Express routes
+		if m := expressRouteRE.FindStringSubmatch(line); len(m) > 2 {
+			routes = append(routes, ExtractedRoute{
+				Method: strings.ToUpper(m[1]), Path: m[2], Handler: "", File: path, Line: lineNum,
+			})
+		}
+	}
+
+	return routes
+}
+
+// inferNextJSRoutePath converts a file path containing app/api/ to an API route path.
+// e.g. "src/app/api/users/route.ts" -> "/api/users"
+func inferNextJSRoutePath(filePath string) string {
+	idx := strings.Index(filePath, "app/api/")
+	if idx < 0 {
+		return "/unknown"
+	}
+	// Strip everything before "app/" and remove the filename
+	routePart := filePath[idx+len("app"):]
+	// Remove trailing /route.ts or /route.js etc.
+	if lastSlash := strings.LastIndex(routePart, "/"); lastSlash >= 0 {
+		routePart = routePart[:lastSlash]
+	}
+	if routePart == "" {
+		routePart = "/"
+	}
+	return routePart
+}
+
+// --- Constraint Extraction (Zod) ---
+
+var (
+	zodFieldRE     = regexp.MustCompile(`(\w+)\s*:\s*z\.`)
+	zodStringMinRE = regexp.MustCompile(`z\.string\(\).*\.min\((\d+)\)`)
+	zodStringMaxRE = regexp.MustCompile(`z\.string\(\).*\.max\((\d+)\)`)
+	zodEmailRE     = regexp.MustCompile(`z\.string\(\).*\.email\(\)`)
+	zodNumberMinRE = regexp.MustCompile(`z\.number\(\).*\.min\((\d+)\)`)
+	zodNumberMaxRE = regexp.MustCompile(`z\.number\(\).*\.max\((\d+)\)`)
+	zodEnumRE      = regexp.MustCompile(`z\.enum\(`)
+	zodOptionalRE  = regexp.MustCompile(`\.optional\(\)`)
+)
+
+func (a *TypeScriptAdapter) ExtractConstraints(path, content string) []ExtractedConstraint {
+	var constraints []ExtractedConstraint
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1
+		trimmed := strings.TrimSpace(line)
+
+		// Must be a zod field line
+		fieldMatch := zodFieldRE.FindStringSubmatch(trimmed)
+		if len(fieldMatch) < 2 {
+			continue
+		}
+		fieldName := fieldMatch[1]
+
+		// Check if field is required (no .optional())
+		if !zodOptionalRE.MatchString(trimmed) {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: fieldName, Rule: "required", SourceFile: path, Line: lineNum,
+			})
+		}
+
+		// z.string().min(N)
+		if m := zodStringMinRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: fieldName, Rule: "min", Value: m[1], SourceFile: path, Line: lineNum,
+			})
+		}
+
+		// z.string().max(N)
+		if m := zodStringMaxRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: fieldName, Rule: "max", Value: m[1], SourceFile: path, Line: lineNum,
+			})
+		}
+
+		// z.string().email()
+		if zodEmailRE.MatchString(trimmed) {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: fieldName, Rule: "format", Value: "email", SourceFile: path, Line: lineNum,
+			})
+		}
+
+		// z.number().min(N)
+		if m := zodNumberMinRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: fieldName, Rule: "min", Value: m[1], SourceFile: path, Line: lineNum,
+			})
+		}
+
+		// z.number().max(N)
+		if m := zodNumberMaxRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: fieldName, Rule: "max", Value: m[1], SourceFile: path, Line: lineNum,
+			})
+		}
+
+		// z.enum([...])
+		if zodEnumRE.MatchString(trimmed) {
+			constraints = append(constraints, ExtractedConstraint{
+				Field: fieldName, Rule: "enum", SourceFile: path, Line: lineNum,
+			})
+		}
+	}
+
+	return constraints
+}
+
+// --- Assertion Extraction (Jest/Vitest) ---
+
+var (
+	describeBlockRE = regexp.MustCompile(`describe\(\s*['"]([^'"]+)['"]`)
+	itTestRE        = regexp.MustCompile(`(?:it|test)\(\s*['"]([^'"]+)['"]`)
+)
+
+func (a *TypeScriptAdapter) ExtractAssertions(path, content string) []ExtractedAssertion {
+	var assertions []ExtractedAssertion
+	lines := strings.Split(content, "\n")
+
+	currentDescribe := ""
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// Track describe block context
+		if m := describeBlockRE.FindStringSubmatch(line); len(m) > 1 {
+			currentDescribe = m[1]
+		}
+
+		// Extract it/test assertions
+		if m := itTestRE.FindStringSubmatch(line); len(m) > 1 {
+			desc := m[1]
+			testName := desc
+			if currentDescribe != "" {
+				testName = currentDescribe + " > " + desc
+			}
+			assertions = append(assertions, ExtractedAssertion{
+				TestName:    testName,
+				Description: desc,
+				IsError:     isErrorDescription(desc),
+				SourceFile:  path,
+				Line:        lineNum,
+			})
+		}
+	}
+
+	return assertions
+}
+
+// --- Import Extraction ---
+
+var tsImportRE = regexp.MustCompile(`import\s+.*\s+from\s+['"]([^'"]+)['"]`)
+
+func (a *TypeScriptAdapter) ExtractImports(path, content string) []ExtractedImport {
+	var imports []ExtractedImport
+	lines := strings.Split(content, "\n")
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if m := tsImportRE.FindStringSubmatch(trimmed); len(m) > 1 {
+			imports = append(imports, ExtractedImport{Module: m[1], File: path})
+		}
+	}
+
+	return imports
+}
+
+// --- System Name Inference ---
+
+var packageNameRE = regexp.MustCompile(`"name"\s*:\s*"([^"]+)"`)
+
+func (a *TypeScriptAdapter) InferSystemName(files []SourceFile) string {
+	for _, f := range files {
+		if strings.HasSuffix(f.Path, "package.json") || strings.Contains(f.Path, "/package.json") {
+			if m := packageNameRE.FindStringSubmatch(f.Content); len(m) > 1 {
+				return m[1]
+			}
+		}
+	}
+	return ""
+}

--- a/specter/internal/reverse/adapter_typescript_test.go
+++ b/specter/internal/reverse/adapter_typescript_test.go
@@ -1,0 +1,228 @@
+// @spec spec-reverse
+package reverse
+
+import "testing"
+
+var tsAdapter = &TypeScriptAdapter{}
+
+// @ac AC-03
+func TestTypeScriptAdapter_ExtractConstraints_ZodSchema(t *testing.T) {
+	content := `import { z } from 'zod';
+
+const UserSchema = z.object({
+  name: z.string().min(1).max(100),
+  email: z.string().email(),
+  age: z.number().min(18).max(120),
+  bio: z.string().optional(),
+});
+`
+	constraints := tsAdapter.ExtractConstraints("schema.ts", content)
+	if len(constraints) == 0 {
+		t.Fatal("expected constraints, got none")
+	}
+
+	// Collect rules by field
+	type fieldRule struct {
+		field string
+		rule  string
+	}
+	found := make(map[fieldRule]bool)
+	for _, c := range constraints {
+		found[fieldRule{c.Field, c.Rule}] = true
+	}
+
+	// name: required, min=1, max=100
+	for _, expected := range []fieldRule{
+		{"name", "required"},
+		{"name", "min"},
+		{"name", "max"},
+		{"email", "required"},
+		{"email", "format"},
+		{"age", "required"},
+		{"age", "min"},
+		{"age", "max"},
+	} {
+		if !found[expected] {
+			t.Errorf("expected field=%q rule=%q, not found", expected.field, expected.rule)
+		}
+	}
+
+	// bio has .optional(), so it should NOT have required
+	if found[fieldRule{"bio", "required"}] {
+		t.Error("bio should not have required rule (it has .optional())")
+	}
+}
+
+// @ac AC-04
+func TestTypeScriptAdapter_ExtractAssertions_JestDescribeIt(t *testing.T) {
+	content := `import { describe, it, expect } from 'vitest';
+
+describe('UserService', () => {
+  it('should create a valid user', () => {
+    expect(true).toBe(true);
+  });
+
+  it('should reject invalid email', () => {
+    expect(false).toBe(false);
+  });
+
+  it('should return error for missing name', () => {
+    expect(false).toBe(false);
+  });
+});
+`
+	assertions := tsAdapter.ExtractAssertions("user.test.ts", content)
+	if len(assertions) != 3 {
+		t.Fatalf("expected 3 assertions, got %d", len(assertions))
+	}
+
+	if assertions[0].Description != "should create a valid user" {
+		t.Errorf("first assertion description = %q, want %q", assertions[0].Description, "should create a valid user")
+	}
+	if assertions[0].TestName != "UserService > should create a valid user" {
+		t.Errorf("first assertion test name = %q, want %q", assertions[0].TestName, "UserService > should create a valid user")
+	}
+	if assertions[0].IsError {
+		t.Error("first assertion should NOT be marked as error")
+	}
+
+	if assertions[1].Description != "should reject invalid email" {
+		t.Errorf("second assertion description = %q, want %q", assertions[1].Description, "should reject invalid email")
+	}
+	if !assertions[1].IsError {
+		t.Error("second assertion should be marked as error (contains 'invalid')")
+	}
+
+	if !assertions[2].IsError {
+		t.Error("third assertion should be marked as error (contains 'error')")
+	}
+}
+
+func TestTypeScriptAdapter_ExtractRoutes_Express(t *testing.T) {
+	content := `import express from 'express';
+
+const app = express();
+
+app.get('/api/users', listUsers);
+app.post('/api/users', createUser);
+router.delete('/api/users/:id', deleteUser);
+`
+	routes := tsAdapter.ExtractRoutes("routes.ts", content)
+	if len(routes) != 3 {
+		t.Fatalf("expected 3 routes, got %d", len(routes))
+	}
+	if routes[0].Method != "GET" || routes[0].Path != "/api/users" {
+		t.Errorf("first route = %s %s, want GET /api/users", routes[0].Method, routes[0].Path)
+	}
+	if routes[1].Method != "POST" || routes[1].Path != "/api/users" {
+		t.Errorf("second route = %s %s, want POST /api/users", routes[1].Method, routes[1].Path)
+	}
+	if routes[2].Method != "DELETE" || routes[2].Path != "/api/users/:id" {
+		t.Errorf("third route = %s %s, want DELETE /api/users/:id", routes[2].Method, routes[2].Path)
+	}
+}
+
+func TestTypeScriptAdapter_ExtractRoutes_NextJS(t *testing.T) {
+	content := `import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  return NextResponse.json({ users: [] });
+}
+
+export async function POST(request: Request) {
+  return NextResponse.json({ created: true });
+}
+`
+	routes := tsAdapter.ExtractRoutes("src/app/api/users/route.ts", content)
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if routes[0].Method != "GET" || routes[0].Path != "/api/users" {
+		t.Errorf("first route = %s %s, want GET /api/users", routes[0].Method, routes[0].Path)
+	}
+	if routes[1].Method != "POST" || routes[1].Path != "/api/users" {
+		t.Errorf("second route = %s %s, want POST /api/users", routes[1].Method, routes[1].Path)
+	}
+}
+
+func TestTypeScriptAdapter_ExtractImports(t *testing.T) {
+	content := `import { z } from 'zod';
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+import { authMiddleware } from '../middleware/auth';
+`
+	imports := tsAdapter.ExtractImports("index.ts", content)
+	if len(imports) != 4 {
+		t.Fatalf("expected 4 imports, got %d", len(imports))
+	}
+	modules := make(map[string]bool)
+	for _, imp := range imports {
+		modules[imp.Module] = true
+	}
+	if !modules["zod"] {
+		t.Error("expected zod import")
+	}
+	if !modules["express"] {
+		t.Error("expected express import")
+	}
+	if !modules["@prisma/client"] {
+		t.Error("expected @prisma/client import")
+	}
+	if !modules["../middleware/auth"] {
+		t.Error("expected ../middleware/auth import")
+	}
+}
+
+func TestTypeScriptAdapter_InferSystemName(t *testing.T) {
+	files := []SourceFile{
+		{Path: "package.json", Content: `{"name": "my-nextjs-app", "version": "1.0.0"}`},
+		{Path: "index.ts", Content: "import express from 'express'"},
+	}
+	name := tsAdapter.InferSystemName(files)
+	if name != "my-nextjs-app" {
+		t.Errorf("InferSystemName = %q, want %q", name, "my-nextjs-app")
+	}
+}
+
+func TestTypeScriptAdapter_Detect(t *testing.T) {
+	for _, ext := range []string{".ts", ".tsx", ".js", ".jsx"} {
+		if !tsAdapter.Detect("file"+ext, "") {
+			t.Errorf("expected Detect to return true for %s file", ext)
+		}
+	}
+	if tsAdapter.Detect("main.go", "") {
+		t.Error("expected Detect to return false for .go file")
+	}
+	if tsAdapter.Detect("main.py", "") {
+		t.Error("expected Detect to return false for .py file")
+	}
+}
+
+func TestTypeScriptAdapter_IsTestFile(t *testing.T) {
+	testFiles := []string{
+		"handler.test.ts",
+		"handler.test.tsx",
+		"handler.spec.ts",
+		"handler.test.js",
+		"handler.test.jsx",
+		"__tests__/handler.ts",
+		"src/__tests__/deep/util.ts",
+	}
+	for _, f := range testFiles {
+		if !tsAdapter.IsTestFile(f) {
+			t.Errorf("expected IsTestFile true for %q", f)
+		}
+	}
+
+	nonTestFiles := []string{
+		"handler.ts",
+		"handler.tsx",
+		"index.js",
+		"schema.ts",
+	}
+	for _, f := range nonTestFiles {
+		if tsAdapter.IsTestFile(f) {
+			t.Errorf("expected IsTestFile false for %q", f)
+		}
+	}
+}

--- a/specter/internal/reverse/detect.go
+++ b/specter/internal/reverse/detect.go
@@ -1,0 +1,65 @@
+package reverse
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// DetectAdapter selects the best adapter for the given files by counting
+// file extensions and picking the adapter with the most matching files.
+func DetectAdapter(files []SourceFile, adapters []Adapter) Adapter {
+	if len(adapters) == 0 {
+		return nil
+	}
+
+	// Count how many files each adapter claims
+	scores := make(map[string]int)
+	adapterMap := make(map[string]Adapter)
+	for _, a := range adapters {
+		adapterMap[a.Name()] = a
+	}
+
+	for _, f := range files {
+		for _, a := range adapters {
+			if a.Detect(f.Path, f.Content) {
+				scores[a.Name()]++
+			}
+		}
+	}
+
+	// Pick adapter with highest score
+	var bestName string
+	bestScore := 0
+	// Sort adapter names for deterministic results
+	names := make([]string, 0, len(scores))
+	for name := range scores {
+		names = append(names, name)
+	}
+	for _, name := range names {
+		if scores[name] > bestScore {
+			bestScore = scores[name]
+			bestName = name
+		}
+	}
+
+	if bestName == "" {
+		return nil
+	}
+	return adapterMap[bestName]
+}
+
+// DetectLanguage returns the language name based on file extension.
+// Used for quick classification without a full adapter.
+func DetectLanguage(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".ts", ".tsx", ".js", ".jsx":
+		return "typescript"
+	case ".py":
+		return "python"
+	case ".go":
+		return "go"
+	default:
+		return ""
+	}
+}

--- a/specter/internal/reverse/detect_test.go
+++ b/specter/internal/reverse/detect_test.go
@@ -1,0 +1,103 @@
+// @spec spec-reverse
+package reverse
+
+import "testing"
+
+// mockAdapter is a minimal adapter for testing detection.
+type mockAdapter struct {
+	name       string
+	extensions []string
+}
+
+func (m *mockAdapter) Name() string { return m.name }
+func (m *mockAdapter) Detect(path, content string) bool {
+	for _, ext := range m.extensions {
+		if len(path) > len(ext) && path[len(path)-len(ext):] == ext {
+			return true
+		}
+	}
+	return false
+}
+func (m *mockAdapter) IsTestFile(path string) bool                             { return false }
+func (m *mockAdapter) ExtractRoutes(path, content string) []ExtractedRoute     { return nil }
+func (m *mockAdapter) ExtractConstraints(path, content string) []ExtractedConstraint {
+	return nil
+}
+func (m *mockAdapter) ExtractAssertions(path, content string) []ExtractedAssertion { return nil }
+func (m *mockAdapter) ExtractImports(path, content string) []ExtractedImport       { return nil }
+func (m *mockAdapter) InferSystemName(files []SourceFile) string                   { return "" }
+
+// @ac AC-11
+func TestDetectAdapter_GoFiles(t *testing.T) {
+	files := []SourceFile{
+		{Path: "main.go", Content: "package main"},
+		{Path: "handler.go", Content: "package main"},
+		{Path: "handler_test.go", Content: "package main"},
+	}
+	adapters := []Adapter{
+		&mockAdapter{name: "typescript", extensions: []string{".ts", ".tsx"}},
+		&mockAdapter{name: "go", extensions: []string{".go"}},
+		&mockAdapter{name: "python", extensions: []string{".py"}},
+	}
+
+	got := DetectAdapter(files, adapters)
+	if got == nil {
+		t.Fatal("expected adapter, got nil")
+	}
+	if got.Name() != "go" {
+		t.Errorf("expected 'go' adapter, got %q", got.Name())
+	}
+}
+
+// @ac AC-12
+func TestDetectAdapter_TypeScriptFiles(t *testing.T) {
+	files := []SourceFile{
+		{Path: "index.ts", Content: "import foo from 'bar'"},
+		{Path: "schema.ts", Content: "import z from 'zod'"},
+		{Path: "auth.test.ts", Content: "describe('auth', () => {})"},
+	}
+	adapters := []Adapter{
+		&mockAdapter{name: "typescript", extensions: []string{".ts", ".tsx"}},
+		&mockAdapter{name: "go", extensions: []string{".go"}},
+		&mockAdapter{name: "python", extensions: []string{".py"}},
+	}
+
+	got := DetectAdapter(files, adapters)
+	if got == nil {
+		t.Fatal("expected adapter, got nil")
+	}
+	if got.Name() != "typescript" {
+		t.Errorf("expected 'typescript' adapter, got %q", got.Name())
+	}
+}
+
+func TestDetectAdapter_NoFiles(t *testing.T) {
+	adapters := []Adapter{
+		&mockAdapter{name: "go", extensions: []string{".go"}},
+	}
+	got := DetectAdapter(nil, adapters)
+	if got != nil {
+		t.Errorf("expected nil for no files, got %q", got.Name())
+	}
+}
+
+func TestDetectLanguage(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"file.ts", "typescript"},
+		{"file.tsx", "typescript"},
+		{"file.js", "typescript"},
+		{"file.py", "python"},
+		{"file.go", "go"},
+		{"file.rb", ""},
+		{"file.rs", ""},
+	}
+	for _, tt := range tests {
+		got := DetectLanguage(tt.path)
+		if got != tt.want {
+			t.Errorf("DetectLanguage(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/specter/internal/reverse/gap.go
+++ b/specter/internal/reverse/gap.go
@@ -1,0 +1,127 @@
+package reverse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Hanalyx/specter/internal/schema"
+)
+
+// DetectGaps finds constraints that have no corresponding test assertion.
+// For each unmatched constraint, a gap AC is generated with Gap: true.
+func DetectGaps(constraints []ExtractedConstraint, assertions []ExtractedAssertion) []schema.AcceptanceCriterion {
+	var gaps []schema.AcceptanceCriterion
+
+	for _, c := range constraints {
+		if constraintHasMatch(c, assertions) {
+			continue
+		}
+
+		desc := fmt.Sprintf("UNTESTED: %s", buildGapDescription(c))
+		gaps = append(gaps, schema.AcceptanceCriterion{
+			// ID is assigned by the caller
+			Description: desc,
+			Gap:         true,
+			Priority:    "high",
+		})
+	}
+
+	return gaps
+}
+
+// constraintHasMatch checks if any assertion covers this constraint.
+func constraintHasMatch(c ExtractedConstraint, assertions []ExtractedAssertion) bool {
+	if c.Field == "" {
+		return false
+	}
+
+	fieldLower := strings.ToLower(c.Field)
+	ruleLower := strings.ToLower(c.Rule)
+
+	// Build rule-related keywords
+	ruleKeywords := ruleToKeywords(ruleLower)
+
+	for _, a := range assertions {
+		descLower := strings.ToLower(a.Description)
+		testLower := strings.ToLower(a.TestName)
+		combined := descLower + " " + testLower
+
+		// Check if assertion mentions the field
+		if !strings.Contains(combined, fieldLower) {
+			// Also check inputs/expected keys
+			if !keysContain(a.Inputs, fieldLower) && !keysContain(a.Expected, fieldLower) {
+				continue
+			}
+		}
+
+		// Field matches — check if any rule keyword matches
+		for _, kw := range ruleKeywords {
+			if strings.Contains(combined, kw) {
+				return true
+			}
+		}
+
+		// If field matches and it's an error test, likely covers validation
+		if a.IsError {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ruleToKeywords(rule string) []string {
+	base := []string{rule}
+	switch rule {
+	case "min":
+		return append(base, "minimum", "too short", "too small", "at least", "less than")
+	case "max":
+		return append(base, "maximum", "too long", "too large", "exceeds", "more than")
+	case "required":
+		return append(base, "missing", "empty", "blank", "not provided", "null")
+	case "format":
+		return append(base, "invalid", "malformed", "valid")
+	case "email":
+		return append(base, "email", "invalid email", "malformed email")
+	case "enum":
+		return append(base, "allowed", "valid", "invalid", "not one of")
+	case "pattern":
+		return append(base, "pattern", "format", "match", "invalid")
+	case "type":
+		return append(base, "type", "invalid type", "wrong type")
+	default:
+		return base
+	}
+}
+
+func keysContain(m map[string]interface{}, field string) bool {
+	for k := range m {
+		if strings.Contains(strings.ToLower(k), field) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildGapDescription(c ExtractedConstraint) string {
+	field := c.Field
+	if field == "" {
+		field = "value"
+	}
+	switch c.Rule {
+	case "required":
+		return fmt.Sprintf("Validate that %s is required", field)
+	case "min":
+		return fmt.Sprintf("Validate that %s enforces minimum of %v", field, c.Value)
+	case "max":
+		return fmt.Sprintf("Validate that %s enforces maximum of %v", field, c.Value)
+	case "format":
+		return fmt.Sprintf("Validate that %s is a valid %v", field, c.Value)
+	case "email":
+		return fmt.Sprintf("Validate that %s is a valid email address", field)
+	case "enum":
+		return fmt.Sprintf("Validate that %s is one of the allowed values", field)
+	default:
+		return fmt.Sprintf("Validate that %s satisfies %s constraint", field, c.Rule)
+	}
+}

--- a/specter/internal/reverse/gap_test.go
+++ b/specter/internal/reverse/gap_test.go
@@ -1,0 +1,67 @@
+// @spec spec-reverse
+package reverse
+
+import "testing"
+
+// @ac AC-07
+func TestDetectGaps_ConstraintWithNoMatchingAssertion(t *testing.T) {
+	constraints := []ExtractedConstraint{
+		{Field: "email", Rule: "format", Value: "email", SourceFile: "schema.ts", Line: 5},
+		{Field: "name", Rule: "required", SourceFile: "schema.ts", Line: 6},
+	}
+	// Only the name field has a test
+	assertions := []ExtractedAssertion{
+		{TestName: "test_name_required", Description: "returns 400 when name is missing", IsError: true,
+			SourceFile: "schema.test.ts", Line: 10},
+	}
+
+	gaps := DetectGaps(constraints, assertions)
+	if len(gaps) != 1 {
+		t.Fatalf("expected 1 gap, got %d", len(gaps))
+	}
+	if !gaps[0].Gap {
+		t.Error("expected gap AC to have Gap=true")
+	}
+	if gaps[0].Priority != "high" {
+		t.Errorf("expected priority 'high', got %q", gaps[0].Priority)
+	}
+	if gaps[0].Description == "" {
+		t.Error("expected gap AC to have a description")
+	}
+}
+
+func TestDetectGaps_AllConstraintsCovered(t *testing.T) {
+	constraints := []ExtractedConstraint{
+		{Field: "email", Rule: "format", Value: "email"},
+	}
+	assertions := []ExtractedAssertion{
+		{TestName: "test_valid_email", Description: "validates email format", SourceFile: "test.ts"},
+	}
+
+	gaps := DetectGaps(constraints, assertions)
+	if len(gaps) != 0 {
+		t.Fatalf("expected 0 gaps, got %d", len(gaps))
+	}
+}
+
+func TestDetectGaps_ErrorTestCoversConstraint(t *testing.T) {
+	constraints := []ExtractedConstraint{
+		{Field: "age", Rule: "min", Value: 18},
+	}
+	assertions := []ExtractedAssertion{
+		{TestName: "test_age_validation", Description: "returns error for invalid age",
+			IsError: true, SourceFile: "test.ts"},
+	}
+
+	gaps := DetectGaps(constraints, assertions)
+	if len(gaps) != 0 {
+		t.Fatalf("expected 0 gaps (error test covers age field), got %d", len(gaps))
+	}
+}
+
+func TestDetectGaps_NoConstraints(t *testing.T) {
+	gaps := DetectGaps(nil, nil)
+	if len(gaps) != 0 {
+		t.Fatalf("expected 0 gaps for nil input, got %d", len(gaps))
+	}
+}

--- a/specter/internal/reverse/id.go
+++ b/specter/internal/reverse/id.go
@@ -1,0 +1,60 @@
+package reverse
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var nonAlphanumRE = regexp.MustCompile(`[^a-z0-9]+`)
+
+// GenerateSpecID creates a kebab-case spec ID from a file path.
+// The result matches the pattern ^[a-z][a-z0-9-]*$ required by the spec schema.
+func GenerateSpecID(filePath string) string {
+	// Get base name without extension
+	base := filepath.Base(filePath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+
+	// Strip common suffixes
+	for _, suffix := range []string{".test", ".spec", "_test", ".route", ".handler", ".controller", ".service", ".model"} {
+		name = strings.TrimSuffix(name, suffix)
+	}
+
+	// Convert camelCase/PascalCase to kebab-case
+	name = camelToKebab(name)
+
+	// Lowercase and replace non-alphanumeric with hyphens
+	name = strings.ToLower(name)
+	name = nonAlphanumRE.ReplaceAllString(name, "-")
+
+	// Trim leading/trailing hyphens
+	name = strings.Trim(name, "-")
+
+	// Ensure it starts with a letter
+	if len(name) == 0 || !unicode.IsLetter(rune(name[0])) {
+		name = "spec-" + name
+	}
+
+	if name == "" || name == "spec-" {
+		name = "unknown-spec"
+	}
+
+	return name
+}
+
+// camelToKebab converts CamelCase to kebab-case.
+func camelToKebab(s string) string {
+	var result strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) && i > 0 {
+			prev := rune(s[i-1])
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) {
+				result.WriteRune('-')
+			}
+		}
+		result.WriteRune(r)
+	}
+	return result.String()
+}

--- a/specter/internal/reverse/id_test.go
+++ b/specter/internal/reverse/id_test.go
@@ -1,0 +1,58 @@
+// @spec spec-reverse
+package reverse
+
+import "testing"
+
+// @ac AC-08
+func TestGenerateSpecID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"src/UserRegistration.ts", "user-registration"},
+		{"handler.go", "handler"},
+		{"handler_test.go", "handler"},
+		{"auth.test.ts", "auth"},
+		{"CreatePayment.tsx", "create-payment"},
+		{"src/api/users/route.ts", "route"},
+		{"simple-zod.ts", "simple-zod"},
+		{"models.py", "models"},
+		{"test_auth.py", "test-auth"},
+		{"pydantic-model.py", "pydantic-model"},
+		{"MyService.handler.ts", "my-service"},
+		{"123file.go", "spec-123file"},
+		{"", "unknown-spec"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := GenerateSpecID(tt.input)
+			if got != tt.want {
+				t.Errorf("GenerateSpecID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateSpecID_KebabCasePattern(t *testing.T) {
+	inputs := []string{
+		"UserRegistration.ts",
+		"createPaymentIntent.js",
+		"APIHandler.go",
+		"simple.py",
+	}
+
+	for _, input := range inputs {
+		id := GenerateSpecID(input)
+		// Must start with lowercase letter
+		if len(id) == 0 || id[0] < 'a' || id[0] > 'z' {
+			t.Errorf("GenerateSpecID(%q) = %q, must start with lowercase letter", input, id)
+		}
+		// Must only contain lowercase letters, digits, hyphens
+		for _, r := range id {
+			if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+				t.Errorf("GenerateSpecID(%q) = %q, contains invalid character %q", input, id, string(r))
+			}
+		}
+	}
+}

--- a/specter/internal/reverse/reverse.go
+++ b/specter/internal/reverse/reverse.go
@@ -1,0 +1,508 @@
+// Package reverse implements spec-reverse: the reverse compiler.
+//
+// Extracts draft .spec.yaml files from existing source code by analyzing
+// validation schemas, test assertions, route definitions, and import graphs.
+// Uses a plugin adapter architecture for language-specific extraction.
+//
+// Pure functions. No CLI deps, no I/O.
+//
+// @spec spec-reverse
+package reverse
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Hanalyx/specter/internal/parser"
+	"github.com/Hanalyx/specter/internal/schema"
+	"gopkg.in/yaml.v3"
+)
+
+// --- Adapter Interface ---
+
+// Adapter extracts structured data from source code for a specific language.
+// All methods are pure functions: (path, content) -> structured data.
+type Adapter interface {
+	Name() string
+	Detect(path, content string) bool
+	IsTestFile(path string) bool
+	ExtractRoutes(path, content string) []ExtractedRoute
+	ExtractConstraints(path, content string) []ExtractedConstraint
+	ExtractAssertions(path, content string) []ExtractedAssertion
+	ExtractImports(path, content string) []ExtractedImport
+	InferSystemName(files []SourceFile) string
+}
+
+// --- Intermediate Types (Adapter Output) ---
+
+// SourceFile represents a source code file's content and metadata.
+type SourceFile struct {
+	Path    string
+	Content string
+	IsTest  bool
+}
+
+// ExtractedRoute represents a discovered HTTP route/handler.
+type ExtractedRoute struct {
+	Method  string
+	Path    string
+	Handler string
+	File    string
+	Line    int
+}
+
+// ExtractedConstraint is a raw constraint found in source code.
+type ExtractedConstraint struct {
+	Field       string
+	Rule        string
+	Value       interface{}
+	Description string
+	SourceFile  string
+	Line        int
+}
+
+// ExtractedAssertion is a test assertion found in test files.
+type ExtractedAssertion struct {
+	TestName    string
+	Description string
+	Inputs      map[string]interface{}
+	Expected    map[string]interface{}
+	IsError     bool
+	ErrorDesc   string
+	SourceFile  string
+	Line        int
+}
+
+// ExtractedImport represents an import/dependency found in source.
+type ExtractedImport struct {
+	Module string
+	File   string
+}
+
+// --- Core Input/Output Types ---
+
+// ReverseInput provides source files and configuration.
+type ReverseInput struct {
+	Files       []SourceFile
+	AdapterName string // "" = auto-detect
+	GroupBy     string // "file" (default) or "directory"
+	Date        string // ISO 8601 extraction date
+}
+
+// ReverseResult is the output of the reverse compiler.
+type ReverseResult struct {
+	Specs       []GeneratedSpec
+	Diagnostics []ReverseDiagnostic
+	Summary     ReverseSummary
+}
+
+// GeneratedSpec wraps a SpecAST with generation metadata.
+type GeneratedSpec struct {
+	Spec     schema.SpecAST
+	YAML     string
+	FileName string
+	Warnings []string
+}
+
+// ReverseDiagnostic reports issues during reverse compilation.
+type ReverseDiagnostic struct {
+	Kind     string // "no_adapter", "no_constraints", "no_tests", "validation_failed"
+	Severity string // "error", "warning", "info"
+	Message  string
+	File     string
+}
+
+// ReverseSummary is the summary statistics.
+type ReverseSummary struct {
+	FilesProcessed   int
+	SpecsGenerated   int
+	ConstraintsFound int
+	AssertionsFound  int
+	GapsDetected     int
+}
+
+// --- Core Engine ---
+
+// Reverse extracts draft specs from source files using the given adapter configuration.
+func Reverse(input ReverseInput, adapters []Adapter) *ReverseResult {
+	result := &ReverseResult{}
+
+	// Select adapter
+	adapter := selectAdapter(input, adapters, result)
+	if adapter == nil {
+		return result
+	}
+
+	// Classify files
+	var sourceFiles, testFiles []SourceFile
+	for i := range input.Files {
+		f := &input.Files[i]
+		if !adapter.Detect(f.Path, f.Content) {
+			continue
+		}
+		if adapter.IsTestFile(f.Path) {
+			f.IsTest = true
+			testFiles = append(testFiles, *f)
+		} else {
+			sourceFiles = append(sourceFiles, *f)
+		}
+	}
+
+	result.Summary.FilesProcessed = len(sourceFiles) + len(testFiles)
+
+	if len(sourceFiles) == 0 {
+		result.Diagnostics = append(result.Diagnostics, ReverseDiagnostic{
+			Kind:     "no_source_files",
+			Severity: "warning",
+			Message:  fmt.Sprintf("no source files detected for adapter %q", adapter.Name()),
+		})
+		return result
+	}
+
+	// Extract from all files
+	var allConstraints []ExtractedConstraint
+	var allAssertions []ExtractedAssertion
+	var allRoutes []ExtractedRoute
+	var allImports []ExtractedImport
+
+	for _, f := range sourceFiles {
+		allConstraints = append(allConstraints, adapter.ExtractConstraints(f.Path, f.Content)...)
+		allRoutes = append(allRoutes, adapter.ExtractRoutes(f.Path, f.Content)...)
+		allImports = append(allImports, adapter.ExtractImports(f.Path, f.Content)...)
+	}
+	for _, f := range testFiles {
+		allAssertions = append(allAssertions, adapter.ExtractAssertions(f.Path, f.Content)...)
+	}
+
+	result.Summary.ConstraintsFound = len(allConstraints)
+	result.Summary.AssertionsFound = len(allAssertions)
+
+	// Group files
+	groups := groupFiles(input.GroupBy, sourceFiles, testFiles)
+
+	// Infer system name
+	systemName := adapter.InferSystemName(input.Files)
+	if systemName == "" {
+		systemName = "unknown-system"
+	}
+
+	// Assemble specs per group
+	for groupKey, group := range groups {
+		spec := assembleSpec(groupKey, group, adapter, systemName, input.Date, result)
+		if spec == nil {
+			continue
+		}
+
+		// Marshal to YAML
+		doc := schema.SpecDocument{Spec: *spec}
+		yamlBytes, err := yaml.Marshal(doc)
+		if err != nil {
+			result.Diagnostics = append(result.Diagnostics, ReverseDiagnostic{
+				Kind:     "marshal_failed",
+				Severity: "error",
+				Message:  fmt.Sprintf("failed to marshal spec %s: %v", spec.ID, err),
+			})
+			continue
+		}
+		yamlStr := string(yamlBytes)
+
+		// Validate via parser.ParseSpec()
+		parseResult := parser.ParseSpec(yamlStr)
+		if !parseResult.OK {
+			var errMsgs []string
+			for _, e := range parseResult.Errors {
+				errMsgs = append(errMsgs, fmt.Sprintf("[%s] %s: %s", e.Type, e.Path, e.Message))
+			}
+			result.Diagnostics = append(result.Diagnostics, ReverseDiagnostic{
+				Kind:     "validation_failed",
+				Severity: "error",
+				Message:  fmt.Sprintf("generated spec %s failed validation: %s", spec.ID, strings.Join(errMsgs, "; ")),
+			})
+			continue
+		}
+
+		fileName := spec.ID + ".spec.yaml"
+		gs := GeneratedSpec{
+			Spec:     *spec,
+			YAML:     yamlStr,
+			FileName: fileName,
+		}
+
+		if len(spec.AcceptanceCriteria) > 0 {
+			gapCount := 0
+			for _, ac := range spec.AcceptanceCriteria {
+				if ac.Gap {
+					gapCount++
+				}
+			}
+			if gapCount > 0 {
+				gs.Warnings = append(gs.Warnings, fmt.Sprintf("%d gap(s) detected — constraints without test coverage", gapCount))
+				result.Summary.GapsDetected += gapCount
+			}
+		}
+
+		result.Specs = append(result.Specs, gs)
+		result.Summary.SpecsGenerated++
+	}
+
+	return result
+}
+
+// --- Internal helpers ---
+
+func selectAdapter(input ReverseInput, adapters []Adapter, result *ReverseResult) Adapter {
+	if input.AdapterName != "" {
+		for _, a := range adapters {
+			if a.Name() == input.AdapterName {
+				return a
+			}
+		}
+		result.Diagnostics = append(result.Diagnostics, ReverseDiagnostic{
+			Kind:     "no_adapter",
+			Severity: "error",
+			Message:  fmt.Sprintf("adapter %q not found", input.AdapterName),
+		})
+		return nil
+	}
+	return DetectAdapter(input.Files, adapters)
+}
+
+// fileGroup holds source and test files that will be assembled into one spec.
+type fileGroup struct {
+	SourceFiles []SourceFile
+	TestFiles   []SourceFile
+}
+
+func groupFiles(groupBy string, sourceFiles, testFiles []SourceFile) map[string]*fileGroup {
+	groups := make(map[string]*fileGroup)
+
+	keyFn := fileGroupKey
+	if groupBy == "directory" {
+		keyFn = dirGroupKey
+	}
+
+	for _, f := range sourceFiles {
+		key := keyFn(f.Path)
+		if groups[key] == nil {
+			groups[key] = &fileGroup{}
+		}
+		groups[key].SourceFiles = append(groups[key].SourceFiles, f)
+	}
+	for _, f := range testFiles {
+		key := keyFn(f.Path)
+		if groups[key] == nil {
+			groups[key] = &fileGroup{}
+		}
+		groups[key].TestFiles = append(groups[key].TestFiles, f)
+	}
+
+	return groups
+}
+
+func fileGroupKey(path string) string {
+	return path
+}
+
+func dirGroupKey(path string) string {
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 {
+		return "."
+	}
+	return path[:idx]
+}
+
+func assembleSpec(groupKey string, group *fileGroup, adapter Adapter, systemName, date string, result *ReverseResult) *schema.SpecAST {
+	// Extract from this group's files
+	var constraints []ExtractedConstraint
+	var assertions []ExtractedAssertion
+	var routes []ExtractedRoute
+	var imports []ExtractedImport
+
+	for _, f := range group.SourceFiles {
+		constraints = append(constraints, adapter.ExtractConstraints(f.Path, f.Content)...)
+		routes = append(routes, adapter.ExtractRoutes(f.Path, f.Content)...)
+		imports = append(imports, adapter.ExtractImports(f.Path, f.Content)...)
+	}
+	for _, f := range group.TestFiles {
+		assertions = append(assertions, adapter.ExtractAssertions(f.Path, f.Content)...)
+	}
+
+	if len(constraints) == 0 && len(assertions) == 0 && len(routes) == 0 {
+		result.Diagnostics = append(result.Diagnostics, ReverseDiagnostic{
+			Kind:     "no_extractable_content",
+			Severity: "info",
+			Message:  fmt.Sprintf("no constraints, assertions, or routes found in %s", groupKey),
+			File:     groupKey,
+		})
+		return nil
+	}
+
+	specID := GenerateSpecID(groupKey)
+
+	// Build constraints
+	specConstraints := make([]schema.Constraint, len(constraints))
+	for i, c := range constraints {
+		desc := c.Description
+		if desc == "" {
+			desc = buildConstraintDescription(c)
+		}
+		specConstraints[i] = schema.Constraint{
+			ID:          fmt.Sprintf("C-%02d", i+1),
+			Description: desc,
+			Type:        "technical",
+			Enforcement: "error",
+		}
+		if c.Field != "" && c.Rule != "" {
+			specConstraints[i].Validation = &schema.ConstraintValidation{
+				Field: c.Field,
+				Rule:  c.Rule,
+				Value: c.Value,
+			}
+		}
+	}
+
+	// Build ACs from assertions
+	specACs := make([]schema.AcceptanceCriterion, 0, len(assertions))
+	for i, a := range assertions {
+		ac := schema.AcceptanceCriterion{
+			ID:          fmt.Sprintf("AC-%02d", i+1),
+			Description: a.Description,
+			Priority:    "medium",
+		}
+		if len(a.Inputs) > 0 {
+			ac.Inputs = a.Inputs
+		}
+		if len(a.Expected) > 0 {
+			ac.ExpectedOutput = a.Expected
+		}
+		if a.IsError && a.ErrorDesc != "" {
+			ac.ErrorCases = []schema.ErrorCase{{
+				Condition:        a.ErrorDesc,
+				ExpectedBehavior: a.Description,
+			}}
+		}
+		specACs = append(specACs, ac)
+	}
+
+	// Detect gaps and append gap ACs
+	gapACs := DetectGaps(constraints, assertions)
+	nextACNum := len(specACs) + 1
+	for i, gac := range gapACs {
+		gac.ID = fmt.Sprintf("AC-%02d", nextACNum+i)
+		// Reference the constraint that created this gap
+		constraintIdx := findGapConstraintIndex(gac.Description, constraints)
+		if constraintIdx >= 0 {
+			gac.ReferencesConstraints = []string{fmt.Sprintf("C-%02d", constraintIdx+1)}
+		}
+		specACs = append(specACs, gac)
+	}
+
+	// Ensure at least one constraint and one AC (schema requires minItems: 1)
+	if len(specConstraints) == 0 {
+		specConstraints = []schema.Constraint{{
+			ID:          "C-01",
+			Description: "MUST implement the behavior defined in this module (auto-generated placeholder)",
+			Type:        "technical",
+			Enforcement: "error",
+		}}
+	}
+	if len(specACs) == 0 {
+		specACs = []schema.AcceptanceCriterion{{
+			ID:          "AC-01",
+			Description: "Module behavior matches implementation (auto-generated placeholder)",
+			Gap:         true,
+			Priority:    "high",
+		}}
+	}
+
+	// Build objective summary
+	summary := fmt.Sprintf("Reverse-compiled spec for %s.", specID)
+	if len(routes) > 0 {
+		routeDescs := make([]string, 0, len(routes))
+		for _, r := range routes {
+			routeDescs = append(routeDescs, fmt.Sprintf("%s %s", r.Method, r.Path))
+		}
+		summary = fmt.Sprintf("Reverse-compiled spec for %s. Routes: %s.", specID, strings.Join(routeDescs, ", "))
+	}
+
+	// Build dependencies from imports
+	var deps []string
+	seen := make(map[string]bool)
+	for _, imp := range imports {
+		if !seen[imp.Module] {
+			deps = append(deps, imp.Module)
+			seen[imp.Module] = true
+		}
+	}
+	sort.Strings(deps)
+
+	// Source file and test file paths for provenance
+	var sourceFilePath string
+	var testFilePaths []string
+	if len(group.SourceFiles) > 0 {
+		sourceFilePath = group.SourceFiles[0].Path
+	}
+	for _, f := range group.TestFiles {
+		testFilePaths = append(testFilePaths, f.Path)
+	}
+
+	spec := &schema.SpecAST{
+		ID:      specID,
+		Version: "0.1.0",
+		Status:  "draft",
+		Tier:    3,
+		Context: schema.SpecContext{
+			System:       systemName,
+			Feature:      specID,
+			Dependencies: deps,
+		},
+		Objective: schema.SpecObjective{
+			Summary: summary,
+		},
+		Constraints:        specConstraints,
+		AcceptanceCriteria: specACs,
+		TrustLevel:         "auto_with_review",
+		GeneratedFrom: &schema.GeneratedFrom{
+			SourceFile:     sourceFilePath,
+			TestFiles:      testFilePaths,
+			ExtractionDate: date,
+		},
+	}
+
+	return spec
+}
+
+func buildConstraintDescription(c ExtractedConstraint) string {
+	field := c.Field
+	if field == "" {
+		field = "value"
+	}
+	switch c.Rule {
+	case "required":
+		return fmt.Sprintf("%s MUST be provided", field)
+	case "min":
+		return fmt.Sprintf("%s MUST have minimum value/length of %v", field, c.Value)
+	case "max":
+		return fmt.Sprintf("%s MUST have maximum value/length of %v", field, c.Value)
+	case "format":
+		return fmt.Sprintf("%s MUST be a valid %v", field, c.Value)
+	case "enum":
+		return fmt.Sprintf("%s MUST be one of the allowed values", field)
+	case "pattern":
+		return fmt.Sprintf("%s MUST match pattern %v", field, c.Value)
+	case "type":
+		return fmt.Sprintf("%s MUST be of type %v", field, c.Value)
+	default:
+		return fmt.Sprintf("%s MUST satisfy %s constraint", field, c.Rule)
+	}
+}
+
+func findGapConstraintIndex(gapDesc string, constraints []ExtractedConstraint) int {
+	for i, c := range constraints {
+		if c.Field != "" && strings.Contains(gapDesc, c.Field) {
+			return i
+		}
+	}
+	return -1
+}

--- a/specter/specs/spec-reverse.spec.yaml
+++ b/specter/specs/spec-reverse.spec.yaml
@@ -1,0 +1,266 @@
+spec:
+  id: spec-reverse
+  version: "1.0.0"
+  status: draft
+  tier: 2
+
+  context:
+    system: Specter toolchain
+    feature: Reverse compiler — extract draft specs from existing code
+    description: >
+      Solves the cold-start problem for SDD adoption. Given existing source code
+      and test files, the reverse compiler extracts draft .spec.yaml files by
+      detecting validation schemas, test assertions, route definitions, and
+      import relationships. Uses a plugin adapter architecture so each language
+      (TypeScript, Python, Go) has its own extraction logic while the core
+      engine handles assembly, gap detection, and validation.
+    dependencies:
+      - "gopkg.in/yaml.v3 (YAML output)"
+      - "internal/parser (round-trip validation)"
+      - "internal/schema (SpecAST types)"
+    related_specs:
+      - "spec-parse"
+      - "spec-coverage"
+    assumptions:
+      - "Source code uses well-known frameworks (Zod, Pydantic, Go struct tags)"
+      - "Test files follow standard naming conventions per language"
+      - "Extraction is regex-based for v1.0 — no AST parsing, no AI"
+      - "Generated specs always have status: draft and require human review"
+
+  objective:
+    summary: >
+      Extract draft .spec.yaml files from existing codebases by analyzing source
+      code for validation constraints, test files for acceptance criteria, and
+      import graphs for dependencies. Flag untested constraints as gaps.
+    scope:
+      includes:
+        - "Adapter interface for language-specific extraction"
+        - "TypeScript adapter: Zod schemas, Jest/Vitest tests, Next.js/Express routes"
+        - "Python adapter: Pydantic models, pytest tests, FastAPI/Django routes"
+        - "Go adapter: struct validate tags, _test.go files, net/http/gin/chi routes"
+        - "Core engine: assemble SpecAST from adapter output"
+        - "Gap detection: constraints without corresponding test assertions"
+        - "Spec ID generation from file/module names"
+        - "Provenance tracking via generated_from metadata"
+        - "Output validation via parser.ParseSpec() round-trip"
+        - "Auto-detection of language adapter from file extensions"
+      excludes:
+        - "AI-assisted gap filling or context generation"
+        - "Tree-sitter or full AST parsing"
+        - "Custom adapter plugins loaded at runtime"
+        - "OpenAPI/Swagger ingestion"
+        - "Database schema extraction"
+        - "Watch/incremental mode"
+
+  constraints:
+    - id: C-01
+      description: "MUST define an Adapter interface with methods: Name, Detect, IsTestFile, ExtractRoutes, ExtractConstraints, ExtractAssertions, ExtractImports, InferSystemName"
+      type: technical
+      enforcement: error
+
+    - id: C-02
+      description: "MUST assemble valid schema.SpecAST objects from adapter output with all required fields populated (id, version, status, tier, context, objective, constraints, acceptance_criteria)"
+      type: technical
+      enforcement: error
+
+    - id: C-03
+      description: "MUST set status to 'draft' and populate generated_from metadata (source_file, test_files, extraction_date) on all reverse-compiled specs"
+      type: technical
+      enforcement: error
+
+    - id: C-04
+      description: "MUST detect gaps — constraints found in code that have no corresponding test assertion — and generate ACs with gap: true"
+      type: business
+      enforcement: error
+
+    - id: C-05
+      description: "MUST generate spec IDs in kebab-case matching pattern ^[a-z][a-z0-9-]*$ from file or module names"
+      type: technical
+      enforcement: error
+
+    - id: C-06
+      description: "MUST validate all generated YAML by round-tripping through parser.ParseSpec() before output"
+      type: technical
+      enforcement: error
+
+    - id: C-07
+      description: "MUST auto-detect the appropriate adapter from file extensions when no --adapter flag is provided"
+      type: technical
+      enforcement: error
+
+    - id: C-08
+      description: "MUST NOT depend on any CLI framework or perform I/O — pure function from []SourceFile to ReverseResult"
+      type: technical
+      enforcement: error
+
+    - id: C-09
+      description: "MUST support three built-in adapters: typescript, python, go"
+      type: business
+      enforcement: error
+
+    - id: C-10
+      description: "MUST generate auto-numbered constraint IDs (C-01, C-02) and AC IDs (AC-01, AC-02) with no gaps"
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: "Go source file with struct validate tags produces spec with constraints"
+      inputs:
+        source_file: "handler.go with `validate:\"required,min=1,max=100\"` struct tags"
+        adapter: "go"
+      expected_output:
+        constraints_count: 3
+        constraint_rules: ["required", "min", "max"]
+        status: "draft"
+      references_constraints: ["C-01", "C-02", "C-09"]
+      priority: critical
+
+    - id: AC-02
+      description: "Go test file with t.Run sub-tests produces ACs"
+      inputs:
+        test_file: "handler_test.go with t.Run(\"returns 200 on valid input\", ...)"
+        adapter: "go"
+      expected_output:
+        ac_count: 1
+        ac_description: "returns 200 on valid input"
+      references_constraints: ["C-01", "C-02"]
+      priority: critical
+
+    - id: AC-03
+      description: "TypeScript Zod schema produces constraints with field names and rules"
+      inputs:
+        source_file: "schema.ts with z.object({ email: z.string().email(), age: z.number().min(18) })"
+        adapter: "typescript"
+      expected_output:
+        constraints_count: 2
+        fields: ["email", "age"]
+        rules: ["format", "min"]
+      references_constraints: ["C-01", "C-02", "C-09"]
+      priority: critical
+
+    - id: AC-04
+      description: "Jest test with describe/it blocks produces ACs"
+      inputs:
+        test_file: "auth.test.ts with it('returns 401 when unauthorized', ...)"
+        adapter: "typescript"
+      expected_output:
+        ac_count: 1
+        ac_description: "returns 401 when unauthorized"
+      references_constraints: ["C-01", "C-02"]
+      priority: critical
+
+    - id: AC-05
+      description: "Python Pydantic model with Field validators produces constraints"
+      inputs:
+        source_file: "models.py with name: str = Field(min_length=1, max_length=255)"
+        adapter: "python"
+      expected_output:
+        constraints_count: 2
+        rules: ["min", "max"]
+      references_constraints: ["C-01", "C-02", "C-09"]
+      priority: critical
+
+    - id: AC-06
+      description: "Pytest function produces AC"
+      inputs:
+        test_file: "test_auth.py with def test_returns_403_for_non_admin():"
+        adapter: "python"
+      expected_output:
+        ac_count: 1
+        ac_description: "returns 403 for non admin"
+      references_constraints: ["C-01", "C-02"]
+      priority: critical
+
+    - id: AC-07
+      description: "Constraint without matching test assertion produces gap AC"
+      inputs:
+        source_file: "schema.ts with z.string().email()"
+        test_file: "schema.test.ts with NO email validation test"
+      expected_output:
+        gap_ac_count: 1
+        gap: true
+        priority: "high"
+      references_constraints: ["C-04"]
+      priority: critical
+
+    - id: AC-08
+      description: "Spec ID generated from file path in kebab-case"
+      inputs:
+        file_path: "src/UserRegistration.ts"
+      expected_output:
+        spec_id: "user-registration"
+      references_constraints: ["C-05"]
+      priority: high
+
+    - id: AC-09
+      description: "Generated YAML passes parser.ParseSpec() validation"
+      inputs:
+        source_file: "any valid source with at least one constraint and one test"
+      expected_output:
+        parse_result_ok: true
+      references_constraints: ["C-06"]
+      priority: critical
+
+    - id: AC-10
+      description: "Generated spec includes generated_from provenance metadata"
+      inputs:
+        source_file: "handler.go"
+        test_files: ["handler_test.go"]
+      expected_output:
+        generated_from:
+          source_file: "handler.go"
+          test_files: ["handler_test.go"]
+          extraction_date: "2026-04-02"
+      references_constraints: ["C-03"]
+      priority: high
+
+    - id: AC-11
+      description: "Auto-detect selects Go adapter for directory with .go files"
+      inputs:
+        files: ["main.go", "handler.go", "handler_test.go"]
+      expected_output:
+        adapter: "go"
+      references_constraints: ["C-07"]
+      priority: high
+
+    - id: AC-12
+      description: "Auto-detect selects TypeScript adapter for directory with .ts files"
+      inputs:
+        files: ["index.ts", "schema.ts", "auth.test.ts"]
+      expected_output:
+        adapter: "typescript"
+      references_constraints: ["C-07"]
+      priority: high
+
+    - id: AC-13
+      description: "Constraint and AC IDs are auto-numbered sequentially"
+      inputs:
+        source_file: "file with 3 constraints and 2 tests"
+      expected_output:
+        constraint_ids: ["C-01", "C-02", "C-03"]
+        ac_ids: ["AC-01", "AC-02"]
+      references_constraints: ["C-10"]
+      priority: high
+
+    - id: AC-14
+      description: "Core engine is a pure function with no I/O"
+      inputs:
+        function: "reverse.Reverse()"
+      expected_output:
+        no_file_reads: true
+        no_cli_deps: true
+      references_constraints: ["C-08"]
+      priority: high
+
+  depends_on:
+    - spec_id: spec-parse
+      version_range: "^1.0.0"
+      relationship: requires
+
+  changelog:
+    - version: "1.0.0"
+      date: "2026-04-02"
+      author: "specter-team"
+      type: initial
+      description: "Initial spec for the reverse compiler with adapter plugin architecture"


### PR DESCRIPTION
## Summary

- Add `specter reverse` command — extracts draft `.spec.yaml` files from existing codebases
- Plugin adapter architecture with 3 built-in adapters: TypeScript (Zod/Jest/Next.js), Python (Pydantic/pytest/FastAPI), Go (struct tags/table tests/gin)
- Gap detection: flags constraints without test coverage as `gap: true` ACs
- Auto-detection of language adapter from file extensions
- Round-trip validation: all generated specs pass `specter parse`
- 77 total tests (up from 37), 6 specs, all dogfooding passes

## Test plan

- [x] `make check` passes (vet + test + build)
- [x] `make dogfood` passes (6 specs, 0 issues)
- [x] `specter reverse --adapter=go --dry-run ./internal/parser/` produces valid spec
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)