### PR TITLE
fix: route-path ID priority, Zod custom message extraction, --exclude flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Specter will be documented in this file.
 
+## [0.2.4] - 2026-04-03
+
+### Fixed
+
+- Route-path ID now takes priority over generic-filename logic for Next.js App Router files (`onboarding-route` → `onboarding`, `slug-route` → `blog-slug`)
+- Zod `.min(N, "message")` and `.max(N, "message")` with custom error messages now extracted correctly (previously the closing paren regex failed when extra args were present)
+- Zod `.email("message")` and `.url("message")` with custom messages now extracted correctly
+- CLI discovers `prisma/schema.prisma` from parent directories when scanning a subdirectory like `src/`
+
+### Added
+
+- `--exclude` flag for `specter reverse` — exclude paths from scanning (e.g., `--exclude src/components --exclude "*.test.*"`)
+
 ## [0.2.3] - 2026-04-03
 
 ### Fixed

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -462,6 +462,7 @@ func reverseCmd() *cobra.Command {
 		outputDir   string
 		groupBy     string
 		dryRun      bool
+		excludes    []string
 	)
 
 	cmd := &cobra.Command{
@@ -492,6 +493,16 @@ func reverseCmd() *cobra.Command {
 				if info.IsDir() {
 					return nil
 				}
+				// Check --exclude patterns
+				for _, pattern := range excludes {
+					if matched, _ := filepath.Match(pattern, path); matched {
+						return nil
+					}
+					// Also match against just the relative path segments
+					if strings.Contains(path, pattern) {
+						return nil
+					}
+				}
 				lang := reverse.DetectLanguage(path)
 				if lang == "" {
 					base := filepath.Base(path)
@@ -510,8 +521,9 @@ func reverseCmd() *cobra.Command {
 				return nil
 			})
 
-			// Look for manifest files in parent directories (for system name inference)
-			manifests := []string{"package.json", "go.mod", "pyproject.toml"}
+			// Look for manifest and schema files in parent directories
+			manifests := []string{"package.json", "go.mod", "pyproject.toml",
+				"prisma/schema.prisma", "schema.prisma"}
 			absTarget, _ := filepath.Abs(targetPath)
 			dir := absTarget
 			for {
@@ -627,6 +639,7 @@ func reverseCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&outputDir, "output", "o", "specs", "Output directory for generated .spec.yaml files")
 	cmd.Flags().StringVar(&groupBy, "group-by", "file", "Grouping strategy: file or directory")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview output without writing files")
+	cmd.Flags().StringArrayVar(&excludes, "exclude", nil, "Exclude paths matching pattern (can be repeated)")
 
 	return cmd
 }

--- a/specter/internal/reverse/adapter_typescript.go
+++ b/specter/internal/reverse/adapter_typescript.go
@@ -91,12 +91,12 @@ func inferNextJSRoutePath(filePath string) string {
 
 var (
 	zodFieldRE     = regexp.MustCompile(`(\w+)\s*:\s*z\.`)
-	zodStringMinRE = regexp.MustCompile(`z\.string\(\).*\.min\((\d+)\)`)
-	zodStringMaxRE = regexp.MustCompile(`z\.string\(\).*\.max\((\d+)\)`)
-	zodEmailRE     = regexp.MustCompile(`z\.string\(\).*\.email\(\)`)
-	zodUrlRE       = regexp.MustCompile(`z\.string\(\).*\.url\(\)`)
-	zodNumberMinRE = regexp.MustCompile(`z\.number\(\).*\.min\((\d+)\)`)
-	zodNumberMaxRE = regexp.MustCompile(`z\.number\(\).*\.max\((\d+)\)`)
+	zodStringMinRE = regexp.MustCompile(`z\.string\(\).*\.min\((\d+)`)
+	zodStringMaxRE = regexp.MustCompile(`z\.string\(\).*\.max\((\d+)`)
+	zodEmailRE     = regexp.MustCompile(`z\.string\(\).*\.email\(`)
+	zodUrlRE       = regexp.MustCompile(`z\.string\(\).*\.url\(`)
+	zodNumberMinRE = regexp.MustCompile(`z\.number\(\).*\.min\((\d+)`)
+	zodNumberMaxRE = regexp.MustCompile(`z\.number\(\).*\.max\((\d+)`)
 	zodEnumRE      = regexp.MustCompile(`z\.enum\(\[([^\]]*)\]`)
 	zodOptionalRE  = regexp.MustCompile(`\.optional\(\)`)
 	zodBooleanRE   = regexp.MustCompile(`z\.boolean\(\)`)

--- a/specter/internal/reverse/reverse.go
+++ b/specter/internal/reverse/reverse.go
@@ -11,6 +11,7 @@ package reverse
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -343,11 +344,14 @@ func assembleSpec(groupKey string, group *fileGroup, adapter Adapter, systemName
 		return nil
 	}
 
-	specID := GenerateSpecID(groupKey)
-
-	// For Next.js App Router files (route.ts), derive ID from route path instead
-	if specID == "route" && len(routes) > 0 {
+	// For Next.js App Router files (route.ts/route.js), derive ID from route path
+	// This check runs BEFORE GenerateSpecID so route paths take priority
+	specID := ""
+	if len(routes) > 0 && isNextJSRouteFile(groupKey) {
 		specID = GenerateSpecIDFromRoute(routes[0].Path)
+	}
+	if specID == "" {
+		specID = GenerateSpecID(groupKey)
 	}
 
 	// Build constraints
@@ -536,6 +540,12 @@ func normalizeValidationRule(rule string) string {
 		return canonical
 	}
 	return "custom"
+}
+
+// isNextJSRouteFile checks if the file path ends with route.ts, route.js, etc.
+func isNextJSRouteFile(path string) bool {
+	base := filepath.Base(path)
+	return base == "route.ts" || base == "route.tsx" || base == "route.js" || base == "route.jsx"
 }
 
 func findGapConstraintIndex(gapDesc string, constraints []ExtractedConstraint) int {


### PR DESCRIPTION
## Summary

Addresses mission-aligned items from Jendays field report:

- Route-path ID takes priority for Next.js App Router files (`onboarding-route` → `onboarding`)
- Zod `.min(N, "custom message")` now extracted (regex was failing on extra args)
- CLI discovers `prisma/schema.prisma` from parent directories
- New `--exclude` flag for scoping reverse scans

## Test plan

- [x] `make check` passes
- [x] `make dogfood` passes
- [x] Verified Zod custom message extraction with test fixture
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)