### PR TITLE
release: v0.3.1 — skip existing specs, --overwrite, --exclude, Jendays fixes, pre-release CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Specter will be documented in this file.
 
+## [0.3.1] - 2026-04-04
+
+### Fixed
+
+- Route-path ID now takes priority over generic-filename logic for Next.js App Router (`onboarding-route` → `onboarding`)
+- Zod `.min(N, "message")` / `.max(N, "message")` / `.email("msg")` with custom error messages now extracted correctly
+- CLI discovers `prisma/schema.prisma` from parent directories when scanning a subdirectory
+- Inline Python comment false positives eliminated (`# isort:skip`, `# noqa` on import lines)
+
+### Added
+
+- `--overwrite` flag for `specter reverse` — existing spec files are skipped by default, preserving manual edits
+- `--exclude` flag for `specter reverse` — scope scans with path exclusions
+- 3-tier pre-release CI workflow validating against 12 open-source repos (chi, fiber, validator, FastAPI, pydantic, django, cal.com, create-t3-app, payload, tRPC, TanStack, refine)
+
 ## [0.3.0] - 2026-04-03
 
 ### Added

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -464,6 +464,7 @@ func reverseCmd() *cobra.Command {
 		outputDir   string
 		groupBy     string
 		dryRun      bool
+		overwrite   bool
 		excludes    []string
 	)
 
@@ -612,6 +613,13 @@ func reverseCmd() *cobra.Command {
 				}
 
 				outPath := filepath.Join(outputDir, gs.FileName)
+
+				// Skip existing files unless --overwrite is set
+				if _, existErr := os.Stat(outPath); existErr == nil && !overwrite {
+					fmt.Printf("SKIPPED %s (already exists, use --overwrite to replace)\n", outPath)
+					continue
+				}
+
 				if mkErr := os.MkdirAll(outputDir, 0755); mkErr != nil {
 					fmt.Fprintf(os.Stderr, "error creating output directory: %v\n", mkErr)
 					os.Exit(1)
@@ -641,6 +649,7 @@ func reverseCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&outputDir, "output", "o", "specs", "Output directory for generated .spec.yaml files")
 	cmd.Flags().StringVar(&groupBy, "group-by", "file", "Grouping strategy: file or directory")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview output without writing files")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing spec files (default: skip)")
 	cmd.Flags().StringArrayVar(&excludes, "exclude", nil, "Exclude paths matching pattern (can be repeated)")
 
 	return cmd


### PR DESCRIPTION
## Summary

- `specter reverse` now skips existing spec files by default (preserves manual edits)
- `--overwrite` flag to force replacement
- `--exclude` flag for scoping scans
- Route-path ID priority for Next.js App Router
- Zod custom message extraction fix
- Prisma discovery from parent directories
- Inline Python comment filtering
- 3-tier pre-release CI with 12 real-world repos

## Test plan

- [x] `make check` passes
- [x] Skip/overwrite behavior verified manually
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)