### PR TITLE
docs: refresh after v0.9.2 ship

### DIFF
--- a/specter/BACKLOG.md
+++ b/specter/BACKLOG.md
@@ -2,13 +2,25 @@
 
 Forward-looking roadmap. Items are grouped by target release. Each item is a single sentence of intent plus a link to the design doc or discussion when one exists.
 
-Current shipped version: **v0.9.0** (published to VS Code Marketplace as stable 2026-04-19). **v0.9.1** in flight on `release/v0.9.1` — post-audit fixes.
+Current shipped version: **v0.9.2** (published to VS Code Marketplace as stable 2026-04-21).
 
 ---
 
-## v0.9.1 — Post-audit fixes (in flight)
+## v0.9.2 — UX polish (shipped)
 
-On `release/v0.9.1` branch. Three commits: specs → failing tests → implementation. Derived from `research/SPECTER_AUDIT_2026-04-19.md`.
+Published 2026-04-21. Two items from jwtms migration testing; no security or correctness issues.
+
+- **`specter coverage` redesign**: summary header with per-tier breakdown; worst-first sort (failing → partial → 100%, tier desc within each bucket); `--failing` flag to filter the table to sub-100% entries; 40-char truncation for long spec IDs (JSON output unchanged).
+- **`specter init --refresh`**: non-destructive manifest update. Refreshes `domains.default.specs` only; preserves `settings`, `registry`, custom domains, tier overrides. `--dry-run` variant. Mutually exclusive with `--force`.
+- **Marketplace metadata**: added `Other` category and discovery keywords (`spec`, `sdd`, `spec-driven-development`, ...).
+
+Spec bumps: `spec-coverage` 1.7.0→1.8.0, `spec-manifest` 1.5.0→1.6.0.
+
+---
+
+## v0.9.1 — Post-audit fixes (shipped)
+
+Published 2026-04-19. Derived from `research/SPECTER_AUDIT_2026-04-19.md`.
 
 - **CRITICAL**: mandatory SHA256 checksum verification on binary download (no silent fallback).
 - **BLOCKERS**: register `specter.runReverse`, remove `specter.openQuickStart` orphan declaration, CI-enforced package.json ↔ extension.ts command parity test.
@@ -16,56 +28,6 @@ On `release/v0.9.1` branch. Three commits: specs → failing tests → implement
 - **Internal**: `specter.insertAnnotation` → `specter._insertAnnotation` (VS Code community convention for internal commands).
 
 Spec bumps: `spec-coverage` 1.6.0→1.7.0, `spec-vscode` 1.2.0→1.3.0.
-
----
-
-## v0.9.2 — UX polish (candidate)
-
-Two items surfaced during jwtms migration testing. Neither is audit-critical; queued after v0.9.1 ships the security fix.
-
-### `specter coverage` visual display redesign
-
-**Pain**: on a 249-spec workspace (jwtms), the coverage report is 249 lines where ~220 are "100% PASS". The 20-ish rows that need attention are scattered throughout; developer has to scan every line to find them. Long spec IDs break column alignment.
-
-**Pinned design**:
-
-- **Sort worst-first by default**: failing → partial (under threshold but status PASS) → 100% covered. User sees what needs action at the top; sea of green is below the fold.
-- **Summary header** before the table, e.g. `Spec Coverage Report — 249 specs · 97.2% avg coverage` followed by per-tier breakdown (`Tier 1: 32/34 passing (94%)` etc.).
-- **`--failing` flag** hides 100%-covered specs. Optionally combine with `--tier=1` and `--below-threshold` as filter flags.
-- **Column alignment**: truncate spec IDs over 40 chars with an ellipsis, or dynamically compute column widths at render time from the actual content.
-- **`--quiet` flag** (lower priority): prints a single line when all specs pass, suitable for CI log noise reduction.
-
-**Deliberately excluded**: terminal color codes (TTY detection is fiddly and unreliable in CI), tier section headers (sort does more with less complexity), progress-bar rendering (visual noise with limited signal).
-
-**Spec changes expected**: `spec-coverage` 1.7.0 → 1.8.0 adds constraints + ACs for the sort, filter, and summary.
-
-**Scope**: ~4 hours Go + tests + doc update.
-
-### `specter init --refresh` for non-greenfield workspaces
-
-**Pain**: after the user adds specs to an existing project, there's no non-destructive way to update `domains.default.specs`. Today's options: `specter init` refuses (manifest exists), `specter init --force` rewrites everything (loses manual edits to `settings`, `registry`, tier overrides, custom domains).
-
-**Pinned design**:
-
-- New flag: `specter init --refresh`.
-  1. Reads existing `specter.yaml`.
-  2. Rescans `settings.specs_dir` (or default `specs/`) for parseable spec files.
-  3. Updates **only** `domains.default.specs` with the current set of parseable IDs.
-  4. Leaves every other manifest field untouched.
-- **Decision pins**:
-  - *Custom domains* (user splits specs across multiple domains): refresh does NOT touch them. Only `domains.default.specs` is refreshed; unclaimed specs (not in any other domain) go into `default`. Deterministic, scriptable.
-  - *Removed specs* (present in `domains.default.specs` but no longer on disk): silent removal. Print a summary at the end: `updated specter.yaml: +3 specs added, -1 removed`.
-  - *Parse-failing specs*: skip them, print the v0.9.0 pattern-analysis warning. Reuses the existing code path in `specter init`.
-  - *Dry-run*: `specter init --refresh --dry-run` prints the diff without writing. Useful for review before committing.
-- **Name chosen**: `--refresh` flag on `specter init`, not a separate `specter manifest refresh` subcommand. Lower discovery cost; users already know `init`. Matches `git init` semantics (safe in existing repos). If a richer `specter manifest *` subcommand tree emerges later (e.g. for add/remove/validate), revisit.
-
-**Spec changes expected**: `spec-manifest` 1.5.0 → 1.6.0 adds constraints + ACs for `--refresh`, `--dry-run`, and the decision pins.
-
-**Scope**: ~6 hours Go + tests + doc update.
-
-### Why these are in v0.9.2 and not v0.9.1
-
-v0.9.1 ships a CRITICAL security fix (mandatory checksum verification) and three BLOCKERS. It should ship promptly and small. These two items are UX polish — real value, not urgent. Same pattern as shipping the v0.8.x CVE fix quickly and scheduling the v0.9.0 UX cleanup separately.
 
 ---
 

--- a/specter/README.md
+++ b/specter/README.md
@@ -308,20 +308,26 @@ Every package in `internal/` is a pure function — no I/O, no CLI dependencies.
 
 ## Dogfooding
 
-Specter validates its own specs. The tool has 5 specs covering its own pipeline, 33 acceptance criteria, and 37 annotated tests. Every feature was specified before it was implemented.
+Specter validates its own specs. The tool has 14 specs covering its own pipeline and extension, 192 acceptance criteria, and a large annotated test suite. Every feature was specified before it was implemented.
 
 ```
 $ specter coverage
 
-Spec ID          Tier  ACs  Covered  Coverage  Status
-─────────────────────────────────────────────────────
-spec-check       T1    6    6        100%      PASS
-spec-coverage    T2    5    5        100%      PASS
-spec-parse       T1    10   10       100%      PASS
-spec-resolve     T1    7    7        100%      PASS
-spec-sync        T2    5    5        100%      PASS
+Spec Coverage Report — 14 specs · 100% avg coverage
+  Tier 1: 3/3 passing (100%)
+  Tier 2: 9/9 passing (100%)
+  Tier 3: 2/2 passing (100%)
 
-5 specs: 5 passing, 0 failing
+Spec ID                                   Tier   ACs      Covered   Coverage   Status
+----------------------------------------------------------------------------------
+spec-check                                T1     8        8         100%       PASS
+spec-parse                                T1     13       13        100%       PASS
+spec-resolve                              T1     9        9         100%       PASS
+spec-coverage                             T2     18       18        100%       PASS
+spec-diff                                 T2     10       10        100%       PASS
+...
+
+14 specs: 14 passing, 0 failing
 ```
 
 ---

--- a/specter/docs/CLI_REFERENCE.md
+++ b/specter/docs/CLI_REFERENCE.md
@@ -172,7 +172,7 @@ Generate a spec-to-test traceability matrix. Scans test files for `@spec` and `@
 **Synopsis:**
 
 ```
-specter coverage [--json] [--tests <glob>]
+specter coverage [--json] [--failing] [--tests <glob>]
 ```
 
 **Options:**
@@ -180,6 +180,7 @@ specter coverage [--json] [--tests <glob>]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--json` | — | Output the coverage report as JSON. |
+| `--failing` | — | Show only specs below 100% coverage in the table. Summary header still reflects the full report. When all specs are at 100%, emits a single-line confirmation instead of an empty table. Added in v0.9.2. |
 | `--tests <glob>` | auto-discover | Glob pattern for test files. Default discovers `*.test.ts`, `*.test.js`, `*.test.py`, `*_test.go`, `*_test.py`. |
 
 **Annotation format:**
@@ -211,20 +212,58 @@ func TestValidRegistration(t *testing.T) { ... }
 | 2 (Core Business Logic) | 80% |
 | 3 (Utility / Internal) | 50% |
 
-**Example (table output):**
+**Example (table output, v0.9.2+):**
 
 ```
 $ specter coverage
 
-Spec Coverage Report
+Spec Coverage Report — 2 specs · 83% avg coverage
+  Tier 1: 0/1 passing (0%)
+  Tier 2: 1/1 passing (100%)
 
-Spec ID                  Tier   ACs      Covered   Coverage   Status
------------------------------------------------------------------
-spec-auth                T1     6        4         67%        FAIL
-spec-payments            T2     5        5         100%       PASS
+Spec ID                                   Tier   ACs      Covered   Coverage   Status
+----------------------------------------------------------------------------------
+spec-auth                                 T1     6        4         67%        FAIL
+  uncovered: AC-01, AC-03
+spec-payments                             T2     5        5         100%       PASS
+
+2 specs: 1 passing, 1 failing
+```
+
+**Table output shape (since v0.9.2):**
+
+- A **summary header** precedes the table: total-specs count, arithmetic-mean coverage, and per-tier breakdown (`Tier K: X/Y passing (Z%)`). Tiers with zero specs in the workspace are omitted.
+- Entries are **sorted worst-first**: failing (below threshold) → partial (below 100% but passing threshold) → 100% covered. Within each bucket, tier descending (T1 before T2 before T3) so higher-risk specs surface first.
+- Spec IDs longer than 40 characters are **truncated** in the table with a trailing ellipsis (`…`). This keeps column alignment on workspaces with long path-derived IDs. The `--json` output is unaffected — it emits the full spec_id.
+
+**Example (`--failing`, v0.9.2+):**
+
+```
+$ specter coverage --failing
+
+Spec Coverage Report — 2 specs · 83% avg coverage
+  Tier 1: 0/1 passing (0%)
+  Tier 2: 1/1 passing (100%)
+
+Spec ID                                   Tier   ACs      Covered   Coverage   Status
+----------------------------------------------------------------------------------
+spec-auth                                 T1     6        4         67%        FAIL
   uncovered: AC-01, AC-03
 
 2 specs: 1 passing, 1 failing
+```
+
+When every spec is at 100%, `--failing` emits a single-line confirmation in place of the empty table:
+
+```
+$ specter coverage --failing
+
+Spec Coverage Report — 14 specs · 100% avg coverage
+  Tier 1: 3/3 passing (100%)
+  Tier 2: 9/9 passing (100%)
+  Tier 3: 2/2 passing (100%)
+
+All 14 specs at 100% coverage.
 ```
 
 **Example (`--json`):**
@@ -427,6 +466,7 @@ Initialize a `specter.yaml` project manifest, or scaffold a draft `.spec.yaml` f
 
 ```
 specter init [--name <name>] [--force] [--template <type>]
+specter init --refresh [--dry-run]
 ```
 
 **Options:**
@@ -434,8 +474,10 @@ specter init [--name <name>] [--force] [--template <type>]
 | Option | Description |
 |--------|-------------|
 | `--name <name>` | System name for the manifest. Defaults to the current directory name. |
-| `--force` | Overwrite an existing `specter.yaml`. |
+| `--force` | Overwrite an existing `specter.yaml`. Mutually exclusive with `--refresh`. |
 | `--template <type>` | Create a draft `.spec.yaml` from a template instead of a manifest. Types: `api-endpoint`, `service`, `auth`, `data-model`. |
+| `--refresh` | Update only `domains.default.specs` in an existing `specter.yaml`. Preserves every other field — `settings`, `registry`, tier overrides, custom domains. Added in v0.9.2. |
+| `--dry-run` | Used with `--refresh`: print the proposed diff to stdout without writing the file. Added in v0.9.2. |
 
 **Behaviour (v0.9.0+):**
 
@@ -478,6 +520,38 @@ The manifest was still written with an empty default domain as a
 placeholder. Add your spec IDs under `domains.default.specs` once
 the parse errors are resolved.
 ```
+
+**Refresh mode (v0.9.2+):**
+
+`specter init --refresh` is the non-destructive counterpart to `--force`. It reads the existing `specter.yaml`, rescans `settings.specs_dir` (or default `specs/`), and updates **only** `domains.default.specs` with the current on-disk spec set. Every other field is preserved — `settings`, `registry`, system metadata, and any custom domains declared under `domains.<name>` (anything that isn't `default`).
+
+Specs claimed by a custom domain (listed under a non-default `domains.<name>.specs`) stay in that domain and are **not** migrated into `default`. A spec belongs to exactly one domain.
+
+Specs that were previously listed in `domains.default.specs` but are no longer discoverable on disk (deleted, renamed, or now failing to parse) are removed from the list. The summary line reports the change counts.
+
+**Example (`--refresh`):**
+
+```
+$ specter init --refresh
+updated specter.yaml: +1 added, -0 removed
+```
+
+**Example (`--refresh --dry-run`):**
+
+Prints the proposed diff without writing. The file on disk is byte-identical before and after. Useful for review before committing.
+
+```
+$ specter init --refresh --dry-run
+Dry run — no changes will be written.
+
+Proposed changes to domains.default.specs:
+  + spec-payments
+  - spec-legacy-auth
+
+Run `specter init --refresh` (without --dry-run) to apply.
+```
+
+**Flag conflict:** `--refresh` and `--force` are mutually exclusive. `--force` rewrites the entire manifest; `--refresh` is surgical. Combining them exits non-zero with a clear error.
 
 **Example (template):**
 

--- a/specter/docs/GETTING_STARTED.md
+++ b/specter/docs/GETTING_STARTED.md
@@ -456,7 +456,7 @@ Once `specter sync` passes locally, add it to your CI pipeline. This is the gate
 ```yaml
 - uses: hanalyx/specter-sync-action@v1
   with:
-    version: 0.9.0
+    version: 0.9.2
 ```
 
 **Or inline download (if you can't use the composite action):**
@@ -466,7 +466,7 @@ Once `specter sync` passes locally, add it to your CI pipeline. This is the gate
   run: |
     OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
     case "${{ runner.arch }}" in X64) ARCH=amd64 ;; ARM64) ARCH=arm64 ;; esac
-    VERSION=0.9.0   # pin a version; don't rely on "latest" in CI
+    VERSION=0.9.2   # pin a version; don't rely on "latest" in CI
     curl -LO "https://github.com/Hanalyx/specter/releases/download/v${VERSION}/specter_${VERSION}_${OS}_${ARCH}.tar.gz"
     tar xzf "specter_${VERSION}_${OS}_${ARCH}.tar.gz" && sudo mv specter /usr/local/bin/
 - name: Specter sync


### PR DESCRIPTION
## Summary

Post-v0.9.2 doc audit. Doc-only commit; no code changes.

## What's updated

### BACKLOG.md
- Current shipped version bumped to v0.9.2
- v0.9.1 and v0.9.2 sections marked shipped (were "in flight" / "candidate")

### README.md
- Dogfood example reflects current state: 14 specs / 192 ACs (was 5 / 33)
- Coverage output block uses the v0.9.2 format (summary header, per-tier breakdown, aligned columns)

### docs/CLI_REFERENCE.md
- \`specter coverage\` section: new \`--failing\` flag documented; v0.9.2 table example (summary header + sort rules + truncation); separate example for all-passing single-line output
- \`specter init\` section: new \`--refresh\` and \`--dry-run\` flags; \"Refresh mode\" subsection explaining custom-domain preservation, spec removal handling, and the \`--refresh\` / \`--force\` mutual exclusion

### docs/GETTING_STARTED.md
- CI integration version pins bumped 0.9.0 → 0.9.2

## Not in this PR

Local gitignored updates to \`specter/CLAUDE.md\` (project Claude instructions) capturing two patterns that emerged from v0.9.x:
- \"Class-of-bug discipline\" — parity tests for contract pairs (package.json ↔ extension.ts, Go types ↔ schema, etc.)
- \"SDD cycle — three commits, in order\" — spec → test → code, separately

Those stay local by design.

## Test plan

- [x] \`make check\` — clean
- [x] \`make dogfood\` — 14/14 at 100%
- [x] Doc-only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)