### PR TITLE
chore: add release-gate discipline (no publish)

### DIFF
--- a/specter/BACKLOG.md
+++ b/specter/BACKLOG.md
@@ -34,6 +34,13 @@ Motivation: provide the "which specs govern this file?" use case from jwtms with
 
 ---
 
+## v0.8.x prerequisites / blocking future releases
+
+- **Go toolchain bump (1.22 → 1.23+).** `govulncheck` flags 5 Go stdlib CVEs fixed in 1.23+; `make release-check` now chains through `prerelease` which includes `vulncheck`, so no release can ship until this lands. Low-risk bump; update `go.mod` directive, CI workflow `setup-go` pin, and any contributor install docs. Probably an hour of work plus re-running `make check` and `make dogfood`.
+- **`@vscode/test-electron` headless integration tests.** The release-gate currently relies on a human operator reproducing changes in a live VS Code window. Automating that via `@vscode/test-electron` would let CI spawn a real VS Code instance with the extension loaded against fixture workspaces and assert the sidebar / status bar / output channel behave as expected. Backstops the human gate; does not replace it. About a day of setup.
+
+---
+
 ## v0.8+ / unscheduled — deferred from v0.7.0 proposal
 
 Each needs its own design doc before scheduling:

--- a/specter/GOTCHAS.md
+++ b/specter/GOTCHAS.md
@@ -233,7 +233,30 @@ Five fabricated flags in production code. The CLI rejects unknown flags (Cobra d
 
 ---
 
-## 18. VS Code extension and CLI versions must stay in lockstep
+## 18. Marketplace is NOT a test harness — humans must verify before publish
+
+**Symptom:** Four patch releases of the VS Code extension in a single day (v0.8.0 → v0.8.1 → v0.8.2 → v0.8.3), each one fixing a bug that the first real user hit the moment they installed. Users see the auto-update notification every few hours and each install reveals another regression. Damages credibility.
+
+**Cause:** The pre-publish loop was:
+1. Write code
+2. Run `make check` + `npx jest`
+3. `vsce package` + `vsce publish`
+4. Wait for a user to install and report whatever broke
+
+Step 4 was the test. Unit tests covered roughly 30% of the extension's actual user-facing surface — specifically the pure-function parts. The un-covered 70% (binary resolution, tree rendering, CLI invocation, activation race conditions, cwd assumptions) is where every one of the four v0.8.x bugs lived.
+
+The lesson isn't "write more unit tests" alone — the real gap was the absence of a human-verified end-to-end test in a real VS Code window against a real workspace before every publish. No mock, no CI substitute, no "I'm confident it works" — an actual install + reload + click-through.
+
+**What's in place now (v0.8.3+):**
+- `RELEASING.md` documents an 8-step gate. Mandatory before any `vsce publish`.
+- `make release-check` packages the VSIX and prints the checklist. It does not run `vsce publish` — that stays manual so the operator cannot forget step 7 (human sign-off).
+- `BACKLOG.md` queues `@vscode/test-electron` headless integration tests for v0.9 — the proper long-term backstop.
+
+**Rule:** Marketplace is a distribution channel, not a test harness. Every publish must ship behavior that has already been verified by a person in a live VS Code window. If that person is me or an AI agent, the verification must be demonstrated (screenshot, recorded session, or reproducible script) — not asserted. The first user to install should be the hundred-and-first person to see the feature work, not the first.
+
+---
+
+## 19. VS Code extension and CLI versions must stay in lockstep
 
 **Symptom:** Extension v0.6.5 queries `api.github.com/.../releases/latest`, gets back e.g. v0.6.5, then tries to download `.../releases/download/v0.6.5/...`. If the GitHub release for that tag doesn't exist yet, you get 404 "Not Found" in the body (see #3).
 

--- a/specter/Makefile
+++ b/specter/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-race lint fmt fmt-check vulncheck check clean dogfood prerelease install-hooks version-sync publish-vscode
+.PHONY: build test test-race lint fmt fmt-check vulncheck check clean dogfood prerelease install-hooks version-sync publish-vscode release-check
 
 BINARY := bin/specter
 VERSION := $(shell cat VERSION 2>/dev/null || echo "dev")
@@ -95,3 +95,46 @@ prerelease: check test-race vulncheck dogfood
 	cd vscode-extension && npm run build && npm run package
 	@echo ""
 	@echo "--- All pre-release checks passed ---"
+
+# Release gate — packages the VSIX and prints the mandatory human-verification
+# checklist. Does NOT run vsce publish under any circumstance.
+# See CLAUDE.md > "Release discipline" for why every step matters.
+release-check: prerelease
+	@VER=$$(cat VERSION); \
+	VSIX=vscode-extension/specter-vscode-$$VER.vsix; \
+	if [ ! -f "$$VSIX" ]; then \
+		echo "ERROR: expected $$VSIX after prerelease; not found."; exit 1; \
+	fi; \
+	echo ""; \
+	echo "============================================================"; \
+	echo "  VSIX built: $$VSIX"; \
+	echo "============================================================"; \
+	echo ""; \
+	echo "Before running 'vsce publish', the human operator MUST:"; \
+	echo ""; \
+	echo "  1. Install locally:"; \
+	echo "       code --install-extension $$VSIX --force"; \
+	echo ""; \
+	echo "  2. Reload VS Code and open a KNOWN-WORKING workspace"; \
+	echo "     (the specter/ repo itself — 14 dogfood specs)."; \
+	echo "     Verify: Coverage sidebar populates with spec entries."; \
+	echo ""; \
+	echo "  3. Reload VS Code and open a KNOWN-FAILING workspace"; \
+	echo "     (one whose specs do not parse Specter's schema)."; \
+	echo "     Verify: sidebar shows the empty-state message AND"; \
+	echo "     status bar shows the error state AND Output channel"; \
+	echo "     contains the parse errors."; \
+	echo ""; \
+	echo "  4. Exercise every changed code path end-to-end."; \
+	echo ""; \
+	echo "  5. Check the Output channel for unexplained red entries."; \
+	echo ""; \
+	echo "  6. Sign off."; \
+	echo ""; \
+	echo "  7. Publish:"; \
+	echo "       npx vsce publish --packagePath $$VSIX"; \
+	echo "     For non-trivial changes, prefer --pre-release first."; \
+	echo ""; \
+	echo "Skipping a step is not a shortcut — it's a commitment to"; \
+	echo "ship a broken version. See RELEASING.md for the full gate."; \
+	echo "============================================================"

--- a/specter/RELEASING.md
+++ b/specter/RELEASING.md
@@ -1,0 +1,83 @@
+# Releasing Specter
+
+This document defines the gate that must be satisfied before any `vsce publish` (VS Code extension) or `git push origin vX.Y.Z` (CLI release).
+
+It exists because the v0.8.0 → v0.8.3 extension thrash (four patch releases in one day, each fixing a bug the first real user hit on install) proved that running `make check` and `vsce package` is not sufficient to ship. Marketplace is a distribution channel, not a test harness.
+
+---
+
+## The gate
+
+Every step is mandatory. Skipping a step is not a shortcut — it's a commitment to ship a broken version.
+
+### 1. CI green
+
+`make check`, dogfood, and extension jest all pass in GitHub Actions. Not optional, not sufficient alone.
+
+### 2. Install the packaged VSIX locally
+
+```bash
+code --install-extension specter-vscode-X.Y.Z.vsix --force
+```
+
+CI building the VSIX is not the same as VS Code loading it. The v0.6.5 → v0.6.6 bug (stale `out/` directory shipped in the VSIX) was invisible to CI.
+
+### 3. Reload, then open a known-working test workspace
+
+The `specter/` repo itself is a good choice (14 dogfood specs). The Coverage sidebar should populate with real entries, not the empty-state message.
+
+### 4. Reload, then open a known-failing test workspace
+
+A directory whose `.spec.yaml` files fail Specter's schema (e.g. specs written in an older custom schema). The Coverage sidebar should show the empty-state message, the status bar should be in the error state, and the Output channel should contain the parse errors.
+
+### 5. Exercise every changed code path
+
+If the change touches:
+- **Binary resolution** — delete `~/.specter/bin/specter` and watch the re-download.
+- **Tree rendering** — verify both empty and populated states.
+- **CLI flag handling** — invoke the affected command from the integrated terminal.
+- **Activation flow** — open a workspace that matches the activation trigger but wasn't open when VS Code started.
+
+If a change doesn't obviously route through one of these, write down the path it does exercise and test that explicitly.
+
+### 6. Check the Output channel
+
+`View → Output → Specter`. No unexplained red entries during normal use.
+
+### 7. Human verifies and signs off
+
+No AI / automated "I think it works" substitutes here. The person cutting the release reproduces the change in a live VS Code window and confirms the behavior matches intent. This is the step that has repeatedly failed during v0.8.x and is the reason this gate exists.
+
+### 8. Only then run `vsce publish`
+
+For non-trivial changes — schema shifts, new UI surfaces, binary-download code, new CLI flags — publish as `--pre-release` first and keep it on the pre-release channel long enough for issues to surface before promoting to stable.
+
+Stable-only publishes are reserved for small, low-risk patches.
+
+```bash
+# Non-trivial — prefer pre-release first
+npx vsce publish --packagePath specter-vscode-X.Y.Z.vsix --pre-release
+
+# Small low-risk patch (after pre-release has baked, or for trivial fixes)
+npx vsce publish --packagePath specter-vscode-X.Y.Z.vsix
+```
+
+---
+
+## The helper
+
+`make release-check` automates the first half of the gate — it runs `make prerelease` (check + vulncheck + dogfood + cross-compile + VSIX package), then prints this checklist to remind the operator of steps 2–7. It does **not** run `vsce publish` under any circumstance. That stays manual so the operator cannot forget to verify.
+
+```bash
+make release-check
+# ... prints the checklist, then exits. You then perform steps 2–7 by hand
+#     before running vsce publish.
+```
+
+---
+
+## Related docs
+
+- `GOTCHAS.md` #18 — the failure mode this gate exists to prevent.
+- `BACKLOG.md` — `@vscode/test-electron` headless integration tests are queued as the proper long-term backstop for the human verification step.
+- `CHANGELOG.md` — release history.


### PR DESCRIPTION
## Summary

Lands the 8-step release gate agreed on after the v0.8.0 → v0.8.3 thrash. No runtime behavior change, no version bump, no \`vsce publish\`. Pure process.

## Changes

- **\`RELEASING.md\` (new, tracked)** — 8-step gate. Step 7 is "human verifies and signs off"; step 8 is "only then publish, prefer --pre-release for non-trivial changes."
- **\`Makefile\`** — new \`make release-check\` target that packages the VSIX and prints the checklist. Explicitly does NOT run \`vsce publish\`.
- **\`GOTCHAS.md\` #18** — documents the Marketplace-as-test-harness failure mode with v0.8.x evidence.
- **\`BACKLOG.md\`** — two items now block future extension releases:
  - Go toolchain 1.22 → 1.23+ bump (govulncheck flags 5 stdlib CVEs)
  - \`@vscode/test-electron\` headless integration tests as the proper backstop

## Test plan

- [x] \`make dogfood\` green
- [x] \`make release-check\` correctly blocks on the pre-existing Go stdlib CVEs (proves the gate works — no release can ship until the Go bump lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)