### PR TITLE
feat(vscode): quick-fix 'Remove deprecated field' for known-removed fields

### DIFF
--- a/specter/specs/spec-vscode.spec.yaml
+++ b/specter/specs/spec-vscode.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: spec-vscode
-  version: "1.3.0"
-  status: draft
+  version: "1.4.0"
+  status: approved
   tier: 2
 
   context:
@@ -197,6 +197,11 @@ spec:
 
     - id: C-26
       description: "Async and synchronous error paths in editor hooks (onDidChangeTextDocument, onDidSaveTextDocument, onDidChangeActiveTextEditor, hover/completion/codeLens providers, drift scanner) MUST route caught errors to the Specter Output channel with a timestamp and context string, NOT silently discard them. `catch {}`, `catch (_) {}`, and `.catch(() => {})` on promise chains that can hide real failures are prohibited."
+      type: business
+      enforcement: error
+
+    - id: C-27
+      description: "When a Specter parse diagnostic on a .spec.yaml file carries a message matching `Unknown field '<fieldName>'` AND <fieldName> is in the known-removed-fields list (initial v0.10 list: `trust_level`), the extension MUST offer a CodeAction quick-fix titled `Remove deprecated field '<fieldName>'` that, when invoked, deletes the offending line. Applies to the single diagnostic; batch `Fix all` is a future addition. Pairs with `specter doctor --fix` for the CLI path — both do the same repair."
       type: business
       enforcement: error
 
@@ -476,6 +481,24 @@ spec:
       references_constraints: ["C-26"]
       priority: medium
 
+    - id: AC-50
+      description: "The pure helper `matchRemovedFieldDiagnostic(message)` returns the field name when given `Unknown field 'trust_level'` (in the known-removed list), returns null when given `Unknown field 'some_unknown_field'` (not in the list), and returns null when given any non-matching message (e.g. `Missing required field 'id'`). The helper is runtime-free: no VS Code imports."
+      inputs:
+        case_a: "Unknown field 'trust_level'"
+        case_b: "Unknown field 'some_unknown_field'"
+        case_c: "Missing required field 'id'"
+      expected_output:
+        case_a: "trust_level"
+        case_b: null
+        case_c: null
+      references_constraints: ["C-27"]
+      priority: high
+
+    - id: AC-51
+      description: "The extension registers a CodeActionProvider via vscode.languages.registerCodeActionsProvider keyed on the yaml language and producing a `quickfix` kind action. Registration is captured in activation.ts / extension.ts and the static analysis test in __tests__/ asserts the registration exists."
+      references_constraints: ["C-27"]
+      priority: medium
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.1.0"
@@ -494,6 +517,11 @@ spec:
       relationship: requires
 
   changelog:
+    - version: "1.4.0"
+      date: "2026-04-22"
+      author: "specter-team"
+      type: minor
+      description: "Add C-27/AC-50/AC-51: CodeAction quick-fix 'Remove deprecated field' for Unknown-field parse diagnostics whose field name matches the known-removed list (initial v0.10: trust_level). Pairs with specter doctor --fix for the CLI path — both perform the same repair."
     - version: "1.3.0"
       date: "2026-04-19"
       author: "specter-team"

--- a/specter/vscode-extension/src/__tests__/quickFix.test.ts
+++ b/specter/vscode-extension/src/__tests__/quickFix.test.ts
@@ -1,0 +1,60 @@
+// @spec spec-vscode
+//
+// Tests for the quick-fix helper that identifies Unknown-field parse
+// diagnostics matching the known-removed-fields list. Runtime-free: no
+// vscode imports — pure string predicate.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { matchRemovedFieldDiagnostic, KNOWN_REMOVED_FIELDS } from '../quickFix';
+
+// @ac AC-50
+describe('matchRemovedFieldDiagnostic', () => {
+  it('returns the field name for a known-removed Unknown-field diagnostic', () => {
+    const msg = "Unknown field 'trust_level'. Remove it or check for a typo in the field name.";
+    expect(matchRemovedFieldDiagnostic(msg)).toBe('trust_level');
+  });
+
+  it('returns null for Unknown-field of a field not in the known-removed list', () => {
+    const msg = "Unknown field 'totally_new_field'. Remove it or check for a typo in the field name.";
+    expect(matchRemovedFieldDiagnostic(msg)).toBeNull();
+  });
+
+  it('returns null for a non-Unknown-field diagnostic', () => {
+    const msg = "Missing required field 'id'";
+    expect(matchRemovedFieldDiagnostic(msg)).toBeNull();
+  });
+
+  it('known-removed list includes trust_level (v0.10 seed)', () => {
+    expect(KNOWN_REMOVED_FIELDS).toContain('trust_level');
+  });
+});
+
+// @ac AC-51
+// Static-analysis test: extension.ts must register a CodeActionProvider
+// keyed on the yaml language. We do not spin up a vscode runtime — we grep.
+describe('CodeActionProvider registration (static)', () => {
+  it('extension.ts registers a CodeActionProvider for yaml', () => {
+    const srcPath = path.resolve(__dirname, '..', 'extension.ts');
+    const src = fs.readFileSync(srcPath, 'utf-8');
+
+    if (!/registerCodeActionsProvider\s*\(/.test(src)) {
+      throw new Error(
+        'extension.ts does not call vscode.languages.registerCodeActionsProvider — quick-fix provider must be registered (AC-51).',
+      );
+    }
+    // Provider must mention yaml/language key somewhere in the call.
+    const providerBlockMatch = src.match(/registerCodeActionsProvider\s*\([\s\S]{0,400}?\)/);
+    if (!providerBlockMatch) {
+      throw new Error(
+        'Could not find a complete registerCodeActionsProvider(...) invocation — AC-51 expects yaml keying.',
+      );
+    }
+    if (!/yaml/.test(providerBlockMatch[0])) {
+      throw new Error(
+        `CodeActionProvider registration must key on the yaml language; found: ${providerBlockMatch[0]}`,
+      );
+    }
+  });
+});

--- a/specter/vscode-extension/src/extension.ts
+++ b/specter/vscode-extension/src/extension.ts
@@ -40,6 +40,7 @@ import {
 import { buildConstraintHover, resolveDefinitionTarget } from './navigation';
 import { buildInsightCards, computeInsightsStatus, formatSpecContextForAI, shouldShowWalkthrough } from './insights';
 import { detectDrift, buildDriftHover } from './drift';
+import { matchRemovedFieldDiagnostic } from './quickFix';
 import { SpecterClient } from './client';
 import { detectShellConfig, isPathAlreadyPresent, formatAppendBlock, shouldPromptAddPath } from './shellPath';
 import * as crypto from 'crypto';
@@ -707,6 +708,40 @@ function registerProviders(ctx: vscode.ExtensionContext): void {
         return new vscode.Hover(new vscode.MarkdownString(hover.contents));
       },
     }),
+  );
+
+  // -- CodeAction quick-fix: "Remove deprecated field" for Specter parse
+  // diagnostics naming a field in the known-removed list (AC-50 / AC-51).
+  // Keyed on yaml language so it's available anywhere a .spec.yaml is open.
+  ctx.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      { language: 'yaml' },
+      {
+        provideCodeActions(doc, _range, context) {
+          const actions: vscode.CodeAction[] = [];
+          for (const diag of context.diagnostics) {
+            if (diag.source !== 'specter') continue;
+            const fieldName = matchRemovedFieldDiagnostic(diag.message);
+            if (!fieldName) continue;
+
+            const fix = new vscode.CodeAction(
+              `Remove deprecated field '${fieldName}'`,
+              vscode.CodeActionKind.QuickFix,
+            );
+            // Delete the entire line of the diagnostic. VS Code ranges
+            // sometimes point at a single char — expand to the full line.
+            const lineRange = doc.lineAt(diag.range.start.line).rangeIncludingLineBreak;
+            fix.edit = new vscode.WorkspaceEdit();
+            fix.edit.delete(doc.uri, lineRange);
+            fix.diagnostics = [diag];
+            fix.isPreferred = true;
+            actions.push(fix);
+          }
+          return actions;
+        },
+      },
+      { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] },
+    ),
   );
 
   // -- Go-to-definition (AC-10)

--- a/specter/vscode-extension/src/quickFix.ts
+++ b/specter/vscode-extension/src/quickFix.ts
@@ -1,0 +1,36 @@
+// @spec spec-vscode
+//
+// Pure helper identifying parse diagnostics whose "Unknown field '<X>'"
+// message names a field that has been removed from the spec schema. The
+// CodeAction provider in extension.ts uses this to decide whether to offer
+// a "Remove deprecated field" quick-fix.
+//
+// Kept runtime-free (no vscode imports) so it's testable without a jest
+// runtime shim for the vscode module. See __tests__/quickFix.test.ts.
+
+/**
+ * Fields removed from the spec schema in earlier versions. The quick-fix
+ * only offers itself for fields on this list — new drift (truly unknown
+ * fields) is not silently "fixed" by dropping the line; the user must
+ * decide.
+ *
+ * Paired with internal/migrate's `strip-trust-level` rewrite (specter
+ * doctor --fix applies the same repair at the CLI layer).
+ */
+export const KNOWN_REMOVED_FIELDS: readonly string[] = [
+  'trust_level', // Removed in v0.6.5
+] as const;
+
+/**
+ * Matches the standard specter parser "Unknown field 'X'" message. If the
+ * extracted X is in KNOWN_REMOVED_FIELDS, returns X; otherwise returns null.
+ *
+ * AC-50.
+ */
+export function matchRemovedFieldDiagnostic(message: string): string | null {
+  const m = /Unknown field '([^']+)'/.exec(message);
+  if (!m) return null;
+  const fieldName = m[1];
+  if (!KNOWN_REMOVED_FIELDS.includes(fieldName)) return null;
+  return fieldName;
+}


### PR DESCRIPTION
## Summary

Adds a VS Code CodeAction quick-fix that removes deprecated spec fields. When the Specter parse diagnostic reads \`Unknown field 'trust_level'\`, the lightbulb offers \`Remove deprecated field 'trust_level'\` which deletes the offending line.

Pairs with \`specter doctor --fix\` (PR #57) — both perform the same \`strip-trust-level\` repair via different surfaces.

Three SDD commits preserved: spec → failing tests → implementation.

## Spec diff

\`spec-vscode\` 1.3.0 → 1.4.0:
- C-27: CodeAction quick-fix for Unknown-field diagnostics matching known-removed list
- AC-50: pure \`matchRemovedFieldDiagnostic(message)\` helper
- AC-51: CodeActionProvider registered on yaml language

## Test plan

- [x] 5 new jest tests pass (4 for the pure helper + 1 static-analysis check)
- [x] All 214 jest tests pass overall
- [x] \`tsc --noEmit\` clean
- [x] Backend \`make check\` + \`make dogfood\` green
- [ ] Manual VS Code repro: open a spec with \`trust_level: high\`, hover the error, see lightbulb, apply → line removed

## Known-removed fields list (v0.10 seed)

Just \`trust_level\`. Future schema breakages land here as additions:
\`\`\`ts
export const KNOWN_REMOVED_FIELDS: readonly string[] = [
  'trust_level', // Removed in v0.6.5
];
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)