### PR TITLE
docs: refresh after v0.10.2 Marketplace ship + dogfood-strict merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,8 @@ See [RELEASE_PLAN.md](specter/docs/RELEASE_PLAN.md) for the full commit conventi
 
 ```bash
 # Target the current working branch explicitly — do not rely on the repo default.
-gh pr create --base release/v0.10 --title "..."
+# Check specter/BACKLOG.md's header for the current branch name.
+gh pr create --base release/vX.Y.Z --title "..."
 ```
 
 ## Branch workflow
@@ -85,13 +86,15 @@ Specter uses a **release-working-branch** model. Each release cycle has one long
 ```
 main
  │
- ├── release/v0.10  ← every PR targets this while v0.10 is in flight
- │    ├── feat/specter-migrate
+ ├── release/vX.Y.Z  ← every PR targets this while the cycle is in flight
+ │    ├── feat/some-feature
  │    ├── fix/some-bug
  │    └── docs/something
  │
- └── hotfix/v0.9.3  ← hotfixes branch from main, merge to main, skip the working branch
+ └── hotfix/vA.B.C  ← hotfixes branch from main, merge to main, skip the working branch
 ```
+
+Between releases, `main` is the only branch and PRs target `main` directly. Maintenance-only branches (such as the `chore/dogfood-strict` internal refactor that shipped 2026-04-24) use `chore/<name>` naming and merge without a version bump.
 
 ### Rules
 

--- a/specter/BACKLOG.md
+++ b/specter/BACKLOG.md
@@ -2,9 +2,11 @@
 
 Forward-looking roadmap. Items are grouped by target release. Each item is a single sentence of intent plus a link to the design doc or discussion when one exists.
 
-Current shipped version: **v0.10.2** (CLI released to GitHub 2026-04-23; VS Code extension v0.10.1 on Marketplace — v0.10.2 VSIX built but held pending further testing). Past release notes live in [CHANGELOG.md](CHANGELOG.md) — this file is forward-only.
+Current shipped version: **v0.10.2** (CLI released to GitHub 2026-04-23; VS Code extension v0.10.2 shipped to Marketplace 2026-04-24). Past release notes live in [CHANGELOG.md](CHANGELOG.md) — this file is forward-only.
 
-Current maintenance branch: `chore/dogfood-strict` (opened 2026-04-23). **Not a release cycle.** Dogfood `specter coverage --strict` on Specter itself — v0.10.x shipped the mechanical eval gate but Specter's own tests use v0.9-era source-only annotations that `ingest` cannot read. Specter preaches `--strict` it cannot apply to itself. Migrate all 30 test files to Convention A (runner-visible `spec-id/AC-NN` in subtest titles), wire a `make dogfood-strict` target, and make the strict pipeline part of the gate. Merges to `main` when done with **no version bump, no tag, no CHANGELOG entry** — the work doesn't change CLI behavior, schema, or the extension. Internal infrastructure only.
+Between releases. No working branch open. Per `CONTRIBUTING.md` → Branch workflow, PRs target `main` directly until the v0.11 cycle starts, at which point a new `release/v0.11` branch gets opened and this header is updated to name it.
+
+The `chore/dogfood-strict` maintenance branch merged to `main` on 2026-04-24 (PR #66) — internal-only, no version bump. Specter now dogfoods `specter coverage --strict` on its own tests via `make dogfood-strict`: 15/15 specs mechanically verified across 214 (spec_id, ac_id) pairs from Go + TypeScript test runners.
 
 ---
 

--- a/specter/README.md
+++ b/specter/README.md
@@ -297,9 +297,10 @@ specter/
 ## Development
 
 ```bash
-make check      # go vet + go test + go build — the CI gate
-make dogfood    # run specter against its own specs
-make build-all  # cross-compile for linux/darwin/windows
+make check           # go vet + go test + go build — the CI gate
+make dogfood         # run specter against its own specs (annotation-counting gate)
+make dogfood-strict  # mechanical eval gate: go test -json + jest → specter ingest → coverage --strict
+make build-all       # cross-compile for linux/darwin/windows
 ```
 
 Every package in `internal/` is a pure function — no I/O, no CLI dependencies.

--- a/specter/RELEASING.md
+++ b/specter/RELEASING.md
@@ -24,7 +24,7 @@ CI building the VSIX is not the same as VS Code loading it. The v0.6.5 → v0.6.
 
 ### 3. Reload, then open a known-working test workspace
 
-The `specter/` repo itself is a good choice (14 dogfood specs). The Coverage sidebar should populate with real entries, not the empty-state message.
+The `specter/` repo itself is a good choice (15 dogfood specs as of v0.10.0, after `spec-ingest` was added). The Coverage sidebar should populate with real entries, not the empty-state message.
 
 ### 4. Reload, then open a known-failing test workspace
 


### PR DESCRIPTION
## Summary

Doc-only refresh reflecting current main state. No CLI, schema, or behavior change.

### What

- `BACKLOG.md` header: v0.10.2 shipped to Marketplace 2026-04-24; between-releases state; `chore/dogfood-strict` merged note with end-state.
- `CONTRIBUTING.md`: generic `release/vX.Y.Z` placeholder in PR example + branch diagram (was stuck at `release/v0.10`). Short note on maintenance `chore/<name>` branch convention referencing `chore/dogfood-strict` precedent.
- `specter/RELEASING.md`: 14 → 15 dogfood specs (spec-ingest added in v0.10.0).
- `specter/README.md`: add `make dogfood-strict` to the Development command block.

### Why

All four files had stale state from before v0.10.0 / v0.10.2 / the dogfood-strict merge. The fixes are mechanical; this PR just keeps the tracked docs aligned with what's on main.

Also fixes a process mistake on my part — these updates belong on a branch, not directly on main (branch protection correctly rejected the direct push). This PR is the correct shape for landing them.

## Test plan

- [x] No code changes; `make check` trivially passes
- [x] Diff scope verified: only the 4 files listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)