### PR TITLE
fix(vscode): gate on-edit diagnostics to .spec.yaml only

### DIFF
--- a/specter/specs/spec-vscode.spec.yaml
+++ b/specter/specs/spec-vscode.spec.yaml
@@ -371,6 +371,17 @@ spec:
       references_constraints: ["C-10"]
       priority: medium
 
+    - id: AC-40
+      description: "The on-change and on-save diagnostic hooks skip any document whose path does not end in `.spec.yaml`. The specter.yaml manifest, a test file open in the editor, or any other YAML document is not parsed against the spec schema. Previously the hooks ran `specter parse` on every YAML document, producing false 'Missing required field spec' and 'Unknown field settings' diagnostics on the manifest whose shape is `system: / settings: / domains:`. Gate is a path-suffix check (not languageId) because YAML language registration is shared across all .yaml files."
+      inputs:
+        doc_a: "specter.yaml (manifest — system:, settings:)"
+        doc_b: "specs/auth.spec.yaml (real spec)"
+      expected_output:
+        doc_a_parse_invoked: false
+        doc_b_parse_invoked: true
+      references_constraints: ["C-10"]
+      priority: high
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.1.0"
@@ -413,7 +424,10 @@ spec:
         (specter.revealInTree command wired end-to-end: active editor →
         matching tree node, previously declared in package.json but never
         registered), AC-39 (Insights parse-failure cards have clickable
-        file-path headers that open the file at the reported line).
+        file-path headers that open the file at the reported line),
+        AC-40 (on-change/on-save parse hooks gated to .spec.yaml so the
+        manifest specter.yaml stops receiving spurious `Missing required
+        field 'spec'` diagnostics).
         Addresses quality-audit BLOCKER B1 and HIGHs H1/H3.
     - version: "1.1.0"
       date: "2026-04-18"

--- a/specter/vscode-extension/src/__tests__/activation.test.ts
+++ b/specter/vscode-extension/src/__tests__/activation.test.ts
@@ -2,7 +2,7 @@
 //
 // Tests for extension activation logic and multi-root workspace isolation.
 
-import { shouldActivate, resolveManifestPath, createClientKey } from '../activation';
+import { shouldActivate, resolveManifestPath, createClientKey, isSpecFilePath } from '../activation';
 import * as path from 'path';
 
 // ---------------------------------------------------------------------------
@@ -119,5 +119,41 @@ describe('createClientKey', () => {
 
   it('normalizes trailing slashes so /project and /project/ are the same client', () => {
     expect(createClientKey('/workspace/project/')).toBe(createClientKey('/workspace/project'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-40: parse-on-edit hooks gate on isSpecFilePath
+// ---------------------------------------------------------------------------
+
+// @spec spec-vscode
+// @ac AC-40
+describe('isSpecFilePath', () => {
+  it('accepts a double-extension .spec.yaml file', () => {
+    expect(isSpecFilePath('/project/specs/auth.spec.yaml')).toBe(true);
+  });
+
+  it('rejects the project manifest specter.yaml', () => {
+    expect(isSpecFilePath('/project/specter.yaml')).toBe(false);
+  });
+
+  it('rejects generic .yaml and .yml files', () => {
+    expect(isSpecFilePath('/project/.github/workflows/ci.yml')).toBe(false);
+    expect(isSpecFilePath('/project/config.yaml')).toBe(false);
+  });
+
+  it('rejects a bare ".spec.yaml" filename (no stem) as a guard edge case', () => {
+    // Pathological input; treating it as a spec would crash the parser
+    // on an empty spec name. The predicate rejects it to stay safe.
+    expect(isSpecFilePath('/project/.spec.yaml')).toBe(false);
+  });
+
+  it('matches on basename, not substring, so "openapi-spec.yaml" is rejected', () => {
+    // A file whose basename ends with "spec.yaml" but not ".spec.yaml".
+    expect(isSpecFilePath('/project/docs/openapi-spec.yaml')).toBe(false);
+  });
+
+  it('accepts a nested spec file regardless of depth', () => {
+    expect(isSpecFilePath('/project/specs/domain/a/b/c/foo.spec.yaml')).toBe(true);
   });
 });

--- a/specter/vscode-extension/src/activation.ts
+++ b/specter/vscode-extension/src/activation.ts
@@ -3,6 +3,22 @@
 import * as path from 'path';
 
 /**
+ * AC-40: gate `specter parse` invocations to real spec files. Returns
+ * true when `fsPath`'s basename ends with `.spec.yaml` (double extension,
+ * e.g. `auth.spec.yaml`), false for anything else — including the
+ * project manifest `specter.yaml`, generic .yaml config, or files whose
+ * name happens to match `specter.yaml` but not `*.spec.yaml`.
+ *
+ * Used by the on-change and on-save hooks so the manifest doesn't get
+ * parsed against the spec schema, which would produce spurious
+ * "Missing required field 'spec'" / "Unknown field 'settings'" diagnostics.
+ */
+export function isSpecFilePath(fsPath: string): boolean {
+  const base = path.basename(fsPath);
+  return base.endsWith('.spec.yaml') && base !== '.spec.yaml';
+}
+
+/**
  * AC-01 — Returns true when the workspace contains specter.yaml or at least
  * one *.spec.yaml file (double extension only, not openapi-spec.yaml).
  */

--- a/specter/vscode-extension/src/extension.ts
+++ b/specter/vscode-extension/src/extension.ts
@@ -3,7 +3,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-import { shouldActivate, resolveManifestPath, createClientKey } from './activation';
+import { shouldActivate, resolveManifestPath, createClientKey, isSpecFilePath } from './activation';
 import {
   resolveBinaryPath,
   buildDownloadUrl,
@@ -827,6 +827,12 @@ function registerDiagnosticHooks(ctx: vscode.ExtensionContext): void {
   // On-type debounce: 400ms, parse only (AC-03)
   ctx.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument(e => {
+      // AC-40: `specter parse` is spec-schema-only. Running it against the
+      // project manifest (specter.yaml) surfaces false "Missing required
+      // field 'spec'" / "Unknown field 'settings'" diagnostics — the
+      // manifest has a system: block, not a spec: block. Gate on
+      // `.spec.yaml` like the hover, completion, and codelens hooks do.
+      if (!isSpecDocument(e.document)) return;
       const uri = e.document.uri.toString();
       const existing = debounceMap.get(uri);
       if (existing) clearTimeout(existing);
@@ -855,6 +861,8 @@ function registerDiagnosticHooks(ctx: vscode.ExtensionContext): void {
   // On-save: check + coverage (AC-04)
   ctx.subscriptions.push(
     vscode.workspace.onDidSaveTextDocument(async doc => {
+      // AC-40: same gate as on-change — don't parse-as-spec a manifest.
+      if (!isSpecDocument(doc)) return;
       const client = clientForDocument(doc);
       const replacer = replacerForDocument(doc);
       if (!client || !replacer) return;
@@ -1180,6 +1188,20 @@ function clientForDocument(doc: vscode.TextDocument): SpecterClient | undefined 
   const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
   if (!folder) return undefined;
   return clients.get(createClientKey(folder.uri.fsPath));
+}
+
+/**
+ * AC-40: predicate used by the on-change / on-save hooks to gate
+ * `specter parse` invocations. The CLI's parse command validates against
+ * the spec schema only — running it on a manifest (specter.yaml) surfaces
+ * spurious "Missing required field 'spec'" / "Unknown field 'settings'"
+ * diagnostics because the manifest uses a different schema.
+ *
+ * Pure path predicate lives in activation.ts so it's testable without
+ * importing vscode.
+ */
+function isSpecDocument(doc: vscode.TextDocument): boolean {
+  return isSpecFilePath(doc.uri.fsPath);
 }
 
 function replacerForDocument(doc: vscode.TextDocument): DiagnosticReplacer | undefined {


### PR DESCRIPTION
## Summary

The on-change (400ms debounce) and on-save diagnostic hooks invoked `specter parse` on every YAML document — including the project manifest `specter.yaml`. That produced spurious diagnostics on the manifest:

- `Missing required field 'spec'`
- `Unknown field 'settings'`

because `specter parse` validates against the **spec** schema (`spec:` block required) and the manifest uses a different schema (`system:` / `settings:` / `domains:` at the top level).

Other hooks (hover, completion, CodeLens) already guarded with `endsWith('.spec.yaml')`. The fix extracts the predicate to `activation.ts` (so it's testable without importing vscode) and gates both parse hooks on it.

## Spec

- `spec-vscode` AC-40 (new). Priority: high.

## Test plan

- [x] Unit tests: 6 cases for `isSpecFilePath` including rejection of `specter.yaml`, `openapi-spec.yaml`, bare `.spec.yaml`, and generic `.yaml` / `.yml` files
- [x] `npm test` — 198 tests pass
- [x] `make dogfood` — 14/14 specs at 100% AC coverage (spec-vscode now 40/40)
- [x] `make check` — go vet + lint + test + build all green
- [ ] Manual VS Code verification: open a workspace with specter.yaml, confirm no diagnostics on the manifest; edit a .spec.yaml, confirm diagnostics still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)