### PR TITLE
test: all 14 dogfood specs at 100% AC coverage (no version bump)

### DIFF
--- a/specter/internal/manifest/manifest_test.go
+++ b/specter/internal/manifest/manifest_test.go
@@ -3,6 +3,8 @@ package manifest
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -502,5 +504,89 @@ func TestScaffoldManifest_CanonicalGitHubURL(t *testing.T) {
 	}
 	if strings.Contains(out, "spec-dd") {
 		t.Errorf("scaffold must not reference 'spec-dd' (stale slug), got:\n%s", out)
+	}
+}
+
+// @ac AC-13 — when specter.yaml is absent, Defaults() returns a usable
+// Manifest and all consumers (specs_dir resolution, thresholds, excludes)
+// produce identical behavior to what a minimal explicit manifest would.
+// This is the "backward compatibility" contract: running specter in a
+// directory without specter.yaml must not fail.
+func TestDefaults_MatchesImplicitManifestBehavior(t *testing.T) {
+	implicit := Defaults()
+
+	// An explicit manifest with the documented defaults should produce the
+	// same behavior as Defaults().
+	yamlBody := `
+system:
+  name: anything
+settings:
+  specs_dir: specs
+  coverage:
+    tier1: 100
+    tier2: 80
+    tier3: 50
+`
+	explicit, err := ParseManifest(yamlBody)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	if implicit.SpecsDir() != explicit.SpecsDir() {
+		t.Errorf("specs_dir mismatch: implicit %q vs explicit %q",
+			implicit.SpecsDir(), explicit.SpecsDir())
+	}
+	ithr := implicit.CoverageThresholds()
+	ethr := explicit.CoverageThresholds()
+	for tier := 1; tier <= 3; tier++ {
+		if ithr[tier] != ethr[tier] {
+			t.Errorf("tier %d threshold mismatch: implicit %d vs explicit %d",
+				tier, ithr[tier], ethr[tier])
+		}
+	}
+}
+
+// @ac AC-14 — the manifest package must be a pure, injectable unit with
+// no dependencies on I/O, the CLI layer, or anything that performs
+// side effects. The package is consumed by cmd/specter (which does do
+// I/O) but must itself be callable from tests, the reverse compiler,
+// and any future migration tooling without a working filesystem.
+func TestManifestPackage_HasNoForbiddenImports(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	pkgDir := filepath.Dir(file)
+
+	forbidden := []string{
+		`"os/exec"`,                        // no subprocess spawning
+		`"net/http"`,                       // no network
+		`"github.com/spf13/cobra"`,         // no CLI framework
+		`"github.com/Hanalyx/specter/cmd/`, // no reverse dep on CLI layer
+	}
+
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		t.Fatalf("read pkg dir: %v", err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		// Skip test files — they may legitimately import test helpers.
+		if strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(pkgDir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		content := string(data)
+		for _, imp := range forbidden {
+			if strings.Contains(content, imp) {
+				t.Errorf("%s imports forbidden package %s (manifest package must be I/O-free)", e.Name(), imp)
+			}
+		}
 	}
 }

--- a/specter/scripts/ci_workflow_test.go
+++ b/specter/scripts/ci_workflow_test.go
@@ -1,0 +1,107 @@
+// ci_workflow_test.go — tests for the GitHub Actions CI workflow that
+// enforces Conventional Commits on PR titles. Exercises AC-08 (CI fails
+// on bad title) and AC-09 (CI passes on valid title) of spec-commits by
+// parsing .github/workflows/ci.yml and asserting the "Validate PR title"
+// step's shell logic.
+//
+// @spec spec-commits
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ciWorkflow struct {
+	Jobs map[string]struct {
+		Steps []struct {
+			Name string            `yaml:"name"`
+			If   string            `yaml:"if"`
+			Run  string            `yaml:"run"`
+			Env  map[string]string `yaml:"env"`
+		} `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+func loadCIWorkflow(t *testing.T) *ciWorkflow {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	// scripts/ → ../../../.github/workflows/ci.yml (repo root level, above specter/)
+	path := filepath.Join(filepath.Dir(file), "..", "..", ".github", "workflows", "ci.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+	var w ciWorkflow
+	if err := yaml.Unmarshal(data, &w); err != nil {
+		t.Fatalf("parse ci.yml: %v", err)
+	}
+	return &w
+}
+
+// findValidatePRTitleStep returns the step whose name is "Validate PR title (Conventional Commits)"
+// from any job in the workflow, or nil if not found.
+func findValidatePRTitleStep(w *ciWorkflow) *struct {
+	Name string
+	If   string
+	Run  string
+} {
+	for _, job := range w.Jobs {
+		for _, step := range job.Steps {
+			if strings.Contains(step.Name, "Validate PR title") {
+				return &struct {
+					Name string
+					If   string
+					Run  string
+				}{Name: step.Name, If: step.If, Run: step.Run}
+			}
+		}
+	}
+	return nil
+}
+
+// @ac AC-08
+func TestCIWorkflow_RejectsInvalidPRTitle(t *testing.T) {
+	w := loadCIWorkflow(t)
+	step := findValidatePRTitleStep(w)
+	if step == nil {
+		t.Fatal("no 'Validate PR title' step found in any CI job")
+	}
+
+	// Must guard on pull_request events
+	if !strings.Contains(step.If, "pull_request") {
+		t.Errorf("step must run only on pull_request events, got if: %q", step.If)
+	}
+
+	// Must contain the Conventional Commits regex and exit non-zero on mismatch
+	expectedFragments := []string{
+		"feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert",
+		"exit 1",
+	}
+	for _, frag := range expectedFragments {
+		if !strings.Contains(step.Run, frag) {
+			t.Errorf("validate step must contain %q, got run:\n%s", frag, step.Run)
+		}
+	}
+}
+
+// @ac AC-09
+func TestCIWorkflow_AcceptsValidPRTitle(t *testing.T) {
+	w := loadCIWorkflow(t)
+	step := findValidatePRTitleStep(w)
+	if step == nil {
+		t.Fatal("no 'Validate PR title' step found in any CI job")
+	}
+
+	// On the success path, the step must print a confirming line and NOT
+	// exit non-zero. The "echo PR title OK" plus absence of an unconditional
+	// `exit 1` (it's guarded by the regex mismatch) pins this.
+	if !strings.Contains(step.Run, "PR title OK") {
+		t.Errorf("valid-title path must print 'PR title OK', got run:\n%s", step.Run)
+	}
+}

--- a/specter/vscode-extension/src/__tests__/annotations.test.ts
+++ b/specter/vscode-extension/src/__tests__/annotations.test.ts
@@ -110,6 +110,7 @@ function testCreateIntent() {}
 // AC-09: Hover on @ac shows full description, coverage status, and other files
 // ---------------------------------------------------------------------------
 
+// @spec spec-vscode
 // @ac AC-09
 describe('buildAnnotationHover', () => {
   it('shows the full AC description on hover over @ac AC-01', () => {
@@ -149,6 +150,7 @@ describe('buildAnnotationHover', () => {
 // AC-15: Quick-fix inserts @spec + @ac snippet above unannotated function
 // ---------------------------------------------------------------------------
 
+// @spec spec-vscode
 // @ac AC-15
 describe('buildQuickFix', () => {
   it('inserts @spec and @ac lines above the function', () => {
@@ -177,6 +179,7 @@ describe('buildQuickFix', () => {
 // AC-21: tf-idf AC suggestion — offline, no LM call
 // ---------------------------------------------------------------------------
 
+// @spec spec-vscode
 // @ac AC-21
 describe('suggestACsForFunction', () => {
   it('returns top-2 AC suggestions for a function body', () => {

--- a/specter/vscode-extension/src/__tests__/binary.test.ts
+++ b/specter/vscode-extension/src/__tests__/binary.test.ts
@@ -176,3 +176,31 @@ describe('verifyChecksum', () => {
     expect(ok).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// v0.6.5+ — Error-state recovery affordances (AC-24)
+// ---------------------------------------------------------------------------
+
+// @spec spec-vscode
+// @ac AC-24
+describe('Specter: Re-download CLI command is declared in package.json', () => {
+  // AC-24 pins the presence of the user-facing recovery command. The status-
+  // bar error transition itself is vscode-runtime-coupled and exercised by
+  // client.test.ts (which invokes the real CLI against a fixture workspace
+  // that would fail coverage); the palette-entry existence is a pure
+  // structural fact about package.json.
+  it('package.json declares the specter.redownloadCli command', () => {
+    const pkg = require('../../package.json');
+    const commands: Array<{ command: string; title: string }> = pkg.contributes?.commands ?? [];
+    const found = commands.find(c => c.command === 'specter.redownloadCli');
+    expect(found).toBeTruthy();
+    expect(found?.title.toLowerCase()).toContain('re-download');
+  });
+
+  it('package.json also declares the specter.showOutput command', () => {
+    const pkg = require('../../package.json');
+    const commands: Array<{ command: string; title: string }> = pkg.contributes?.commands ?? [];
+    const found = commands.find(c => c.command === 'specter.showOutput');
+    expect(found).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the 8 AC coverage gaps flagged by \`specter coverage\` — pure test work, no runtime changes, no version bump.

Before:
- spec-commits 78% (AC-08, AC-09 uncovered)
- spec-manifest 90% (AC-13, AC-14)
- spec-vscode 86% (AC-09, AC-15, AC-21, AC-24)

After: 14/14 specs at 100%.

## Notable finding

The v0.8.x spec-vscode regressions (AC-09, AC-15, AC-21 showing uncovered) were not missing tests — they were missing annotation visibility. A template literal at \`annotations.test.ts:85\` contains \`// @spec payment-create-intent\` as literal text. The annotation extractor reads it as a real \`@spec\` comment because the trimmed line starts with \`//\`, flipping the active spec for the rest of the file. Every subsequent \`@ac\` was attributed to payment-create-intent instead of spec-vscode.

Fix: re-declare \`// @spec spec-vscode\` before each affected \`describe\` block. The extractor's blind spot (can't distinguish real comments from comment-shaped text inside multi-line string literals) is real and worth its own fix — I'll open it as a separate issue rather than sneak it in here.

## Test plan

- [x] \`make check\` green
- [x] \`make dogfood\` — 14/14 specs at 100%
- [x] \`npx jest\` — 153/153 (was 151; 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)