### PR TITLE
chore: add RPM to release packages

### DIFF
--- a/specter/.goreleaser.yml
+++ b/specter/.goreleaser.yml
@@ -48,7 +48,7 @@ nfpms:
     package_name: specter
     formats:
       - deb
-      # Phase B: add rpm here
+      - rpm
     vendor: Hanalyx
     homepage: "https://github.com/Hanalyx/spec-dd"
     maintainer: "Hanalyx <noreply@hanalyx.com>"


### PR DESCRIPTION
## Summary

- Enables `.rpm` packaging alongside the existing `.deb` in the `nfpms` config
- Both formats share the same metadata (vendor, maintainer, description, license, bindir)
- Removes the `# Phase B: add rpm here` placeholder comment

## Test plan

- [ ] CI passes (no code changes, only goreleaser config)
- [ ] After merge, tag `v0.4.1` and verify the Release workflow produces both `.deb` and `.rpm` artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)