### PR TITLE
docs(explainer): strip AI-speak from v0.10 CI-gated coverage article

### DIFF
--- a/specter/docs/explainer/v0.10-ci-gated-coverage.md
+++ b/specter/docs/explainer/v0.10-ci-gated-coverage.md
@@ -124,19 +124,47 @@ Feedback loop: `max(test duration) + ~30s` on a workspace with a few hundred spe
 
 ### Local use
 
-`--strict` is not CI-specific. The requirement is a test runner emitting JUnit XML or `go test -json`:
+`--strict` is not CI-specific. The requirement is a test runner emitting JUnit XML or `go test -json` **with the AC claim visible to the runner** — not just in source comments. Specter reads what the runner emits; it does not grep source files to reconstruct intent.
+
+Two conventions work:
+
+**Convention A — subtest name carries the AC.** Simplest for Go:
+
+```go
+// auth_test.go
+func TestAuthService(t *testing.T) {
+    t.Run("spec-auth/AC-03 rejects expired tokens", func(t *testing.T) {
+        // assertions
+    })
+    t.Run("spec-auth/AC-04 rotates refresh tokens", func(t *testing.T) {
+        // assertions
+    })
+}
+```
+
+**Convention B — test body emits the annotation at runtime.** Useful when you can't rename:
+
+```go
+func TestAuthService_ExpiredTokenRejected(t *testing.T) {
+    t.Log("// @spec spec-auth")
+    t.Log("// @ac AC-03")
+    // assertions
+}
+```
+
+Either way, the `(spec_id, ac_id)` pair reaches `go test -json`, which reaches `specter ingest`:
 
 ```bash
 $ go test -json ./... > /tmp/go.json
 $ specter ingest --go-test /tmp/go.json
-Wrote 34 result entries to .specter-results.json
+Wrote 2 result entries to .specter-results.json
 
 $ specter coverage --strict
-Spec Coverage Report — 14 specs · 100% avg coverage
-  Tier 1: 4/4 passing (100%)
-  Tier 2: 9/9 passing (100%)
-  Tier 3: 1/1 passing (100%)
+Spec Coverage Report — 1 specs · 100% avg coverage
+  Tier 1: 1/1 passing (100%)
 ```
+
+The count matches the number of `(spec_id, ac_id)` pairs the runner surfaced. Annotations that live only in source comments — Specter's own v0.9-style `// @spec` above a function — are invisible to `ingest`, by design.
 
 Works in pre-commit hooks, pre-push hooks, or interactive checks.
 

--- a/specter/docs/explainer/v0.10-ci-gated-coverage.md
+++ b/specter/docs/explainer/v0.10-ci-gated-coverage.md
@@ -1,23 +1,10 @@
-# CI-gated coverage: closing the eval-phase hole
+# CI-gated coverage
 
-**Target audience:** teams already running Specter who want their green CI badge to mean something.
-**What shipped:** `specter ingest` + `specter coverage --strict` (v0.10).
-**What it closes:** the silent-pass shapes where annotated-but-failing or annotated-but-skipped tests counted as "covered."
+v0.10 adds `specter ingest` and `specter coverage --strict`. Together they let `specter coverage` fail when annotated tests didn't actually pass.
 
----
+## What coverage did before v0.10
 
-## Why this exists
-
-Specter's mission is to guide the loop **spec → test → implement → eval** in the right order, every time, with intent preserved throughout. Through v0.9.x we enforced three of those four phases mechanically:
-
-- **Spec** — `parse`, `resolve`, `check` validate schema, linkage, and structure.
-- **Test (exists)** — `coverage` counts `@spec`/`@ac` annotations per AC and enforces tier thresholds.
-- **Implement** — out of scope by design; Specter is a gate, not an IDE coach.
-- **Eval** — ⚠️ not actually enforced.
-
-That last gap was the quiet one. `specter coverage` counted an AC as "covered" whenever it found a `// @ac AC-NN` annotation on a test. It never asked whether the test *passed*.
-
-### The three silent-pass shapes
+`specter coverage` counted an AC as "covered" whenever it found a `// @ac AC-NN` annotation on a test. It did not check whether the test passed. Three shapes fall through that gate:
 
 ```go
 // @ac AC-07
@@ -28,44 +15,32 @@ func TestHostMutexReleasedOnPanic(t *testing.T) {
 // @ac AC-08
 func TestConcurrentRunSerializes(t *testing.T) {
     // was green last week, now panics
-    // annotation still present → still counted as covered
+    // annotation still present, still counted as covered
 }
 ```
 
-Three ways this goes wrong silently:
+1. Skipped tests (`t.Skip` / `it.skip` / `@pytest.mark.skip`) keep the annotation.
+2. Regressions keep the annotation after breaking.
+3. Flaky tests report inconsistently.
 
-1. **Skipped tests claim coverage** — `t.Skip(...)` / `it.skip(...)` / `@pytest.mark.skip` keep the annotation, so coverage stays green.
-2. **Failing tests claim coverage** — regressions merge under a green gate because the annotation persists after the test broke.
-3. **Flakes corrupt the signal** — a test that passes 70% of the time reports coverage inconsistently.
+## Design: two-stage ingest
 
-A passing Specter pipeline didn't mean your intent was verified. That broke the promise.
-
----
-
-## Design — two-stage ingest
-
-The shortest path would have been `specter coverage --junit 'test-results/*.xml'` — teach `coverage` to parse JUnit inline. We rejected it. JUnit XML is a moving target across vitest, jest, go test, pytest, playwright, and every framework spells it slightly differently. Coupling that parsing to `coverage`'s hot path would have made the critical gate stage fragile.
-
-Instead, v0.10 introduces two verbs with one contract between them:
+The short path would have been `specter coverage --junit 'test-results/*.xml'` — parse JUnit inline in `coverage`. JUnit XML varies across vitest, jest, pytest, go test, and playwright; folding that into `coverage`'s hot path makes the gate stage fragile. v0.10 splits the responsibility:
 
 ```
 test runner  →  specter ingest  →  .specter-results.json  →  specter coverage --strict
-             (JUnit / go test -json)      (status enum)            (pass/fail gate)
+             (JUnit / go test -json)     (status enum)            (pass/fail gate)
 ```
 
-Each stage does one thing:
+- `specter ingest` reads a runner's output and writes the results file. Flavor-specific parsing lives here.
+- `.specter-results.json` is the stable contract.
+- `specter coverage --strict` reads the results file and emits pass/fail. Runner-agnostic.
 
-- **`specter ingest`** reads a runner's output and writes the canonical results file. Knows about flavor quirks so `coverage` doesn't have to.
-- **`.specter-results.json`** is the stable contract. Fields never change without a schema bump.
-- **`specter coverage --strict`** reads only the results file and emits a pass/fail decision. Fast, deterministic, runner-agnostic.
+Adding a new runner flavor (TAP, bespoke JSON) is a change to `ingest` only.
 
-This means adding a new runner flavor (TAP, bespoke JSON) is a change to `ingest` alone. `coverage` stays simple.
+## The status enum
 
----
-
-## The `status` enum
-
-`.specter-results.json` in v0.9 had a boolean `passed` field. v0.10 adds an explicit status:
+`.specter-results.json` in v0.9 had a boolean `passed`. v0.10 adds `status`:
 
 ```json
 {
@@ -78,52 +53,43 @@ This means adding a new runner flavor (TAP, bespoke JSON) is a change to `ingest
 }
 ```
 
-Four values:
-
 | Status | Meaning |
 |---|---|
-| `passed` | Test ran and its assertions succeeded. |
+| `passed` | Test ran and assertions succeeded. |
 | `failed` | An assertion failed. |
-| `skipped` | The test was marked skip / skip.if / xfail. |
-| `errored` | The framework itself failed outside the assertion — setup threw, teardown panicked, compile error. Distinguished from `failed` because it usually points at infrastructure, not the code under test. |
+| `skipped` | Test was marked skip / skip.if / xfail. |
+| `errored` | Framework itself failed outside the assertion (setup threw, teardown panicked, compile error). |
 
-The old `passed` boolean is preserved alongside the new enum. Consumers on spec-coverage < 1.9.0 continue reading `passed` and see exactly what they saw before. New consumers read `status` for the richer signal. No flag day.
+`errored` is distinct from `failed` because it typically points at infrastructure, not code under test.
+
+The old `passed` boolean is retained. Consumers on spec-coverage < 1.9.0 keep reading `passed`; new consumers read `status`.
 
 ### Worst-status wins
 
-When the same `(spec_id, ac_id)` is hit by multiple tests — common when an AC has a unit test and an integration test — the emitted entry uses the worst observed status:
+When the same `(spec_id, ac_id)` is hit by multiple tests, the emitted entry takes the worst observed status:
 
 ```
 errored > failed > skipped > passed
 ```
 
-One failing sibling demotes the AC. A passing test does not heal a failing one. This keeps the semantics aligned with how developers actually think: "AC-07 has a red test, so AC-07 is not covered, full stop."
+One failing test demotes the AC regardless of passing siblings.
 
----
+## `coverage --strict`
 
-## `coverage --strict` — the enforcement
-
-Without the flag, coverage keeps today's behavior exactly: annotation-only for Tier 2/3, pass-rate-aware for Tier 1 when a results file is present. Upgrading to v0.10 changes nothing until you opt in.
+Without the flag, coverage behaves as before: annotation-only for Tier 2/3, pass-rate-aware for Tier 1 when a results file is present. Upgrading to v0.10 changes nothing until `--strict` is passed.
 
 With `--strict`:
 
-- Every annotated AC must have a `status: passed` entry in `.specter-results.json`. Anything else — `failed`, `skipped`, `errored`, or missing entirely (`unknown`) — demotes it to uncovered.
-- The demotion applies to **all tiers**, not just Tier 1. A Tier 3 utility spec with a failing annotated test is uncovered under `--strict`.
+- Every annotated AC must have a `status: passed` entry. Anything else (`failed`, `skipped`, `errored`, or no entry) demotes it to uncovered.
+- Demotion applies to **all tiers**, not only Tier 1.
 - A missing or empty `.specter-results.json` is a hard error:
   ```
   error: --strict requires .specter-results.json — run 'specter ingest' first
   ```
-  Silently falling back to annotation-only under `--strict` would defeat the whole point, so we don't.
 
-### Why the hard failure on missing results
+Falling back to annotation-only under `--strict` would erase the flag's meaning, so `--strict` fails closed.
 
-`--strict` is a contract: "I verified that the annotated tests passed." Without a results file, that contract can't be satisfied. Treating the missing file as "I guess we'll trust the annotations then" would let teams ship a broken pipeline and think they were protected.
-
----
-
-## CI wiring, end to end
-
-A typical Node project:
+## CI wiring
 
 ```yaml
 name: CI
@@ -152,13 +118,13 @@ jobs:
       - run: specter coverage --strict
 ```
 
-The `specter-coverage` job blocks on `test`, consumes its artifact, and gates the PR. If any annotated test is `failed`/`skipped`/`errored`, coverage exits non-zero and the PR goes red.
+The `specter-coverage` job blocks on `test`, consumes the artifact, and gates the PR. If any annotated test is `failed`/`skipped`/`errored`, coverage exits non-zero.
 
-Cost: the feedback loop is now `max(test duration) + ~30s`, where `~30s` is the ingest + coverage run time on workspaces with a few hundred specs. For a jwtms-scale project (250s integration suite) this is a marginal cost for a much stronger guarantee.
+Feedback loop: `max(test duration) + ~30s` on a workspace with a few hundred specs.
 
-### Can it run locally?
+### Local use
 
-Yes. Nothing about `--strict` is CI-specific. The only requirement is a test runner emitting JUnit XML or `go test -json` — which is a one-flag change to your existing test command:
+`--strict` is not CI-specific. The requirement is a test runner emitting JUnit XML or `go test -json`:
 
 ```bash
 $ go test -json ./... > /tmp/go.json
@@ -172,43 +138,26 @@ Spec Coverage Report — 14 specs · 100% avg coverage
   Tier 3: 1/1 passing (100%)
 ```
 
-Good for pre-commit hooks, pre-push hooks, or interactive "did I break anything?" checks.
+Works in pre-commit hooks, pre-push hooks, or interactive checks.
 
----
+## Adoption path
 
-## Adopting v0.10 incrementally
+1. **No tests, no CI** — `coverage` works as before; `--strict` is not applicable.
+2. **Tests run, runner not emitting structured output** — add `--reporter=junit` (or `-json` for go test).
+3. **JUnit or go-test-json in CI** — wire the two `run:` lines above. Enable `--strict` when the signal is trusted.
+4. **Already maintaining `.specter-results.json` by hand** — move to `--strict` for coverage across Tier 2/3.
 
-The design accommodates graded adoption. Pick whichever line below matches your current state:
+The boolean `passed` compatibility field means no migration is forced.
 
-1. **No tests, no CI** — `coverage` works as before. `--strict` not applicable.
-2. **Have tests, no CI runner emitting structured output** — add a `--reporter=junit` flag (or `-json` for go test). That's it. `ingest` + `--strict` are now available.
-3. **Have JUnit / go-test-json in CI** — wire the two `run:` lines above. Flip `--strict` on once you trust the signal.
-4. **Already using `.specter-results.json` by hand** — you're done for Tier 1. Move to `--strict` if you want the same guarantee across Tier 2/3.
+## Out of scope for v0.10
 
-The boolean `passed` compatibility means there is **no forced migration**. Old tooling keeps working. New tooling gets the richer signal. You choose the pace.
+- **Flake handling.** `--retry 2` is a workaround that hides regressions. The planned answer is `status: flaky` from runners plus a `--deny-flaky` flag. Deferred to v0.11.
+- **Source-file tracking.** `--strict` operates on annotations in test files. Extracting source-file governance is unscheduled.
+- **VS Code surface.** Red-dot rendering for failed annotated ACs is a v0.10 fast-follow, not in this cut.
+- **`specter ingest` scope.** Reads runner output, writes the canonical file. Does not run tests, retry, time them, or recommend new ones.
 
----
+## Release note
 
-## What v0.10 does not do (and why)
-
-**No flake handling.** An intermittently-failing test is a real problem, but the proposal to "add `--retry 2` on the test jobs" is a workaround that hides legitimate regressions. The right answer is that runners emit `status: flaky` when they detect the pattern, and Specter grows a `--deny-flaky` flag that treats `flaky` as failure. That needs real-world patterns from v0.10 usage before we commit to a design — deferred to v0.11.
-
-**No source-file tracking.** `specter coverage --strict` still operates on annotations in test files. The open design question of whether to extract source-file governance from annotations is unscheduled and separate.
-
-**No VS Code surface yet.** Surfacing strict-mode state in the sidebar (e.g., red dot on ACs whose test failed) is a v0.10 fast-follow, not part of this cut.
-
-**`specter ingest` is intentionally narrow.** It takes runner output and writes the canonical file. It does not run tests, retry tests, analyze test durations, or suggest which tests to write. Each of those is either someone else's tool or a deliberate non-goal.
-
----
-
-## The bigger picture
-
-Before v0.10, Specter could tell you "someone remembered to write a test for AC-07." After v0.10, Specter can tell you "the test for AC-07 ran in CI and passed." That's a much stronger promise, and it's the promise the mission statement actually makes.
-
-The loop closes a little further each release:
-
-- **v0.9.x** — test existence is mechanical.
-- **v0.10** — test outcome is mechanical. You're here.
-- **v0.11** — order of operations is mechanical (pre-push hook blocks unannotated diffs; `explain --format claude --all` pushes spec context to the AI before it writes code).
-
-Each piece is narrow and does one thing. Together they make "spec-driven development" mean something a tool can verify instead of something a team promises.
+- v0.9.x — test existence is mechanical.
+- v0.10 — test outcome is mechanical.
+- v0.11 (planned) — pre-push hook blocks unannotated diffs; `explain --format claude --all` writes spec context for AI tools.


### PR DESCRIPTION
Rewrites the v0.10 explainer to drop manifesto-style framing. Keeps all technical content — tables, code blocks, CI examples, enum semantics, adoption path, out-of-scope list.

Removed:
- \"Specter's mission is to guide the loop...\" opening sermon
- \"That broke the promise\" / \"The bigger picture\" closings
- Editorial \"we rejected it\" commentary
- ⚠️ emoji in the spec/test/implement/eval bullet
- Target-audience / what-shipped front-matter block

215 → 163 lines. No technical content change.

After review, preview at:
https://github.com/Hanalyx/specter/blob/docs/explainer-rewrite/specter/docs/explainer/v0.10-ci-gated-coverage.md