### PR TITLE
feat: five Kensa-driven UX improvements (v0.4.0)

### DIFF
--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -175,7 +175,7 @@ func parseCmd() *cobra.Command {
 }
 
 func resolveCmd() *cobra.Command {
-	var jsonOutput, dotOutput bool
+	var jsonOutput, dotOutput, mermaidOutput bool
 	cmd := &cobra.Command{
 		Use:   "resolve",
 		Short: "Build and validate the spec dependency graph",
@@ -215,6 +215,19 @@ func resolveCmd() *cobra.Command {
 					fmt.Printf("  %q -> %q%s;\n", e.From, e.To, label)
 				}
 				fmt.Println("}")
+			} else if mermaidOutput {
+				// C-09: Mermaid flowchart output (renders natively in GitHub PRs)
+				fmt.Println("graph BT")
+				for id, node := range graph.Nodes {
+					fmt.Printf("    %s[\"%s@%s\"]\n", id, id, node.Spec.Version)
+				}
+				for _, e := range graph.Edges {
+					if e.VersionRange != "" {
+						fmt.Printf("    %s -->|\"%s\"| %s\n", e.From, e.VersionRange, e.To)
+					} else {
+						fmt.Printf("    %s --> %s\n", e.From, e.To)
+					}
+				}
 			} else {
 				fmt.Printf("Spec Graph: %d specs, %d dependencies\n\n", len(graph.Nodes), len(graph.Edges))
 				if len(graph.TopologicalOrder) > 0 {
@@ -242,6 +255,15 @@ func resolveCmd() *cobra.Command {
 			} else {
 				for _, d := range graph.Diagnostics {
 					fmt.Fprintf(os.Stderr, "error [%s] %s\n", d.Kind, d.Message)
+					// C-10: dangling-reference suggestions
+					if d.Kind == "dangling_reference" {
+						if len(d.Suggestions) > 0 {
+							fmt.Fprintf(os.Stderr, "  did you mean: %s\n", strings.Join(d.Suggestions, ", "))
+						}
+						if d.SuggestedFixPath != "" {
+							fmt.Fprintf(os.Stderr, "  fix: create %s with `id: %s`\n", d.SuggestedFixPath, d.MissingDep)
+						}
+					}
 				}
 				os.Exit(1)
 			}
@@ -250,12 +272,14 @@ func resolveCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().BoolVar(&dotOutput, "dot", false, "Output graph in DOT format")
+	cmd.Flags().BoolVar(&mermaidOutput, "mermaid", false, "Output graph in Mermaid format (renders in GitHub PRs)")
 	return cmd
 }
 
 func checkCmd() *cobra.Command {
 	var jsonOutput bool
 	var tierOverride int
+	var strict bool
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Run type-checking rules across the spec graph",
@@ -273,7 +297,11 @@ func checkCmd() *cobra.Command {
 				}
 			}
 
-			opts := &checker.CheckOptions{}
+			m, _ := loadManifest()
+			opts := &checker.CheckOptions{
+				Strict:      strict || m.Settings.Strict,
+				WarnOnDraft: m.Settings.WarnOnDraft,
+			}
 			if tierOverride > 0 {
 				opts.TierOverride = tierOverride
 			}
@@ -316,6 +344,7 @@ func checkCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().IntVar(&tierOverride, "tier", 0, "Override tier enforcement level")
+	cmd.Flags().BoolVar(&strict, "strict", false, "Treat warnings as errors (also set via settings.strict in specter.yaml)")
 	return cmd
 }
 
@@ -391,10 +420,18 @@ func coverageCmd() *cobra.Command {
 func syncCmd() *cobra.Command {
 	var jsonOutput bool
 	var testsGlob string
+	var onlyPhase string
+	var strict bool
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Run full validation pipeline (parse + resolve + check + coverage)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			validPhases := map[string]bool{"parse": true, "resolve": true, "check": true, "coverage": true}
+			if onlyPhase != "" && !validPhases[onlyPhase] {
+				fmt.Fprintf(os.Stderr, "error: --only must be one of: parse, resolve, check, coverage\n")
+				os.Exit(1)
+			}
+
 			specFiles := discoverSpecs()
 			if len(specFiles) == 0 {
 				fmt.Println("No .spec.yaml files found.")
@@ -413,9 +450,17 @@ func syncCmd() *cobra.Command {
 				testContents = append(testContents, specsync.FileContent{Path: f, Content: string(data)})
 			}
 
+			m, _ := loadManifest()
+			checkOpts := &checker.CheckOptions{
+				Strict:      strict || m.Settings.Strict,
+				WarnOnDraft: m.Settings.WarnOnDraft,
+			}
+
 			result := specsync.RunSync(specsync.SyncInput{
-				SpecFiles: specContents,
-				TestFiles: testContents,
+				SpecFiles:  specContents,
+				TestFiles:  testContents,
+				CheckOpts:  checkOpts,
+				OnlyPhase:  onlyPhase,
 			})
 
 			if jsonOutput {
@@ -454,6 +499,8 @@ func syncCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().StringVar(&testsGlob, "tests", "", "Glob pattern for test files")
+	cmd.Flags().StringVar(&onlyPhase, "only", "", "Run only this phase (parse|resolve|check|coverage); prerequisites run without halting")
+	cmd.Flags().BoolVar(&strict, "strict", false, "Treat warnings as errors (also set via settings.strict in specter.yaml)")
 	return cmd
 }
 

--- a/specter/docs/IMPROVEMENT_ROADMAP.md
+++ b/specter/docs/IMPROVEMENT_ROADMAP.md
@@ -4,8 +4,8 @@
 
 **Design principle:** Make it easy for developers to use. If Specter does its job well, developers will love it.
 
-**Date:** 2026-04-03
-**Based on:** Real-world testing against 12 open-source repos (5,434 files, 0 crashes, 27,012 assertions extracted)
+**Date:** 2026-04-14
+**Based on:** Real-world testing against 12 open-source repos (5,434 files, 0 crashes, 27,012 assertions extracted) + Kensa team review (2026-04-14)
 
 ---
 
@@ -16,7 +16,7 @@ parse → resolve → check → coverage → sync
   ✅       ✅        ✅       ✅        ✅
 ```
 
-All 5 tools work. Dogfooding passes (6 specs, 85 tests). But they've only been validated against Specter's own specs. No external developer has gone through the full write-spec → run-sync → iterate loop. We don't actually know if the pipeline feels good to use.
+All 5 tools work. Dogfooding passes (7 specs, 85+ tests). The core engine has been validated against 12 real-world repos and one demanding external team (Kensa). No architectural gaps — remaining work is UX, CI integration, and authoring-loop friction.
 
 ---
 
@@ -26,25 +26,27 @@ All 5 tools work. Dogfooding passes (6 specs, 85 tests). But they've only been v
 
 The pipeline works, but is it ready for a developer who just installed Specter and is writing their first spec?
 
-| Gap | Why it matters |
-|-----|---------------|
-| No `specter init` command | Developer downloads Specter, types `specter`... now what? There's no scaffolding. They have to read docs and write YAML from scratch. |
-| Error messages are technical | Parse errors show JSON Schema paths like `spec.constraints[0].id`. A developer needs "Constraint ID 'c01' is invalid — must match pattern C-01, C-02, etc." |
-| No spec templates | Every spec starts from zero. A `specter init --template api-endpoint` would give them a starting point. |
-| `specter sync` only runs locally | No GitHub Action. The developer has to wire CI themselves. A `hanalyx/specter-sync-action` would make CI integration one line. |
-| Coverage thresholds are hardcoded | T1=100%, T2=80%, T3=50%. No way to configure per-project. A team might want T2=90%. |
+| Gap | Why it matters | Status |
+|-----|---------------|--------|
+| ~~No `specter init` command~~ | ~~Developer downloads Specter, types `specter`... now what?~~ | ✅ v0.3.0 |
+| Error messages are technical | Parse errors show JSON Schema paths like `spec.constraints[0].id`. A developer needs "Constraint ID 'c01' is invalid — must match pattern C-01, C-02, etc." | Open |
+| Dangling-reference messages lack suggestions | `error: "handler-interface" does not exist` — no hint of what does exist or what to do | Open |
+| No spec templates | Every spec starts from zero. A `specter init --template api-endpoint` would give them a starting point. | Open |
+| `specter sync` only runs locally | No GitHub Action. The developer has to wire CI themselves. A `hanalyx/specter-sync-action` would make CI integration one line. | Open |
+| Coverage thresholds are hardcoded | T1=100%, T2=80%, T3=50%. No way to configure per-project. A team might want T2=90%. | Open |
+| `tier` vs `tier_overrides` conflict is silent | When a spec declares `tier: 1` and `specter.yaml` assigns a different tier via `tier_overrides`, no warning is emitted and precedence is undocumented | Open |
 
 ### Track 2: Fix What's Broken (P0/P1)
 
 These are bugs that undermine trust. A developer tries Specter, it rejects valid output or silently drops data, and they walk away.
 
-| Bug | Impact | Fix effort |
-|-----|--------|------------|
-| `validation.rule` enum too narrow | 18 rejections across 4 repos — Specter rejects its own output | Small — map unknown rules to `"custom"` in core engine |
-| Missing `.spec.tsx`/`.spec.jsx` in IsTestFile | 713 assertions silently lost in one repo | Trivial — add 2 strings |
-| Test description truncation on embedded quotes | Garbled AC descriptions | Small — fix regex |
-| Python false positive constraints from comments | `# isort MUST be provided` — nonsensical output | Small — skip comment lines |
-| Spec ID collision on generic filenames | 54 specs all named `index` in one repo | Medium — incorporate parent dir |
+| Bug | Impact | Fix effort | Status |
+|-----|--------|------------|--------|
+| ~~`validation.rule` enum too narrow~~ | ~~18 rejections across 4 repos — Specter rejects its own output~~ | Small | ✅ v0.2.2 |
+| ~~Missing `.spec.tsx`/`.spec.jsx` in IsTestFile~~ | ~~713 assertions silently lost in one repo~~ | Trivial | ✅ v0.2.2 |
+| ~~Python false positive constraints from comments~~ | ~~`# isort MUST be provided` — nonsensical output~~ | Small | ✅ v0.2.2 |
+| ~~Spec ID collision on generic filenames~~ | ~~54 specs all named `index` in one repo~~ | Medium | ✅ v0.2.2 |
+| Test description truncation on embedded quotes | Garbled AC descriptions | Small | Open |
 
 ### Track 3: Developer Experience (the love factor)
 
@@ -62,41 +64,94 @@ This is what turns "useful tool" into "tool developers love."
 
 ## Recommended Priority Order
 
-### Phase 1 — Trust (v0.2.2)
+### Phase 1 — Trust (v0.2.2) ✅ COMPLETE
 
 Fix P0/P1 bugs. Specter must never reject its own valid output. This is table stakes.
 
-- Map unknown `validation.rule` values to `"custom"` in core engine
-- Add `.spec.tsx`, `.spec.jsx` to TypeScript adapter IsTestFile
+- ✅ Map unknown `validation.rule` values to `"custom"` in core engine
+- ✅ Add `.spec.tsx`, `.spec.jsx` to TypeScript adapter IsTestFile
+- ✅ Fix Python adapter false positive constraints from comments
+- ✅ Fix spec ID collision for generic filenames (route.ts, main.go, index.ts)
 - Fix test description regex to handle embedded quotes
-- Fix Python adapter false positive constraints from comments
-- Fix spec ID collision for generic filenames (route.ts, main.go, index.ts)
 
-### Phase 2 — First-Run Experience (v0.3.0)
+### Phase 2 — First-Run Experience (v0.3.x)
 
-A developer should go from install to their first passing `specter sync` in under 5 minutes.
+A developer should go from install to their first passing `specter sync` in under 5 minutes. Also: correctness fixes that surface during real-world authoring.
 
-- `specter init` — scaffold a first spec with guided prompts
-- Spec templates (api-endpoint, service, auth, data-model)
-- Human-readable error messages (not JSON Schema paths)
+- ✅ `specter init` — scaffold a first spec from the manifest
+- Spec templates (`api-endpoint`, `service`, `auth`, `data-model`)
 - `specter doctor` — pre-flight check for project readiness
+- **Human-readable error messages** — replace JSON Schema paths with developer-facing language; specifically:
+  - Dangling-reference errors must include: existing spec IDs, Levenshtein-distance closest match, and a suggested file path + `id:` fix. Example:
+    ```
+    error [dangling_reference] Spec "engine-transaction" depends on "handler-interface" which does not exist
+      searched: specs/**/*.spec.yaml
+      existing specs: handler-file-permissions, engine-transaction
+      did you mean: handler-file-permissions?
+      fix: create specs/handler/interface.spec.yaml with `id: handler-interface`
+    ```
+  - Orphan constraint and unmapped AC errors must link to the annotation guide
+- **`tier` vs `tier_overrides` conflict warning** — document that spec-level `tier` wins; emit a diagnostic when the two disagree:
+  ```
+  warn [tier_conflict] specs/engine/transaction.spec.yaml declares tier: 1
+                      but specter.yaml tier_overrides assigns tier: 2 to specs/engine/
+                      using tier: 1 (spec-level wins)
+  ```
 
-### Phase 3 — CI Integration (v0.3.x)
+### Phase 3 — Authoring Loop & CI Integration (v0.4.0)
 
-The mission becomes infrastructure — specs enforced on every PR, not just locally.
+The authoring loop (draft → check → fix → recheck) is where developers spend most of their time. This phase makes that loop fast, informative, and CI-enforced.
 
-- `hanalyx/specter-sync-action` GitHub Action — one-line CI setup
-- Configurable coverage thresholds per project (`.specter.yml`)
-- PR comment integration — show spec coverage diff in PRs
+**Authoring loop:**
 
-### Phase 4 — Editor Experience (v0.4.0)
+- **`specter explain <spec-id>:<ac-id>`** — active diagnostic command for uncovered ACs. Shows what annotation pattern coverage looked for, which files were scanned, and a ready-to-paste example annotation. Example:
+  ```
+  $ specter explain engine-transaction:AC-07
+  AC-07 is uncovered. Specter searched:
+    tests/**/*_test.go with annotation pattern:
+      // AC-07: ...   (Go comment)
+      t.Run("AC-07/...", ...)  (subtest name)
 
-The "love" feature. Real-time validation as developers write specs.
+    0 files matched. Suggested test location:
+      tests/engine/transaction_test.go
 
-- VS Code extension for `.spec.yaml` files
-- Syntax highlighting, schema validation, autocomplete
-- Inline diagnostics (orphan constraints, missing ACs)
-- Go-to-definition for `depends_on` references
+    Example annotation:
+      // AC-07: Concurrent Run calls against the same host serialize.
+      func TestTransaction_AC07_PerHostSerialization(t *testing.T) { ... }
+  ```
+- **`specter watch`** — re-invoke the sync pipeline on filesystem change, 200–500ms loop. Same semantics as `tsc --watch`. Makes the draft → check → fix cycle interactive rather than manual.
+- **`specter diff <spec>@<ref1> <spec>@<ref2>`** — semantic diff between two git revisions of a spec. Shows added/removed/changed ACs, constraints, and dependency version pins. More useful than YAML textual diff for PR review and release notes. Example:
+  ```
+  $ specter diff specs/engine/transaction.spec.yaml@HEAD~5 specs/engine/transaction.spec.yaml
+  spec engine-transaction 0.1.0 → 0.2.0
+    +constraint C-08 (security, error): "Host mutex must be released on panic"
+    +ac AC-12: "Host mutex is released when Run panics"
+    ~ac AC-02 priority: high → critical
+    -ac AC-09: removed (superseded by evidence-envelope spec)
+    ~depends_on handler-interface: any → ^1.0.0
+  ```
+- **`resolve --mermaid`** — Mermaid diagram output alongside existing `--dot`. Renders natively in GitHub PRs where reviewers actually look at graphs.
+- **`specter sync --only <phase>`** — run a single pipeline phase without halting on prior-phase failures. Useful when you want to see all coverage gaps even with unresolved dangling references.
+
+**CI integration:**
+
+- **`specter check --strict`** — treat `enforcement: warning` diagnostics as errors; exit non-zero. Eliminates per-project CI shell gymnastics to re-exit on warnings.
+- **`settings.strict: true`** — project-level equivalent of `--strict` in `specter.yaml`, so the policy is set once and applied everywhere.
+- **`settings.warn_on_draft: true`** — emit a warning (or error under `--strict`) for any spec with `status: draft` encountered during sync. Prevents accidentally shipping unapproved specs in a release branch.
+- **Pass-rate-aware coverage for Tier 1** — coverage currently counts an AC as covered if the annotation exists, regardless of whether the test passes. For Tier 1 specs a failing test is worse than no test. Implementation: adopt the `.specter-results.json` convention (language-agnostic; test infrastructure writes pass/fail results, coverage reads them). Tier 1 AC coverage requires both annotation presence and a passing result entry.
+- **Configurable coverage thresholds** — per-project in `specter.yaml` (e.g. `thresholds.tier1: 100`, `thresholds.tier2: 90`). Per-spec override in the spec file for specs that need stricter or looser policy than the project default.
+- **`hanalyx/specter-sync-action`** — GitHub Action for one-line CI setup. Runs the full sync pipeline and posts a coverage diff comment on PRs.
+- **PR comment integration** — show spec coverage diff in PR comments (AC added/removed, coverage delta by tier).
+
+### Phase 4 — Editor Experience & Schema Evolution (v0.5.0)
+
+The "love" feature: real-time validation as developers write specs. Plus tooling for breaking schema changes.
+
+- **VS Code extension** for `.spec.yaml` files
+  - Syntax highlighting, schema validation, autocomplete
+  - Inline diagnostics (orphan constraints, missing ACs)
+  - Go-to-definition for `depends_on` references
+- **`specter migrate v1→v2 specs/`** — scaffolded migration when `spec-schema.json` bumps a major version. Rewrites existing spec files to the new format and reports fields that require manual intervention. Necessary for adoption at scale — teams with hundreds of specs cannot migrate by hand.
 
 ---
 
@@ -120,6 +175,14 @@ Tested against 12 open-source repos on 2026-04-03:
 | calcom/cal.com | TS/Next.js | 871 | 477 | 1,320 | 9 |
 | **TOTAL** | | **5,434** | **1,822** | **27,012** | **18** |
 
-**Key finding:** Zero crashes across 5,434 files. Core engine is solid. All 18 validation failures trace to the same root cause (validation.rule enum too narrow).
+**Key finding:** Zero crashes across 5,434 files. Core engine is solid. All 18 validation failures trace to the same root cause (validation.rule enum too narrow — fixed in v0.2.2).
 
+### Kensa Team Review (2026-04-14)
 
+External validation from the Kensa engineering team, who drove the full pipeline against a real spec graph with intentional dangling references and unmapped ACs. Key findings:
+
+**What works:** C-NN / AC-NN cross-referencing, tier system with per-path overrides, status lifecycle, reverse with multi-language adapters (specifically: reverse-compiling from both Python and Go implementations to detect drift during a language migration), `resolve --dot` for design-review artifacts, strict schema rejection.
+
+**What Kensa confirmed is architecturally correct:** "Seven improvements above are UX and CI-integration refinements, not architectural gaps."
+
+**Kensa's 7 feedback items** are the direct source for the Phase 2 and Phase 3 additions above (dangling-ref suggestions, tier conflict warning, `specter explain`, `specter watch`, `specter diff`, `--strict`/`warn_on_draft`, pass-rate-aware coverage). All seven have been incorporated.

--- a/specter/internal/checker/check.go
+++ b/specter/internal/checker/check.go
@@ -40,6 +40,8 @@ type CheckSummary struct {
 type CheckOptions struct {
 	TierOverride     int
 	PreviousVersions map[string]*schema.SpecAST
+	Strict           bool // C-07: upgrade all warning/info diagnostics to error
+	WarnOnDraft      bool // C-08: emit warning for specs with status: draft
 }
 
 // Tier-based severity for orphan constraints.
@@ -70,6 +72,20 @@ func CheckSpecs(graph *resolver.SpecGraph, opts *CheckOptions) *CheckResult {
 	}
 
 	var diagnostics []CheckDiagnostic
+
+	// Rule 0: Draft spec warning (AC-08)
+	if opts.WarnOnDraft {
+		for _, node := range graph.Nodes {
+			if node.Spec.Status == "draft" {
+				diagnostics = append(diagnostics, CheckDiagnostic{
+					Kind:     "draft_spec",
+					Severity: "warning",
+					Message:  fmt.Sprintf("Spec %q has status: draft — approve or remove before shipping", node.Spec.ID),
+					SpecID:   node.Spec.ID,
+				})
+			}
+		}
+	}
 
 	// Rule 1: Orphan constraints (AC-01, AC-02, AC-06)
 	for _, node := range graph.Nodes {
@@ -108,6 +124,15 @@ func CheckSpecs(graph *resolver.SpecGraph, opts *CheckOptions) *CheckResult {
 					ChangeType: change.Classification,
 					Details:    change.Field,
 				})
+			}
+		}
+	}
+
+	// C-07: strict mode — upgrade warnings and info to errors
+	if opts.Strict {
+		for i := range diagnostics {
+			if diagnostics[i].Severity == "warning" || diagnostics[i].Severity == "info" {
+				diagnostics[i].Severity = "error"
 			}
 		}
 	}

--- a/specter/internal/checker/check_test.go
+++ b/specter/internal/checker/check_test.go
@@ -174,3 +174,68 @@ func TestNoOrphansWhenAllReferenced(t *testing.T) {
 		}
 	}
 }
+
+// @ac AC-07
+func TestStrictModeUpgradesWarningsToErrors(t *testing.T) {
+	// Tier 2 orphan is normally a warning
+	spec := makeSpec("mid", 2)
+	spec.Constraints = []schema.Constraint{
+		{ID: "C-01", Description: "referenced"},
+		{ID: "C-02", Description: "orphan"},
+	}
+	spec.AcceptanceCriteria = []schema.AcceptanceCriterion{
+		{ID: "AC-01", Description: "test", ReferencesConstraints: []string{"C-01"}},
+	}
+
+	g := makeGraph(map[string]*resolver.SpecNode{"mid": {Spec: spec, File: "mid.yaml"}}, nil)
+
+	// Without strict: warning
+	r := CheckSpecs(g, nil)
+	for _, d := range r.Diagnostics {
+		if d.Kind == "orphan_constraint" && d.Severity != "warning" {
+			t.Errorf("expected warning without strict, got %q", d.Severity)
+		}
+	}
+	if r.Summary.Errors > 0 {
+		t.Error("expected no errors without strict mode")
+	}
+
+	// With strict: error
+	rs := CheckSpecs(g, &CheckOptions{Strict: true})
+	for _, d := range rs.Diagnostics {
+		if d.Kind == "orphan_constraint" && d.Severity != "error" {
+			t.Errorf("expected error with strict=true, got %q", d.Severity)
+		}
+	}
+	if rs.Summary.Errors == 0 {
+		t.Error("expected errors > 0 in strict mode")
+	}
+}
+
+// @ac AC-08
+func TestWarnOnDraftEmitsDraftSpecDiagnostic(t *testing.T) {
+	spec := makeSpec("draft-spec", 2)
+	spec.Status = "draft"
+
+	g := makeGraph(map[string]*resolver.SpecNode{"draft-spec": {Spec: spec, File: "d.yaml"}}, nil)
+
+	// Without warn_on_draft: no draft diagnostic
+	r := CheckSpecs(g, nil)
+	for _, d := range r.Diagnostics {
+		if d.Kind == "draft_spec" {
+			t.Error("unexpected draft_spec diagnostic without WarnOnDraft")
+		}
+	}
+
+	// With warn_on_draft: warning emitted
+	rw := CheckSpecs(g, &CheckOptions{WarnOnDraft: true})
+	found := false
+	for _, d := range rw.Diagnostics {
+		if d.Kind == "draft_spec" && d.SpecID == "draft-spec" && d.Severity == "warning" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected draft_spec warning diagnostic with WarnOnDraft=true")
+	}
+}

--- a/specter/internal/manifest/manifest_test.go
+++ b/specter/internal/manifest/manifest_test.go
@@ -309,3 +309,54 @@ func TestCoverageThresholds_PartialOverride(t *testing.T) {
 		t.Errorf("partial thresholds = %v, want {1:100, 2:90, 3:50}", thresholds)
 	}
 }
+
+// @ac AC-15
+func TestParseManifest_SettingsStrict(t *testing.T) {
+	content := `
+system:
+  name: test-app
+settings:
+  strict: true
+`
+	m, err := ParseManifest(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.Settings.Strict {
+		t.Error("expected Settings.Strict=true, got false")
+	}
+}
+
+// @ac AC-16
+func TestParseManifest_SettingsWarnOnDraft(t *testing.T) {
+	content := `
+system:
+  name: test-app
+settings:
+  warn_on_draft: true
+`
+	m, err := ParseManifest(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.Settings.WarnOnDraft {
+		t.Error("expected Settings.WarnOnDraft=true, got false")
+	}
+}
+
+func TestParseManifest_SettingsDefaultsFalse(t *testing.T) {
+	content := `
+system:
+  name: test-app
+`
+	m, err := ParseManifest(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Settings.Strict {
+		t.Error("expected Settings.Strict=false by default")
+	}
+	if m.Settings.WarnOnDraft {
+		t.Error("expected Settings.WarnOnDraft=false by default")
+	}
+}

--- a/specter/internal/manifest/types.go
+++ b/specter/internal/manifest/types.go
@@ -33,9 +33,11 @@ type DomainConfig struct {
 
 // Settings holds project-level configuration.
 type Settings struct {
-	SpecsDir string         `yaml:"specs_dir,omitempty" json:"specs_dir,omitempty"`
-	Coverage CoverageConfig `yaml:"coverage,omitempty" json:"coverage,omitempty"`
-	Exclude  []string       `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+	SpecsDir    string         `yaml:"specs_dir,omitempty" json:"specs_dir,omitempty"`
+	Coverage    CoverageConfig `yaml:"coverage,omitempty" json:"coverage,omitempty"`
+	Exclude     []string       `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+	Strict      bool           `yaml:"strict,omitempty" json:"strict,omitempty"`       // C-11: treat warnings as errors
+	WarnOnDraft bool           `yaml:"warn_on_draft,omitempty" json:"warn_on_draft,omitempty"` // C-12: warn on draft specs
 }
 
 // CoverageConfig defines per-tier coverage thresholds.

--- a/specter/internal/resolver/resolve.go
+++ b/specter/internal/resolver/resolve.go
@@ -14,15 +14,17 @@ import (
 
 // Diagnostic represents an issue found during resolution.
 type Diagnostic struct {
-	Kind          string   `json:"kind"`
-	Severity      string   `json:"severity"`
-	Message       string   `json:"message"`
-	SpecID        string   `json:"spec_id,omitempty"`
-	MissingDep    string   `json:"missing_dep,omitempty"`
-	RequiredRange string   `json:"required_range,omitempty"`
-	ActualVersion string   `json:"actual_version,omitempty"`
-	CyclePath     []string `json:"cycle_path,omitempty"`
-	Files         []string `json:"files,omitempty"`
+	Kind             string   `json:"kind"`
+	Severity         string   `json:"severity"`
+	Message          string   `json:"message"`
+	SpecID           string   `json:"spec_id,omitempty"`
+	MissingDep       string   `json:"missing_dep,omitempty"`
+	RequiredRange    string   `json:"required_range,omitempty"`
+	ActualVersion    string   `json:"actual_version,omitempty"`
+	CyclePath        []string `json:"cycle_path,omitempty"`
+	Files            []string `json:"files,omitempty"`
+	Suggestions      []string `json:"suggestions,omitempty"`       // C-10: closest existing spec IDs
+	SuggestedFixPath string   `json:"suggested_fix_path,omitempty"` // C-10: likely file path to create
 }
 
 // SpecNode holds a parsed spec and its file path.
@@ -82,6 +84,12 @@ func ResolveSpecs(inputs []SpecInput) *SpecGraph {
 		graph.Nodes[id] = &SpecNode{Spec: inputs[i].Spec, File: inputs[i].File}
 	}
 
+	// Collect all known spec IDs for suggestion matching (C-10)
+	allIDs := make([]string, 0, len(graph.Nodes))
+	for id := range graph.Nodes {
+		allIDs = append(allIDs, id)
+	}
+
 	// Step 2: Build edges, detect dangling refs and version mismatches
 	adjacency := make(map[string][]string) // from -> [to]
 	for id, node := range graph.Nodes {
@@ -91,13 +99,17 @@ func ResolveSpecs(inputs []SpecInput) *SpecGraph {
 			// C-05: Dangling reference (AC-03)
 			target, exists := graph.Nodes[targetID]
 			if !exists {
-				graph.Diagnostics = append(graph.Diagnostics, Diagnostic{
-					Kind:       "dangling_reference",
-					Severity:   "error",
-					Message:    fmt.Sprintf("Spec %q depends on %q which does not exist", id, targetID),
-					SpecID:     id,
-					MissingDep: targetID,
-				})
+				suggestions := closestMatches(targetID, allIDs, 3)
+				d := Diagnostic{
+					Kind:             "dangling_reference",
+					Severity:         "error",
+					Message:          fmt.Sprintf("Spec %q depends on %q which does not exist", id, targetID),
+					SpecID:           id,
+					MissingDep:       targetID,
+					Suggestions:      suggestions,
+					SuggestedFixPath: inferSpecFilePath(targetID),
+				}
+				graph.Diagnostics = append(graph.Diagnostics, d)
 				continue
 			}
 

--- a/specter/internal/resolver/resolve_test.go
+++ b/specter/internal/resolver/resolve_test.go
@@ -180,3 +180,58 @@ func TestValidVersionRange(t *testing.T) {
 		t.Errorf("expected 0 diagnostics, got %v", g.Diagnostics)
 	}
 }
+
+// @ac AC-09
+func TestDanglingReferenceIncludesSuggestion(t *testing.T) {
+	// "handler-interfac" is one character off from "handler-interface"
+	g := ResolveSpecs([]SpecInput{
+		{Spec: makeSpec("a", withDeps(dep("handler-interfac"))), File: "a.spec.yaml"},
+		{Spec: makeSpec("handler-interface"), File: "handler-interface.spec.yaml"},
+	})
+
+	var dr *Diagnostic
+	for i := range g.Diagnostics {
+		if g.Diagnostics[i].Kind == "dangling_reference" {
+			dr = &g.Diagnostics[i]
+			break
+		}
+	}
+	if dr == nil {
+		t.Fatal("expected dangling_reference diagnostic")
+	}
+	if len(dr.Suggestions) == 0 {
+		t.Error("expected at least one suggestion")
+	}
+	found := false
+	for _, s := range dr.Suggestions {
+		if s == "handler-interface" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'handler-interface' in suggestions, got %v", dr.Suggestions)
+	}
+	if dr.SuggestedFixPath == "" {
+		t.Error("expected SuggestedFixPath to be set")
+	}
+}
+
+// @ac AC-09
+func TestDanglingReferenceNoSuggestionWhenFarOff(t *testing.T) {
+	// "xyz-totally-different" is far from "handler-interface"
+	g := ResolveSpecs([]SpecInput{
+		{Spec: makeSpec("a", withDeps(dep("xyz-totally-different"))), File: "a.spec.yaml"},
+		{Spec: makeSpec("handler-interface"), File: "handler-interface.spec.yaml"},
+	})
+
+	for _, d := range g.Diagnostics {
+		if d.Kind == "dangling_reference" {
+			// suggestions may be empty for very distant strings — that's correct
+			if len(d.Suggestions) > 0 {
+				t.Logf("suggestions present but string is far: %v (acceptable)", d.Suggestions)
+			}
+			return
+		}
+	}
+	t.Error("expected dangling_reference diagnostic")
+}

--- a/specter/internal/resolver/suggestions.go
+++ b/specter/internal/resolver/suggestions.go
@@ -1,0 +1,90 @@
+package resolver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// levenshtein computes the edit distance between two strings.
+func levenshtein(a, b string) int {
+	if a == "" {
+		return len(b)
+	}
+	if b == "" {
+		return len(a)
+	}
+
+	ra, rb := []rune(a), []rune(b)
+	m, n := len(ra), len(rb)
+
+	prev := make([]int, n+1)
+	curr := make([]int, n+1)
+	for j := 0; j <= n; j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= m; i++ {
+		curr[0] = i
+		for j := 1; j <= n; j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[n]
+}
+
+func min3(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+		return c
+	}
+	if b < c {
+		return b
+	}
+	return c
+}
+
+// closestMatches returns up to maxN spec IDs closest to target by edit distance,
+// filtered to only those within a reasonable distance (len(target)/2 + 2).
+func closestMatches(target string, candidates []string, maxN int) []string {
+	type scored struct {
+		id   string
+		dist int
+	}
+	var scores []scored
+	threshold := len(target)/2 + 2
+	for _, c := range candidates {
+		d := levenshtein(target, c)
+		if d <= threshold {
+			scores = append(scores, scored{c, d})
+		}
+	}
+	sort.Slice(scores, func(i, j int) bool { return scores[i].dist < scores[j].dist })
+
+	var result []string
+	for i, s := range scores {
+		if i >= maxN {
+			break
+		}
+		result = append(result, s.id)
+	}
+	return result
+}
+
+// inferSpecFilePath converts a spec ID to a likely file path.
+// "handler-interface"  → "specs/handler/interface.spec.yaml"
+// "auth"               → "specs/auth.spec.yaml"
+func inferSpecFilePath(id string) string {
+	parts := strings.SplitN(id, "-", 2)
+	if len(parts) == 2 {
+		return fmt.Sprintf("specs/%s/%s.spec.yaml", parts[0], parts[1])
+	}
+	return fmt.Sprintf("specs/%s.spec.yaml", id)
+}

--- a/specter/internal/reverse/adapter_typescript.go
+++ b/specter/internal/reverse/adapter_typescript.go
@@ -406,10 +406,11 @@ func (a *TypeScriptAdapter) extractPatternConstraints(path, content string) []Ex
 // --- Assertion Extraction (Jest/Vitest) ---
 
 var (
-	describeBlockDQ = regexp.MustCompile(`describe\(\s*"([^"]+)"`)
-	describeBlockSQ = regexp.MustCompile(`describe\(\s*'([^']+)'`)
-	itTestDQ        = regexp.MustCompile("(?:it|test)\\(\\s*\"([^\"]+)\"")
-	itTestSQ        = regexp.MustCompile(`(?:it|test)\(\s*'([^']+)'`)
+	// C-11: patterns handle escaped quotes via (?:[^"\\]|\\.)*
+	describeBlockDQ = regexp.MustCompile(`describe\(\s*"((?:[^"\\]|\\.)*)"`)
+	describeBlockSQ = regexp.MustCompile(`describe\(\s*'((?:[^'\\]|\\.)*)'`)
+	itTestDQ        = regexp.MustCompile(`(?:it|test)\(\s*"((?:[^"\\]|\\.)*)"`)
+	itTestSQ        = regexp.MustCompile(`(?:it|test)\(\s*'((?:[^'\\]|\\.)*)'`)
 )
 
 func (a *TypeScriptAdapter) ExtractAssertions(path, content string) []ExtractedAssertion {

--- a/specter/internal/reverse/adapter_typescript_test.go
+++ b/specter/internal/reverse/adapter_typescript_test.go
@@ -101,6 +101,40 @@ describe('UserService', () => {
 	}
 }
 
+// @ac AC-15
+func TestTypeScriptAdapter_ExtractAssertions_EmbeddedQuotes(t *testing.T) {
+	content := `import { it, describe } from 'vitest';
+
+describe("user's profile", () => {
+  it("user's token is valid", () => {});
+  it('reject "admin" role for guests', () => {});
+  it("handles \"quoted\" field names", () => {});
+});
+`
+	assertions := tsAdapter.ExtractAssertions("auth.test.ts", content)
+	if len(assertions) != 3 {
+		t.Fatalf("expected 3 assertions, got %d", len(assertions))
+	}
+
+	cases := []struct {
+		want string
+	}{
+		{"user's token is valid"},
+		{`reject "admin" role for guests`},
+		{`handles \"quoted\" field names`}, // raw JS source; backslash escape not unescaped
+	}
+	for i, c := range cases {
+		if assertions[i].Description != c.want {
+			t.Errorf("assertion[%d] description = %q, want %q", i, assertions[i].Description, c.want)
+		}
+	}
+
+	// describe block with apostrophe should also be captured correctly
+	if assertions[0].TestName != "user's profile > user's token is valid" {
+		t.Errorf("test name = %q, want %q", assertions[0].TestName, "user's profile > user's token is valid")
+	}
+}
+
 func TestTypeScriptAdapter_ExtractRoutes_Express(t *testing.T) {
 	content := `import express from 'express';
 

--- a/specter/internal/sync/sync.go
+++ b/specter/internal/sync/sync.go
@@ -36,7 +36,9 @@ type SyncResult struct {
 type SyncInput struct {
 	SpecFiles  []FileContent // [filepath, content]
 	TestFiles  []FileContent
-	Thresholds map[int]int // optional coverage thresholds by tier; nil uses defaults
+	Thresholds map[int]int            // optional coverage thresholds by tier; nil uses defaults
+	CheckOpts  *checker.CheckOptions  // optional check options (strict, warn_on_draft)
+	OnlyPhase  string                 // C-05: if set, run prerequisites without halting then run this phase
 }
 
 type FileContent struct {
@@ -47,11 +49,18 @@ type FileContent struct {
 // RunSync executes the full pipeline.
 //
 // C-01: Runs all four phases in order.
-// C-02: Stops at first phase with errors.
-// C-03: Returns pass only if all pass.
+// C-02: Stops at first phase with errors (unless OnlyPhase is set).
+// C-03: Returns pass only if all pass (or only target phase in OnlyPhase mode).
 // C-04: Reports results from all completed phases.
+// C-05: OnlyPhase runs prerequisites without halting; exit code is target phase only.
 func RunSync(input SyncInput) *SyncResult {
 	result := &SyncResult{}
+	onlyPhase := input.OnlyPhase
+
+	// haltOnFail: in normal mode always halt; in --only mode only halt at the target phase.
+	haltOnFail := func(phase string) bool {
+		return onlyPhase == "" || phase == onlyPhase
+	}
 
 	// Phase 1: Parse
 	var inputs []resolver.SpecInput
@@ -73,42 +82,56 @@ func RunSync(input SyncInput) *SyncResult {
 			Phase: "parse", Passed: false,
 			Message: fmt.Sprintf("%d file(s) failed to parse", parseFailCount),
 		})
-		result.StoppedAt = "parse"
-		return result
+		if haltOnFail("parse") {
+			result.StoppedAt = "parse"
+			return result
+		}
+	} else {
+		result.Phases = append(result.Phases, PhaseResult{
+			Phase: "parse", Passed: true,
+			Message: fmt.Sprintf("%d spec(s) parsed successfully", len(inputs)),
+		})
 	}
 
-	result.Phases = append(result.Phases, PhaseResult{
-		Phase: "parse", Passed: true,
-		Message: fmt.Sprintf("%d spec(s) parsed successfully", len(inputs)),
-	})
+	if onlyPhase == "parse" {
+		result.Passed = parseFailCount == 0
+		return result
+	}
 
 	// Phase 2: Resolve
 	graph := resolver.ResolveSpecs(inputs)
 	result.Graph = graph
 
-	errorCount := 0
+	resolveErrorCount := 0
 	for _, d := range graph.Diagnostics {
 		if d.Severity == "error" {
-			errorCount++
+			resolveErrorCount++
 		}
 	}
 
-	if errorCount > 0 {
+	if resolveErrorCount > 0 {
 		result.Phases = append(result.Phases, PhaseResult{
 			Phase: "resolve", Passed: false,
-			Message: fmt.Sprintf("%d dependency error(s)", errorCount),
+			Message: fmt.Sprintf("%d dependency error(s)", resolveErrorCount),
 		})
-		result.StoppedAt = "resolve"
+		if haltOnFail("resolve") {
+			result.StoppedAt = "resolve"
+			return result
+		}
+	} else {
+		result.Phases = append(result.Phases, PhaseResult{
+			Phase: "resolve", Passed: true,
+			Message: fmt.Sprintf("%d specs, %d dependencies resolved", len(graph.Nodes), len(graph.Edges)),
+		})
+	}
+
+	if onlyPhase == "resolve" {
+		result.Passed = resolveErrorCount == 0
 		return result
 	}
 
-	result.Phases = append(result.Phases, PhaseResult{
-		Phase: "resolve", Passed: true,
-		Message: fmt.Sprintf("%d specs, %d dependencies resolved", len(graph.Nodes), len(graph.Edges)),
-	})
-
 	// Phase 3: Check
-	checkResult := checker.CheckSpecs(graph, nil)
+	checkResult := checker.CheckSpecs(graph, input.CheckOpts)
 	result.CheckResult = checkResult
 
 	if checkResult.Summary.Errors > 0 {
@@ -116,14 +139,21 @@ func RunSync(input SyncInput) *SyncResult {
 			Phase: "check", Passed: false,
 			Message: fmt.Sprintf("%d error(s), %d warning(s)", checkResult.Summary.Errors, checkResult.Summary.Warnings),
 		})
-		result.StoppedAt = "check"
-		return result
+		if haltOnFail("check") {
+			result.StoppedAt = "check"
+			return result
+		}
+	} else {
+		result.Phases = append(result.Phases, PhaseResult{
+			Phase: "check", Passed: true,
+			Message: fmt.Sprintf("%d warning(s), %d info", checkResult.Summary.Warnings, checkResult.Summary.Info),
+		})
 	}
 
-	result.Phases = append(result.Phases, PhaseResult{
-		Phase: "check", Passed: true,
-		Message: fmt.Sprintf("%d warning(s), %d info", checkResult.Summary.Warnings, checkResult.Summary.Info),
-	})
+	if onlyPhase == "check" {
+		result.Passed = checkResult.Summary.Errors == 0
+		return result
+	}
 
 	// Phase 4: Coverage
 	var allAnnotations []coverage.AnnotationMatch

--- a/specter/internal/sync/sync_test.go
+++ b/specter/internal/sync/sync_test.go
@@ -170,3 +170,81 @@ func TestMultiSpecPipeline(t *testing.T) {
 		t.Errorf("expected pass, got fail at %s", result.StoppedAt)
 	}
 }
+
+// @ac AC-06
+func TestOnlyPhase_Coverage_ContinuesDespiteResolveError(t *testing.T) {
+	// Spec with a dangling reference — resolve will fail
+	specWithDanglingRef := validSpecYAML("a", 2, "nonexistent-spec")
+
+	result := RunSync(SyncInput{
+		SpecFiles: []FileContent{{Path: "a.yaml", Content: specWithDanglingRef}},
+		TestFiles: []FileContent{{Path: "a.test.ts", Content: testFileContent("a", "AC-01")}},
+		OnlyPhase: "coverage",
+	})
+
+	// All four phases should have been attempted
+	phaseNames := make(map[string]bool)
+	for _, p := range result.Phases {
+		phaseNames[p.Phase] = true
+	}
+	for _, required := range []string{"parse", "resolve", "check", "coverage"} {
+		if !phaseNames[required] {
+			t.Errorf("expected phase %q to be recorded, got phases: %v", required, result.Phases)
+		}
+	}
+
+	// resolve failed but we continued — coverage is what determines Passed
+	resolvePhase := ""
+	for _, p := range result.Phases {
+		if p.Phase == "resolve" {
+			if p.Passed {
+				resolvePhase = "passed"
+			} else {
+				resolvePhase = "failed"
+			}
+		}
+	}
+	if resolvePhase != "failed" {
+		t.Errorf("expected resolve to fail, got %q", resolvePhase)
+	}
+}
+
+// @ac AC-07
+func TestOnlyPhase_Check_ContinuesDespiteParseError(t *testing.T) {
+	result := RunSync(SyncInput{
+		SpecFiles: []FileContent{
+			{Path: "valid.yaml", Content: validSpecYAML("valid", 2, "")},
+			{Path: "bad.yaml", Content: "not: valid: yaml: at: all"},
+		},
+		TestFiles: nil,
+		OnlyPhase: "check",
+	})
+
+	// check phase should be reached (may pass with 0 diagnostics on the valid spec)
+	phaseNames := make(map[string]bool)
+	for _, p := range result.Phases {
+		phaseNames[p.Phase] = true
+	}
+	if !phaseNames["check"] {
+		t.Errorf("expected check phase to be reached, got phases: %v", result.Phases)
+	}
+	// pipeline should NOT have stopped at parse
+	if result.StoppedAt == "parse" {
+		t.Error("expected pipeline not to stop at parse in --only check mode")
+	}
+}
+
+func TestOnlyPhase_Parse_StopsAfterParse(t *testing.T) {
+	result := RunSync(SyncInput{
+		SpecFiles: []FileContent{{Path: "a.yaml", Content: validSpecYAML("a", 2, "")}},
+		TestFiles: []FileContent{{Path: "a.test.ts", Content: testFileContent("a", "AC-01")}},
+		OnlyPhase: "parse",
+	})
+
+	if len(result.Phases) != 1 || result.Phases[0].Phase != "parse" {
+		t.Errorf("expected only parse phase, got %v", result.Phases)
+	}
+	if !result.Passed {
+		t.Error("expected pass for --only parse with valid spec")
+	}
+}

--- a/specter/specs/spec-check.spec.yaml
+++ b/specter/specs/spec-check.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-check
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -67,6 +67,16 @@ spec:
 
     - id: C-06
       description: "MUST NOT depend on any CLI framework — pure function from SpecGraph to Diagnostic[]"
+      type: technical
+      enforcement: error
+
+    - id: C-07
+      description: "MUST support strict mode (CheckOptions.Strict=true) that upgrades all warning-severity diagnostics to error severity"
+      type: technical
+      enforcement: error
+
+    - id: C-08
+      description: "MUST support warn_on_draft mode (CheckOptions.WarnOnDraft=true) that emits a warning diagnostic for every spec with status: draft"
       type: technical
       enforcement: error
 
@@ -143,7 +153,34 @@ spec:
       references_constraints: ["C-05", "C-06"]
       priority: critical
 
+    - id: AC-07
+      description: "CheckOptions.Strict=true upgrades all warning-severity orphan diagnostics to error"
+      inputs:
+        spec: "tier 2 spec (orphans are normally warnings)"
+        opts: "CheckOptions{Strict: true}"
+      expected_output:
+        orphan_severity: "error"
+        summary_errors_gt_zero: true
+      references_constraints: ["C-07"]
+      priority: high
+
+    - id: AC-08
+      description: "CheckOptions.WarnOnDraft=true emits draft_spec warning for specs with status: draft"
+      inputs:
+        spec: "spec with status: draft"
+        opts: "CheckOptions{WarnOnDraft: true}"
+      expected_output:
+        diagnostic_kind: "draft_spec"
+        severity: "warning"
+      references_constraints: ["C-08"]
+      priority: high
+
   changelog:
+    - version: "1.1.0"
+      date: "2026-04-14"
+      author: "specter-team"
+      type: minor
+      description: "Add C-07/AC-07 strict mode (warnings-as-errors) and C-08/AC-08 warn_on_draft mode"
     - version: "1.0.0"
       date: "2026-03-28"
       author: "specter-team"

--- a/specter/specs/spec-manifest.spec.yaml
+++ b/specter/specs/spec-manifest.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-manifest
-  version: "1.0.0"
+  version: "1.1.0"
   status: draft
   tier: 2
 
@@ -96,6 +96,16 @@ spec:
 
     - id: C-10
       description: "MUST NOT depend on any CLI framework — pure functions from YAML string to typed structures"
+      type: technical
+      enforcement: error
+
+    - id: C-11
+      description: "MUST parse settings.strict (bool): when true, all warning-severity check diagnostics are treated as errors"
+      type: technical
+      enforcement: error
+
+    - id: C-12
+      description: "MUST parse settings.warn_on_draft (bool): when true, specter check emits a warning for every spec with status: draft"
       type: technical
       enforcement: error
 
@@ -231,6 +241,24 @@ spec:
       references_constraints: ["C-10"]
       priority: high
 
+    - id: AC-15
+      description: "Manifest with settings.strict: true parses with Strict=true in Settings struct"
+      inputs:
+        yaml: "settings:\n  strict: true"
+      expected_output:
+        settings_strict: true
+      references_constraints: ["C-11"]
+      priority: high
+
+    - id: AC-16
+      description: "Manifest with settings.warn_on_draft: true parses with WarnOnDraft=true in Settings struct"
+      inputs:
+        yaml: "settings:\n  warn_on_draft: true"
+      expected_output:
+        settings_warn_on_draft: true
+      references_constraints: ["C-12"]
+      priority: high
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.0.0"
@@ -240,6 +268,11 @@ spec:
       relationship: requires
 
   changelog:
+    - version: "1.1.0"
+      date: "2026-04-14"
+      author: "specter-team"
+      type: minor
+      description: "Add C-11/AC-15 settings.strict and C-12/AC-16 settings.warn_on_draft fields"
     - version: "1.0.0"
       date: "2026-04-03"
       author: "specter-team"

--- a/specter/specs/spec-resolve.spec.yaml
+++ b/specter/specs/spec-resolve.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-resolve
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -34,11 +34,13 @@ spec:
         - "Detect dangling references (depends_on non-existent spec)"
         - "Detect semver range mismatches"
         - "Output: SpecGraph + diagnostics list"
+        - "DOT graph output (--dot)"
+        - "Mermaid graph output (--mermaid, renders in GitHub PRs)"
+        - "Dangling-reference suggestions: Levenshtein closest match + suggested fix path"
       excludes:
         - "Semantic conflict detection (that is spec-check)"
         - "Transitive dependency flattening"
         - "Lock file generation"
-        - "Graph visualization (future feature)"
 
   constraints:
     - id: C-01
@@ -81,6 +83,16 @@ spec:
       type: technical
       enforcement: error
 
+    - id: C-09
+      description: "MUST support --mermaid output flag that renders the dependency graph in Mermaid flowchart syntax (graph BT) for native GitHub PR rendering"
+      type: technical
+      enforcement: warning
+
+    - id: C-10
+      description: "MUST enrich dangling_reference diagnostics with: list of existing spec IDs, Levenshtein-distance closest match(es), and a suggested fix file path"
+      type: technical
+      enforcement: error
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.0.0"
@@ -111,7 +123,7 @@ spec:
       priority: critical
 
     - id: AC-03
-      description: "Spec depending on non-existent ID produces DanglingReference diagnostic"
+      description: "Spec depending on non-existent ID produces DanglingReference diagnostic with missing_dep set"
       inputs:
         specs: ["a.spec.yaml (depends on nonexistent)"]
       expected_output:
@@ -119,7 +131,7 @@ spec:
         kind: "dangling_reference"
         spec_id: "a"
         missing_dep: "nonexistent"
-      references_constraints: ["C-05"]
+      references_constraints: ["C-05", "C-10"]
       priority: critical
 
     - id: AC-04
@@ -169,7 +181,35 @@ spec:
       references_constraints: ["C-07"]
       priority: high
 
+    - id: AC-08
+      description: "resolve --mermaid outputs a valid Mermaid flowchart with graph BT, node definitions, and labeled edges"
+      inputs:
+        specs: ["a.spec.yaml (depends on b@^1.0.0)", "b.spec.yaml (v1.0.0)"]
+        flag: "--mermaid"
+      expected_output:
+        starts_with: "graph BT"
+        contains_node_a: true
+        contains_edge_with_label: "^1.0.0"
+      references_constraints: ["C-09"]
+      priority: high
+
+    - id: AC-09
+      description: "Dangling reference with close existing spec ID includes suggestion in diagnostic"
+      inputs:
+        specs: ["a.spec.yaml (depends on handler-interfac)", "handler-interface.spec.yaml"]
+      expected_output:
+        diagnostic_kind: "dangling_reference"
+        suggestions_non_empty: true
+        suggestion_includes: "handler-interface"
+      references_constraints: ["C-10"]
+      priority: high
+
   changelog:
+    - version: "1.1.0"
+      date: "2026-04-14"
+      author: "specter-team"
+      type: minor
+      description: "Add C-09/AC-08 --mermaid output, C-10/AC-09 dangling-reference suggestions with Levenshtein matching"
     - version: "1.0.0"
       date: "2026-03-28"
       author: "specter-team"

--- a/specter/specs/spec-reverse.spec.yaml
+++ b/specter/specs/spec-reverse.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-reverse
-  version: "1.0.0"
+  version: "1.1.0"
   status: draft
   tier: 2
 
@@ -100,6 +100,11 @@ spec:
 
     - id: C-10
       description: "MUST generate auto-numbered constraint IDs (C-01, C-02) and AC IDs (AC-01, AC-02) with no gaps"
+      type: technical
+      enforcement: error
+
+    - id: C-11
+      description: "MUST correctly extract test descriptions containing escaped quotes (e.g., it(\"user's token is valid\") or it('reject \"admin\" role'))"
       type: technical
       enforcement: error
 
@@ -253,12 +258,26 @@ spec:
       references_constraints: ["C-08"]
       priority: high
 
+    - id: AC-15
+      description: "Jest/Vitest test descriptions with escaped or embedded quotes are extracted correctly"
+      inputs:
+        test_file: "auth.test.ts with it(\"user's token is valid\") and it('reject \\\"admin\\\" role')"
+      expected_output:
+        ac_descriptions: ["user's token is valid", "reject \"admin\" role"]
+      references_constraints: ["C-11"]
+      priority: high
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.0.0"
       relationship: requires
 
   changelog:
+    - version: "1.1.0"
+      date: "2026-04-14"
+      author: "specter-team"
+      type: minor
+      description: "Add C-11/AC-15: correct extraction of test descriptions with embedded or escaped quotes"
     - version: "1.0.0"
       date: "2026-04-02"
       author: "specter-team"

--- a/specter/specs/spec-sync.spec.yaml
+++ b/specter/specs/spec-sync.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-sync
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -41,7 +41,7 @@ spec:
       enforcement: error
 
     - id: C-02
-      description: "MUST stop at the first phase that has errors (no point checking if parse fails)"
+      description: "MUST stop at the first phase that has errors (no point checking if parse fails) — unless --only <phase> is specified, in which case prerequisite phases run without halting"
       type: technical
       enforcement: error
 
@@ -52,6 +52,11 @@ spec:
 
     - id: C-04
       description: "MUST report results from all completed phases"
+      type: technical
+      enforcement: error
+
+    - id: C-05
+      description: "MUST support --only <phase> flag that runs prerequisite phases silently (without halting on their failures) then runs the target phase; exit code is based solely on the target phase result"
       type: technical
       enforcement: error
 
@@ -95,7 +100,34 @@ spec:
       references_constraints: ["C-03", "C-04"]
       priority: high
 
+    - id: AC-06
+      description: "--only coverage runs all four phases but does not halt on parse/resolve/check failures; exit code reflects coverage phase only"
+      inputs:
+        specs: ["spec with dangling reference (resolve fails)", "coverage annotation present"]
+        flag: "--only coverage"
+      expected_output:
+        phases_run: ["parse", "resolve", "check", "coverage"]
+        exit_based_on: "coverage"
+      references_constraints: ["C-05"]
+      priority: high
+
+    - id: AC-07
+      description: "--only check runs parse and resolve as prerequisites without halting, then runs check; exit code reflects check phase only"
+      inputs:
+        specs: ["spec with parse error (parse fails)", "valid spec"]
+        flag: "--only check"
+      expected_output:
+        phases_run_includes: ["parse", "resolve", "check"]
+        exit_based_on: "check"
+      references_constraints: ["C-05"]
+      priority: high
+
   changelog:
+    - version: "1.1.0"
+      date: "2026-04-14"
+      author: "specter-team"
+      type: minor
+      description: "Add C-05/AC-06/AC-07: --only <phase> flag for targeted phase execution without halting on prerequisites"
     - version: "1.0.0"
       date: "2026-03-28"
       author: "specter-team"


### PR DESCRIPTION
## Summary

Five UX improvements driven by the Kensa team's external review of Specter v0.3.1. All items are from the roadmap's Phase 2/3 tracks. No architectural changes — these are authoring-loop and CI-integration refinements.

- **Fix quote-truncation regex** — TypeScript adapter test descriptions containing apostrophes or embedded quotes were silently truncated at the first quote character. Fixed by replacing `[^"]+` with `(?:[^"\\]|\\.)*` in all four Jest/Vitest patterns. (spec-reverse C-11/AC-15)
- **`--strict` + manifest settings** — `specter check --strict` and `specter sync --strict` treat warning-severity diagnostics as errors. `settings.strict: true` and `settings.warn_on_draft: true` in `specter.yaml` apply the same policies project-wide. (spec-check C-07/C-08, spec-manifest C-11/C-12)
- **`resolve --mermaid`** — Mermaid flowchart output alongside existing `--dot`. Renders natively in GitHub PR descriptions and review comments. (spec-resolve C-09/AC-08)
- **Dangling-reference suggestions** — When a `depends_on` target doesn't exist, the error now includes the closest existing spec IDs (Levenshtein distance, inline implementation, no new dep) and a suggested file path + `id:` fix. (spec-resolve C-10/AC-09)
- **`sync --only <phase>`** — Runs prerequisite phases without halting on their failures, then runs the target phase; exit code reflects only the target. Accepts `parse | resolve | check | coverage`. (spec-sync C-05/AC-06/AC-07)

## Spec changes

Five specs bumped from v1.0.0 → v1.1.0 with new constraints and ACs before any code was written.

## Test plan

- [ ] `make check` passes (vet + all tests + build)
- [ ] `make dogfood` passes (all 7 specs parse/resolve/check clean)
- [ ] `specter check --strict` exits non-zero on a spec with a Tier 2 orphan constraint
- [ ] `specter resolve --mermaid` produces `graph BT` output with node and edge lines
- [ ] `specter resolve` with a misspelled `depends_on` shows `did you mean:` suggestion
- [ ] `specter sync --only coverage` continues past a resolve failure and reports coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)