### PR TITLE
ci: trigger on release/** branches so v0.10 PRs get CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
     paths: ['specter/**', '.github/**', 'CONTRIBUTING.md']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
     paths: ['specter/**', '.github/**', 'CONTRIBUTING.md']
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

PR #52 (v0.10 feature work targeting \`release/v0.10\`) reported no CI checks because the workflow only triggered on \`main\`. With the v0.9.2 branch discipline routing PRs through a working branch, we need CI to fire on release branches too.

One-line change to both \`push\` and \`pull_request\` branch filters:

\`\`\`diff
-    branches: [main]
+    branches: [main, 'release/**']
\`\`\`

Between-releases clause of the branch discipline applies — this PR targets \`main\` directly because it's infrastructure for the v0.10 cycle, not a v0.10 feature.

## Test plan

- [x] \`main\` still matches → PRs to main still run CI
- [x] \`release/**\` now matches → PR #52 will get CI once this merges and PR #52 rebases/gets a push
- [ ] CI green (this PR itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)