### PR TITLE
fix: resolve reverse compiler bugs and expand TypeScript extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Specter will be documented in this file.
 
+## [0.2.1] - 2026-04-03
+
+### Fixed
+
+- Fix null `validation.value` crash when Zod patterns have no extractable literal (`.email()`, `.url()`, `.optional()`, `.refine()`, `z.boolean()`, `z.array()`)
+- Fix all Next.js App Router files generating the same spec ID `route` — now derives ID from route path (e.g., `/api/webhooks/stripe` → `webhooks-stripe`)
+- Include source file path in `validation_failed` diagnostics for easier debugging
+- Find `package.json`/`go.mod`/`pyproject.toml` in parent directories for system name inference
+
+### Added
+
+- TypeScript adapter: extract constraints from TypeScript enums, union types, and `as const` arrays
+- TypeScript adapter: extract constraints from Prisma schema files (`.prisma`) — field types, `@unique`, `@db.VarChar(N)`, required/optional
+- TypeScript adapter: extract role and status constraints from code patterns (e.g., `session.user.role === "ADMIN"`)
+- TypeScript adapter: recognize `.url()`, `z.boolean()`, `z.array()` Zod patterns
+- Zod enum now extracts values (e.g., `z.enum(["a", "b"])` → `Value: "a", "b"`)
+- 85 tests (up from 77)
+
 ## [0.2.0] - 2026-04-03
 
 ### Added

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -510,6 +510,38 @@ func reverseCmd() *cobra.Command {
 				return nil
 			})
 
+			// Look for manifest files in parent directories (for system name inference)
+			manifests := []string{"package.json", "go.mod", "pyproject.toml"}
+			absTarget, _ := filepath.Abs(targetPath)
+			dir := absTarget
+			for {
+				for _, m := range manifests {
+					mPath := filepath.Join(dir, m)
+					if data, err := os.ReadFile(mPath); err == nil {
+						// Only add if not already found during walk
+						alreadyFound := false
+						for _, f := range files {
+							abs, _ := filepath.Abs(f.Path)
+							if abs == mPath {
+								alreadyFound = true
+								break
+							}
+						}
+						if !alreadyFound {
+							files = append(files, reverse.SourceFile{
+								Path:    mPath,
+								Content: string(data),
+							})
+						}
+					}
+				}
+				parent := filepath.Dir(dir)
+				if parent == dir {
+					break
+				}
+				dir = parent
+			}
+
 			if len(files) == 0 {
 				fmt.Println("No source files found.")
 				os.Exit(1)

--- a/specter/internal/reverse/adapter_typescript.go
+++ b/specter/internal/reverse/adapter_typescript.go
@@ -1,7 +1,9 @@
 package reverse
 
 import (
+	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -14,7 +16,8 @@ func (a *TypeScriptAdapter) Detect(path, content string) bool {
 	return strings.HasSuffix(path, ".ts") ||
 		strings.HasSuffix(path, ".tsx") ||
 		strings.HasSuffix(path, ".js") ||
-		strings.HasSuffix(path, ".jsx")
+		strings.HasSuffix(path, ".jsx") ||
+		strings.HasSuffix(path, ".prisma")
 }
 
 func (a *TypeScriptAdapter) IsTestFile(path string) bool {
@@ -84,17 +87,44 @@ func inferNextJSRoutePath(filePath string) string {
 	return routePart
 }
 
-// --- Constraint Extraction (Zod) ---
+// --- Constraint Extraction (Zod + TypeScript patterns + Prisma) ---
 
 var (
 	zodFieldRE     = regexp.MustCompile(`(\w+)\s*:\s*z\.`)
 	zodStringMinRE = regexp.MustCompile(`z\.string\(\).*\.min\((\d+)\)`)
 	zodStringMaxRE = regexp.MustCompile(`z\.string\(\).*\.max\((\d+)\)`)
 	zodEmailRE     = regexp.MustCompile(`z\.string\(\).*\.email\(\)`)
+	zodUrlRE       = regexp.MustCompile(`z\.string\(\).*\.url\(\)`)
 	zodNumberMinRE = regexp.MustCompile(`z\.number\(\).*\.min\((\d+)\)`)
 	zodNumberMaxRE = regexp.MustCompile(`z\.number\(\).*\.max\((\d+)\)`)
-	zodEnumRE      = regexp.MustCompile(`z\.enum\(`)
+	zodEnumRE      = regexp.MustCompile(`z\.enum\(\[([^\]]*)\]`)
 	zodOptionalRE  = regexp.MustCompile(`\.optional\(\)`)
+	zodBooleanRE   = regexp.MustCompile(`z\.boolean\(\)`)
+	zodArrayRE     = regexp.MustCompile(`z\.array\(`)
+	zodRefineRE    = regexp.MustCompile(`\.refine\(`)
+	zodTransformRE = regexp.MustCompile(`\.transform\(`)
+	zodDefaultRE   = regexp.MustCompile(`\.default\(`)
+
+	// TypeScript enums: enum Role { ADMIN = "ADMIN", USER = "USER" }
+	tsEnumRE = regexp.MustCompile(`enum\s+(\w+)\s*\{([^}]+)\}`)
+	// TypeScript union types: type Status = "active" | "inactive" | "pending"
+	tsUnionTypeRE = regexp.MustCompile(`type\s+(\w+)\s*=\s*((?:['"][^'"]+['"]\s*\|\s*)*['"][^'"]+['"])`)
+	// TypeScript const assertions: const ROLES = ["admin", "user"] as const
+	tsConstArrayRE = regexp.MustCompile(`const\s+(\w+)\s*=\s*\[([^\]]+)\]\s*as\s+const`)
+
+	// Prisma model fields: name String @unique @db.VarChar(255)
+	prismaFieldRE   = regexp.MustCompile(`^\s+(\w+)\s+(String|Int|Float|Boolean|DateTime|Json|BigInt|Decimal|Bytes)(\?)?(.*)$`)
+	prismaUniqueRE  = regexp.MustCompile(`@unique`)
+	prismaDefaultRE = regexp.MustCompile(`@default\(([^)]+)\)`)
+	prismaVarCharRE = regexp.MustCompile(`@db\.VarChar\((\d+)\)`)
+	prismaRelRE     = regexp.MustCompile(`@relation`)
+
+	// Role/auth checks: if (role !== "ADMIN") or session?.user?.role === "ADMIN"
+	roleCheckRE = regexp.MustCompile(`(?:role|user\.role|session\.user\.role)\s*(?:===?|!==?)\s*['"](\w+)['"]`)
+	// Status checks: if (status === "active") or status !== "deleted"
+	statusCheckRE = regexp.MustCompile(`(?:\.status|status)\s*(?:===?|!==?)\s*['"](\w+)['"]`)
+	// HTTP status returns: return.*(?:Response|NextResponse).*status.*(\d{3})
+	httpStatusRE = regexp.MustCompile(`(?:status|statusCode)\s*[:=]\s*(\d{3})`)
 )
 
 func (a *TypeScriptAdapter) ExtractConstraints(path, content string) []ExtractedConstraint {
@@ -105,61 +135,269 @@ func (a *TypeScriptAdapter) ExtractConstraints(path, content string) []Extracted
 		lineNum := i + 1
 		trimmed := strings.TrimSpace(line)
 
-		// Must be a zod field line
-		fieldMatch := zodFieldRE.FindStringSubmatch(trimmed)
-		if len(fieldMatch) < 2 {
+		// --- Zod schema fields ---
+		if fieldMatch := zodFieldRE.FindStringSubmatch(trimmed); len(fieldMatch) >= 2 {
+			fieldName := fieldMatch[1]
+			constraints = append(constraints, a.extractZodConstraints(fieldName, trimmed, path, lineNum)...)
+		}
+
+		// --- TypeScript enums ---
+		if m := tsEnumRE.FindStringSubmatch(trimmed); len(m) > 2 {
+			enumName := m[1]
+			constraints = append(constraints, ExtractedConstraint{
+				Field:       strings.ToLower(enumName[:1]) + enumName[1:],
+				Rule:        "enum",
+				Value:       strings.TrimSpace(m[2]),
+				Description: fmt.Sprintf("%s MUST be one of the enum values defined in %s", enumName, enumName),
+				SourceFile:  path,
+				Line:        lineNum,
+			})
+		}
+
+		// --- TypeScript union types ---
+		if m := tsUnionTypeRE.FindStringSubmatch(trimmed); len(m) > 2 {
+			typeName := m[1]
+			values := m[2]
+			constraints = append(constraints, ExtractedConstraint{
+				Field:       strings.ToLower(typeName[:1]) + typeName[1:],
+				Rule:        "enum",
+				Value:       values,
+				Description: fmt.Sprintf("%s MUST be one of: %s", typeName, values),
+				SourceFile:  path,
+				Line:        lineNum,
+			})
+		}
+
+		// --- TypeScript const arrays (as const) ---
+		if m := tsConstArrayRE.FindStringSubmatch(trimmed); len(m) > 2 {
+			constName := m[1]
+			constraints = append(constraints, ExtractedConstraint{
+				Field:       strings.ToLower(constName[:1]) + constName[1:],
+				Rule:        "enum",
+				Value:       strings.TrimSpace(m[2]),
+				Description: fmt.Sprintf("%s MUST be one of the values in %s", constName, constName),
+				SourceFile:  path,
+				Line:        lineNum,
+			})
+		}
+	}
+
+	// --- Prisma schema extraction ---
+	if strings.HasSuffix(path, ".prisma") {
+		constraints = append(constraints, a.extractPrismaConstraints(path, content)...)
+	}
+
+	// --- Role/auth/status pattern extraction ---
+	constraints = append(constraints, a.extractPatternConstraints(path, content)...)
+
+	return constraints
+}
+
+func (a *TypeScriptAdapter) extractZodConstraints(fieldName, line, path string, lineNum int) []ExtractedConstraint {
+	var constraints []ExtractedConstraint
+
+	// Required (no .optional())
+	if !zodOptionalRE.MatchString(line) {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "required", SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.string().min(N)
+	if m := zodStringMinRE.FindStringSubmatch(line); len(m) > 1 {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "min", Value: m[1], SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.string().max(N)
+	if m := zodStringMaxRE.FindStringSubmatch(line); len(m) > 1 {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "max", Value: m[1], SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.string().email()
+	if zodEmailRE.MatchString(line) {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "format", Value: "email", SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.string().url()
+	if zodUrlRE.MatchString(line) {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "format", Value: "url", SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.number().min(N)
+	if m := zodNumberMinRE.FindStringSubmatch(line); len(m) > 1 {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "min", Value: m[1], SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.number().max(N)
+	if m := zodNumberMaxRE.FindStringSubmatch(line); len(m) > 1 {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "max", Value: m[1], SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.enum([...]) — extract values
+	if m := zodEnumRE.FindStringSubmatch(line); len(m) > 1 {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "enum", Value: strings.TrimSpace(m[1]), SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.boolean()
+	if zodBooleanRE.MatchString(line) && !zodArrayRE.MatchString(line) {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "type", Value: "boolean", SourceFile: path, Line: lineNum,
+		})
+	}
+
+	// z.array(...)
+	if zodArrayRE.MatchString(line) {
+		constraints = append(constraints, ExtractedConstraint{
+			Field: fieldName, Rule: "type", Value: "array", SourceFile: path, Line: lineNum,
+		})
+	}
+
+	return constraints
+}
+
+func (a *TypeScriptAdapter) extractPrismaConstraints(path, content string) []ExtractedConstraint {
+	var constraints []ExtractedConstraint
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		lineNum := i + 1
+		m := prismaFieldRE.FindStringSubmatch(line)
+		if len(m) < 5 {
 			continue
 		}
-		fieldName := fieldMatch[1]
 
-		// Check if field is required (no .optional())
-		if !zodOptionalRE.MatchString(trimmed) {
+		fieldName := m[1]
+		fieldType := m[2]
+		isOptional := m[3] == "?"
+		attrs := m[4]
+
+		// Skip relation fields
+		if prismaRelRE.MatchString(attrs) {
+			continue
+		}
+
+		// Type constraint
+		constraints = append(constraints, ExtractedConstraint{
+			Field:       fieldName,
+			Rule:        "type",
+			Value:       fieldType,
+			Description: fmt.Sprintf("%s MUST be of type %s", fieldName, fieldType),
+			SourceFile:  path,
+			Line:        lineNum,
+		})
+
+		// Required (not optional)
+		if !isOptional {
 			constraints = append(constraints, ExtractedConstraint{
 				Field: fieldName, Rule: "required", SourceFile: path, Line: lineNum,
 			})
 		}
 
-		// z.string().min(N)
-		if m := zodStringMinRE.FindStringSubmatch(trimmed); len(m) > 1 {
+		// @unique
+		if prismaUniqueRE.MatchString(attrs) {
 			constraints = append(constraints, ExtractedConstraint{
-				Field: fieldName, Rule: "min", Value: m[1], SourceFile: path, Line: lineNum,
+				Field:       fieldName,
+				Rule:        "unique",
+				Value:       "true",
+				Description: fmt.Sprintf("%s MUST be unique", fieldName),
+				SourceFile:  path,
+				Line:        lineNum,
 			})
 		}
 
-		// z.string().max(N)
-		if m := zodStringMaxRE.FindStringSubmatch(trimmed); len(m) > 1 {
+		// @db.VarChar(N)
+		if vm := prismaVarCharRE.FindStringSubmatch(attrs); len(vm) > 1 {
 			constraints = append(constraints, ExtractedConstraint{
-				Field: fieldName, Rule: "max", Value: m[1], SourceFile: path, Line: lineNum,
+				Field: fieldName, Rule: "max", Value: vm[1], SourceFile: path, Line: lineNum,
 			})
+		}
+	}
+
+	return constraints
+}
+
+func (a *TypeScriptAdapter) extractPatternConstraints(path, content string) []ExtractedConstraint {
+	var constraints []ExtractedConstraint
+	lines := strings.Split(content, "\n")
+
+	// Collect unique role and status values
+	roles := make(map[string]int)  // value -> first line
+	statuses := make(map[string]int)
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		for _, m := range roleCheckRE.FindAllStringSubmatch(line, -1) {
+			if len(m) > 1 {
+				if _, exists := roles[m[1]]; !exists {
+					roles[m[1]] = lineNum
+				}
+			}
 		}
 
-		// z.string().email()
-		if zodEmailRE.MatchString(trimmed) {
-			constraints = append(constraints, ExtractedConstraint{
-				Field: fieldName, Rule: "format", Value: "email", SourceFile: path, Line: lineNum,
-			})
+		for _, m := range statusCheckRE.FindAllStringSubmatch(line, -1) {
+			if len(m) > 1 {
+				if _, exists := statuses[m[1]]; !exists {
+					statuses[m[1]] = lineNum
+				}
+			}
 		}
+	}
 
-		// z.number().min(N)
-		if m := zodNumberMinRE.FindStringSubmatch(trimmed); len(m) > 1 {
-			constraints = append(constraints, ExtractedConstraint{
-				Field: fieldName, Rule: "min", Value: m[1], SourceFile: path, Line: lineNum,
-			})
+	// Emit role constraint if roles found
+	if len(roles) > 0 {
+		var roleValues []string
+		firstLine := 0
+		for v, line := range roles {
+			roleValues = append(roleValues, v)
+			if firstLine == 0 || line < firstLine {
+				firstLine = line
+			}
 		}
+		sort.Strings(roleValues)
+		constraints = append(constraints, ExtractedConstraint{
+			Field:       "role",
+			Rule:        "enum",
+			Value:       strings.Join(roleValues, ", "),
+			Description: fmt.Sprintf("role MUST be one of: %s", strings.Join(roleValues, ", ")),
+			SourceFile:  path,
+			Line:        firstLine,
+		})
+	}
 
-		// z.number().max(N)
-		if m := zodNumberMaxRE.FindStringSubmatch(trimmed); len(m) > 1 {
-			constraints = append(constraints, ExtractedConstraint{
-				Field: fieldName, Rule: "max", Value: m[1], SourceFile: path, Line: lineNum,
-			})
+	// Emit status constraint if statuses found
+	if len(statuses) > 0 {
+		var statusValues []string
+		firstLine := 0
+		for v, line := range statuses {
+			statusValues = append(statusValues, v)
+			if firstLine == 0 || line < firstLine {
+				firstLine = line
+			}
 		}
-
-		// z.enum([...])
-		if zodEnumRE.MatchString(trimmed) {
-			constraints = append(constraints, ExtractedConstraint{
-				Field: fieldName, Rule: "enum", SourceFile: path, Line: lineNum,
-			})
-		}
+		sort.Strings(statusValues)
+		constraints = append(constraints, ExtractedConstraint{
+			Field:       "status",
+			Rule:        "enum",
+			Value:       strings.Join(statusValues, ", "),
+			Description: fmt.Sprintf("status MUST be one of: %s", strings.Join(statusValues, ", ")),
+			SourceFile:  path,
+			Line:        firstLine,
+		})
 	}
 
 	return constraints

--- a/specter/internal/reverse/adapter_typescript_test.go
+++ b/specter/internal/reverse/adapter_typescript_test.go
@@ -1,7 +1,10 @@
 // @spec spec-reverse
 package reverse
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 var tsAdapter = &TypeScriptAdapter{}
 
@@ -195,6 +198,152 @@ func TestTypeScriptAdapter_Detect(t *testing.T) {
 	}
 	if tsAdapter.Detect("main.py", "") {
 		t.Error("expected Detect to return false for .py file")
+	}
+}
+
+func TestTypeScriptAdapter_ExtractConstraints_TypeScriptEnum(t *testing.T) {
+	content := `enum Role { ADMIN = "ADMIN", USER = "USER", MODERATOR = "MODERATOR" }
+`
+	constraints := tsAdapter.ExtractConstraints("types.ts", content)
+	found := false
+	for _, c := range constraints {
+		if c.Rule == "enum" && strings.Contains(c.Field, "role") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected enum constraint from TypeScript enum")
+	}
+}
+
+func TestTypeScriptAdapter_ExtractConstraints_UnionType(t *testing.T) {
+	content := `type Status = "active" | "inactive" | "pending"
+`
+	constraints := tsAdapter.ExtractConstraints("types.ts", content)
+	found := false
+	for _, c := range constraints {
+		if c.Rule == "enum" && strings.Contains(c.Field, "status") {
+			found = true
+			if c.Value == nil {
+				t.Error("expected union type values in Value field")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected enum constraint from union type")
+	}
+}
+
+func TestTypeScriptAdapter_ExtractConstraints_Prisma(t *testing.T) {
+	content := `model User {
+  id        String   @id @default(cuid())
+  email     String   @unique @db.VarChar(255)
+  name      String
+  bio       String?
+  role      String   @default("USER")
+  createdAt DateTime @default(now())
+}
+`
+	constraints := tsAdapter.ExtractConstraints("schema.prisma", content)
+	if len(constraints) == 0 {
+		t.Fatal("expected constraints from Prisma schema, got none")
+	}
+
+	type fieldRule struct {
+		field string
+		rule  string
+	}
+	found := make(map[fieldRule]bool)
+	for _, c := range constraints {
+		found[fieldRule{c.Field, c.Rule}] = true
+	}
+
+	if !found[fieldRule{"email", "unique"}] {
+		t.Error("expected email unique constraint")
+	}
+	if !found[fieldRule{"email", "max"}] {
+		t.Error("expected email max constraint from @db.VarChar(255)")
+	}
+	if !found[fieldRule{"name", "required"}] {
+		t.Error("expected name required constraint")
+	}
+	if found[fieldRule{"bio", "required"}] {
+		t.Error("bio should not be required (it has ?)")
+	}
+}
+
+func TestTypeScriptAdapter_ExtractConstraints_RoleChecks(t *testing.T) {
+	content := `export function requireRole(session: Session) {
+  if (session.user.role === "ADMIN") {
+    return true;
+  }
+  if (session.user.role === "MODERATOR") {
+    return true;
+  }
+  return false;
+}
+`
+	constraints := tsAdapter.ExtractConstraints("auth.ts", content)
+	found := false
+	for _, c := range constraints {
+		if c.Field == "role" && c.Rule == "enum" {
+			found = true
+			val, ok := c.Value.(string)
+			if !ok {
+				t.Error("expected string value for role enum")
+			} else if !strings.Contains(val, "ADMIN") || !strings.Contains(val, "MODERATOR") {
+				t.Errorf("expected role enum to contain ADMIN and MODERATOR, got %q", val)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected role enum constraint from role checks")
+	}
+}
+
+func TestTypeScriptAdapter_ExtractConstraints_ZodUrl(t *testing.T) {
+	content := `const schema = z.object({
+  website: z.string().url(),
+});
+`
+	constraints := tsAdapter.ExtractConstraints("schema.ts", content)
+	found := false
+	for _, c := range constraints {
+		if c.Field == "website" && c.Rule == "format" && c.Value == "url" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected format=url constraint for z.string().url()")
+	}
+}
+
+func TestTypeScriptAdapter_ExtractConstraints_ZodBooleanArray(t *testing.T) {
+	content := `const schema = z.object({
+  active: z.boolean(),
+  tags: z.array(z.string()),
+});
+`
+	constraints := tsAdapter.ExtractConstraints("schema.ts", content)
+	type fieldRule struct {
+		field string
+		rule  string
+	}
+	found := make(map[fieldRule]bool)
+	for _, c := range constraints {
+		found[fieldRule{c.Field, c.Rule}] = true
+	}
+	if !found[fieldRule{"active", "type"}] {
+		t.Error("expected type=boolean constraint for z.boolean()")
+	}
+	if !found[fieldRule{"tags", "type"}] {
+		t.Error("expected type=array constraint for z.array()")
+	}
+}
+
+func TestTypeScriptAdapter_Detect_Prisma(t *testing.T) {
+	if !tsAdapter.Detect("schema.prisma", "") {
+		t.Error("expected Detect to return true for .prisma file")
 	}
 }
 

--- a/specter/internal/reverse/detect.go
+++ b/specter/internal/reverse/detect.go
@@ -53,7 +53,7 @@ func DetectAdapter(files []SourceFile, adapters []Adapter) Adapter {
 func DetectLanguage(path string) string {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
-	case ".ts", ".tsx", ".js", ".jsx":
+	case ".ts", ".tsx", ".js", ".jsx", ".prisma":
 		return "typescript"
 	case ".py":
 		return "python"

--- a/specter/internal/reverse/id.go
+++ b/specter/internal/reverse/id.go
@@ -44,6 +44,39 @@ func GenerateSpecID(filePath string) string {
 	return name
 }
 
+// GenerateSpecIDFromRoute creates a kebab-case spec ID from an API route path.
+// e.g. "/api/webhooks/stripe" -> "webhooks-stripe", "/api/blog/[slug]" -> "blog-slug"
+func GenerateSpecIDFromRoute(routePath string) string {
+	// Strip /api/ prefix
+	path := routePath
+	if idx := strings.Index(path, "/api/"); idx >= 0 {
+		path = path[idx+len("/api/"):]
+	} else {
+		path = strings.TrimPrefix(path, "/")
+	}
+
+	// Replace path separators and brackets with hyphens
+	path = strings.ReplaceAll(path, "/", "-")
+	path = strings.ReplaceAll(path, "[", "")
+	path = strings.ReplaceAll(path, "]", "")
+
+	// Clean up and ensure valid spec ID
+	path = strings.ToLower(path)
+	path = nonAlphanumRE.ReplaceAllString(path, "-")
+	path = strings.Trim(path, "-")
+
+	if path == "" {
+		return "api-root"
+	}
+
+	// Ensure starts with letter
+	if len(path) > 0 && !unicode.IsLetter(rune(path[0])) {
+		path = "api-" + path
+	}
+
+	return path
+}
+
 // camelToKebab converts CamelCase to kebab-case.
 func camelToKebab(s string) string {
 	var result strings.Builder

--- a/specter/internal/reverse/id_test.go
+++ b/specter/internal/reverse/id_test.go
@@ -34,6 +34,30 @@ func TestGenerateSpecID(t *testing.T) {
 	}
 }
 
+func TestGenerateSpecIDFromRoute(t *testing.T) {
+	tests := []struct {
+		route string
+		want  string
+	}{
+		{"/api/webhooks/stripe", "webhooks-stripe"},
+		{"/api/blog/[slug]", "blog-slug"},
+		{"/api/onboarding", "onboarding"},
+		{"/api/auth/register", "auth-register"},
+		{"/api/blog/categories", "blog-categories"},
+		{"/unknown", "unknown"},
+		{"/api/", "api-root"},
+		{"/", "api-root"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.route, func(t *testing.T) {
+			got := GenerateSpecIDFromRoute(tt.route)
+			if got != tt.want {
+				t.Errorf("GenerateSpecIDFromRoute(%q) = %q, want %q", tt.route, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGenerateSpecID_KebabCasePattern(t *testing.T) {
 	inputs := []string{
 		"UserRegistration.ts",

--- a/specter/internal/reverse/reverse.go
+++ b/specter/internal/reverse/reverse.go
@@ -214,10 +214,15 @@ func Reverse(input ReverseInput, adapters []Adapter) *ReverseResult {
 			for _, e := range parseResult.Errors {
 				errMsgs = append(errMsgs, fmt.Sprintf("[%s] %s: %s", e.Type, e.Path, e.Message))
 			}
+			sourceFile := ""
+			if spec.GeneratedFrom != nil {
+				sourceFile = spec.GeneratedFrom.SourceFile
+			}
 			result.Diagnostics = append(result.Diagnostics, ReverseDiagnostic{
 				Kind:     "validation_failed",
 				Severity: "error",
-				Message:  fmt.Sprintf("generated spec %s failed validation: %s", spec.ID, strings.Join(errMsgs, "; ")),
+				Message:  fmt.Sprintf("generated spec %s (from %s) failed validation: %s", spec.ID, sourceFile, strings.Join(errMsgs, "; ")),
+				File:     sourceFile,
 			})
 			continue
 		}
@@ -340,6 +345,11 @@ func assembleSpec(groupKey string, group *fileGroup, adapter Adapter, systemName
 
 	specID := GenerateSpecID(groupKey)
 
+	// For Next.js App Router files (route.ts), derive ID from route path instead
+	if specID == "route" && len(routes) > 0 {
+		specID = GenerateSpecIDFromRoute(routes[0].Path)
+	}
+
 	// Build constraints
 	specConstraints := make([]schema.Constraint, len(constraints))
 	for i, c := range constraints {
@@ -353,7 +363,7 @@ func assembleSpec(groupKey string, group *fileGroup, adapter Adapter, systemName
 			Type:        "technical",
 			Enforcement: "error",
 		}
-		if c.Field != "" && c.Rule != "" {
+		if c.Field != "" && c.Rule != "" && c.Value != nil {
 			specConstraints[i].Validation = &schema.ConstraintValidation{
 				Field: c.Field,
 				Rule:  c.Rule,


### PR DESCRIPTION
## Summary

Fixes 4 bugs from the Jendays field report and expands TypeScript adapter extraction:

- Fix null `validation.value` when Zod patterns lack extractable literals
- Fix Next.js App Router ID collision (all files named `route.ts` → same ID)
- Include source file path in validation diagnostics
- Find manifest files in parent directories for system name inference
- Add extraction for TS enums, union types, Prisma schemas, role/status patterns

## Test plan

- [x] `make check` passes (85 tests)
- [x] `make dogfood` passes (6 specs)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)