### PR TITLE
docs(backlog): extract Schema stability policy from stale branch

### DIFF
--- a/specter/BACKLOG.md
+++ b/specter/BACKLOG.md
@@ -184,6 +184,20 @@ Items from the local `docs/IMPROVEMENT_ROADMAP.md` that haven't landed yet:
 
 ---
 
+## Policy decisions (activate when prerequisites ship)
+
+### Schema stability policy
+
+The spec schema is considered **draft during v0.x**. `schema_version: 1` is the placeholder value for pre-1.0 projects — the integer does not move during the v0.x series. Breaking schema changes are allowed under the pre-1.0 "no stability promise" convention, and `specter doctor --fix` absorbs them via inference over drift patterns.
+
+**At Specter v1.0.0**, the then-current schema shape becomes the canonical `schema_version: 1` permanently. Subsequent breaking schema changes bump the integer (`2`, `3`, …) and MUST ship a migration path via `doctor --fix`.
+
+Rationale: Specter is a type system for specs. Schema stability is a user-trust contract, and pre-1.0 is the window to iterate freely before making that contract. `schema_version` lives in `specter.yaml` (project-level), not in every spec file.
+
+**Status**: aspirational. Policy activates when `specter doctor --fix` (currently parked on `feat/doctor-fix`) and the `schema_version` manifest field (parked on `feat/schema-version-manifest`) ship. Candidate for v0.11 scope. Until both ship, this policy describes intent, not enforced behavior. Extracted from the `docs/schema-stability-policy` branch before that branch was deleted.
+
+---
+
 ## Unscheduled — design work needed first
 
 Each needs its own design doc before scheduling:


### PR DESCRIPTION
## Summary

One-commit doc-only PR. Rescues the policy content from `docs/schema-stability-policy` (a pre-v0.10 branch that was never updated; safe to delete after this lands).

## What

Adds a new `Policy decisions (activate when prerequisites ship)` section to `BACKLOG.md`, containing the Schema stability policy text. Marked explicitly as aspirational — it references `specter doctor --fix` and `schema_version` (both unshipped, parked on `feat/doctor-fix` and `feat/schema-version-manifest`).

## Why

The stale branch has drifted too far from main to merge cleanly; its single valuable commit is this policy section. Extraction preserves the content; deletion of the originating branch is a follow-up.

## Test plan

- [x] Docs-only, no code changes; `make check` trivially passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)