### PR TITLE
fix: strip inline Python comments before constraint extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Specter will be documented in this file.
 
+## [0.2.3] - 2026-04-03
+
+### Fixed
+
+- Strip inline Python comments before constraint extraction — eliminates false positives from `# isort:skip`, `# noqa`, etc. on import lines (Django: 67 → 31 constraints, 36 false positives removed)
+
 ## [0.2.2] - 2026-04-03
 
 ### Fixed

--- a/specter/internal/reverse/adapter_python.go
+++ b/specter/internal/reverse/adapter_python.go
@@ -101,12 +101,20 @@ func (a *PythonAdapter) ExtractConstraints(path, content string) []ExtractedCons
 		lineNum := i + 1
 		trimmed := strings.TrimSpace(line)
 
-		// Skip comment-only lines and common directives
-		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") ||
-			strings.Contains(trimmed, "# noqa") || strings.Contains(trimmed, "# isort") ||
-			strings.Contains(trimmed, "# type:") || strings.Contains(trimmed, "# pragma") ||
-			strings.Contains(trimmed, "# fmt:") || strings.Contains(trimmed, "# pylint") ||
-			strings.Contains(trimmed, "# noinspection") {
+		// Skip comment-only lines
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+
+		// Strip inline comments before constraint matching
+		// e.g., "import foo  # isort:skip" → "import foo"
+		if idx := strings.Index(trimmed, "  #"); idx >= 0 {
+			trimmed = strings.TrimSpace(trimmed[:idx])
+		}
+		if idx := strings.Index(trimmed, "\t#"); idx >= 0 {
+			trimmed = strings.TrimSpace(trimmed[:idx])
+		}
+		if trimmed == "" {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Fixes the last remaining P1 bug from the 12-repo test suite. Lines like `import foo  # isort:skip` produced false positive constraints ("isort MUST be provided"). Now strips inline comments before running constraint regexes.

Django results: 67 → 31 constraints (36 false positives eliminated), noqa fully gone.

## Test plan

- [x] `make check` passes
- [x] Verified against django/django (2,888 files)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)