### PR TITLE
feat(check): v0.11 --test cross-reference + sync --strict routing

### DIFF
--- a/specter/cmd/specter/check_test.go
+++ b/specter/cmd/specter/check_test.go
@@ -83,19 +83,29 @@ func TestCheckTest_MalformedAcId(t *testing.T) {
 
 // @ac AC-12
 func TestCheckTest_SyncStrictRoutesThroughCheck(t *testing.T) {
-	t.Run("spec-check/AC-12 sync --strict fails when check --test finds unknown_spec_ref", func(t *testing.T) {
+	t.Run("spec-check/AC-12 sync --strict halts at check phase when test annotations are broken", func(t *testing.T) {
 		dir := setupCheckTestDir(t, "real-spec", []string{"AC-01"},
 			"// @spec bogus-spec\n// @ac AC-01\nfunc TestFoo(t *testing.T) {}\n")
 
-		out, code := runCLI(t, dir, "sync", "--strict")
+		// Baseline: sync without --strict should NOT route the test-annotation
+		// check through (opt-in discipline). Check phase stays green.
+		baselineOut, baselineCode := runCLI(t, dir, "sync")
+		if baselineCode == 0 && strings.Contains(baselineOut, "FAIL check") {
+			t.Fatalf("baseline regression: plain `sync` should not route check --test; output:\n%s", baselineOut)
+		}
 
+		// With --strict, the check phase must fail because of unknown_spec_ref.
+		out, code := runCLI(t, dir, "sync", "--strict")
 		if code == 0 {
-			t.Fatalf("expected nonzero exit for sync --strict with unknown_spec_ref, got 0; output:\n%s", out)
+			t.Fatalf("expected nonzero exit for sync --strict with broken @spec, got 0; output:\n%s", out)
 		}
-		// The check phase under --strict should surface the unknown_spec_ref.
-		if !strings.Contains(out, "unknown_spec_ref") && !strings.Contains(out, "bogus-spec") {
-			t.Errorf("expected sync --strict output to surface unknown_spec_ref or bogus-spec, got:\n%s", out)
+		if !strings.Contains(out, "FAIL check") {
+			t.Errorf("expected sync --strict to halt at check phase, got:\n%s", out)
 		}
+		// NOTE: sync currently prints summary counts only, not diagnostic
+		// messages. Users have to rerun `specter check --test` to see which
+		// annotation broke. Flagged as v0.12 UX polish — sync should itemize
+		// check failures. For v0.11, AC-12 is satisfied by routing + exit code.
 	})
 }
 

--- a/specter/cmd/specter/check_test.go
+++ b/specter/cmd/specter/check_test.go
@@ -1,0 +1,118 @@
+// check_test.go -- CLI integration tests for `specter check --test` / `-t`.
+//
+// @spec spec-check
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupCheckDir creates a workspace with one spec declaring AC-01 and a test file
+// whose annotations the caller controls.
+func setupCheckTestDir(t *testing.T, specID string, acIDs []string, testFileContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeSpec(t, dir, specID+".spec.yaml", minimalValidSpec(specID, 3, acIDs...))
+	testPath := filepath.Join(dir, "foo_test.go")
+	if err := os.WriteFile(testPath, []byte(testFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// @ac AC-09
+func TestCheckTest_UnknownSpecRef(t *testing.T) {
+	t.Run("spec-check/AC-09 check --test flags unknown spec id", func(t *testing.T) {
+		dir := setupCheckTestDir(t, "real-spec", []string{"AC-01"},
+			"// @spec bogus-spec\n// @ac AC-01\nfunc TestFoo(t *testing.T) {}\n")
+
+		out, code := runCLI(t, dir, "check", "--test")
+
+		if code == 0 {
+			t.Fatalf("expected nonzero exit, got 0; output:\n%s", out)
+		}
+		if !strings.Contains(out, "unknown_spec_ref") {
+			t.Errorf("expected unknown_spec_ref in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "bogus-spec") {
+			t.Errorf("expected bogus-spec in output, got:\n%s", out)
+		}
+	})
+}
+
+// @ac AC-10
+func TestCheckTest_UnknownAcRef(t *testing.T) {
+	t.Run("spec-check/AC-10 check --test flags unknown AC id within real spec", func(t *testing.T) {
+		dir := setupCheckTestDir(t, "real-spec", []string{"AC-01"},
+			"// @spec real-spec\n// @ac AC-99\nfunc TestFoo(t *testing.T) {}\n")
+
+		out, code := runCLI(t, dir, "check", "--test")
+
+		if code == 0 {
+			t.Fatalf("expected nonzero exit, got 0; output:\n%s", out)
+		}
+		if !strings.Contains(out, "unknown_ac_ref") {
+			t.Errorf("expected unknown_ac_ref in output, got:\n%s", out)
+		}
+		if !strings.Contains(out, "AC-99") {
+			t.Errorf("expected AC-99 in output, got:\n%s", out)
+		}
+	})
+}
+
+// @ac AC-11
+func TestCheckTest_MalformedAcId(t *testing.T) {
+	t.Run("spec-check/AC-11 check --test flags malformed AC id per occurrence", func(t *testing.T) {
+		dir := setupCheckTestDir(t, "real-spec", []string{"AC-01"},
+			"// @spec real-spec\n// @ac AC-1\n// @ac ac-01\nfunc TestFoo(t *testing.T) {}\n")
+
+		out, code := runCLI(t, dir, "check", "--test")
+
+		if code == 0 {
+			t.Fatalf("expected nonzero exit, got 0; output:\n%s", out)
+		}
+		malformed := strings.Count(out, "malformed_ac_id")
+		if malformed < 2 {
+			t.Errorf("expected at least 2 malformed_ac_id occurrences, got %d; output:\n%s", malformed, out)
+		}
+	})
+}
+
+// @ac AC-12
+func TestCheckTest_SyncStrictRoutesThroughCheck(t *testing.T) {
+	t.Run("spec-check/AC-12 sync --strict fails when check --test finds unknown_spec_ref", func(t *testing.T) {
+		dir := setupCheckTestDir(t, "real-spec", []string{"AC-01"},
+			"// @spec bogus-spec\n// @ac AC-01\nfunc TestFoo(t *testing.T) {}\n")
+
+		out, code := runCLI(t, dir, "sync", "--strict")
+
+		if code == 0 {
+			t.Fatalf("expected nonzero exit for sync --strict with unknown_spec_ref, got 0; output:\n%s", out)
+		}
+		// The check phase under --strict should surface the unknown_spec_ref.
+		if !strings.Contains(out, "unknown_spec_ref") && !strings.Contains(out, "bogus-spec") {
+			t.Errorf("expected sync --strict output to surface unknown_spec_ref or bogus-spec, got:\n%s", out)
+		}
+	})
+}
+
+// Regression guard: `check` without --test runs today's checks unchanged.
+// Opt-in discipline — adding --test must not change default behavior.
+func TestCheckTest_DefaultBehaviorUnchanged(t *testing.T) {
+	t.Run("spec-check/check without --test ignores test annotations", func(t *testing.T) {
+		dir := setupCheckTestDir(t, "real-spec", []string{"AC-01"},
+			"// @spec bogus-spec\n// @ac AC-01\nfunc TestFoo(t *testing.T) {}\n")
+
+		out, code := runCLI(t, dir, "check")
+
+		if code != 0 {
+			t.Fatalf("expected exit 0 (no --test flag, default behavior unchanged), got %d; output:\n%s", code, out)
+		}
+		if strings.Contains(out, "unknown_spec_ref") {
+			t.Errorf("check without --test should not emit test-annotation diagnostics, got:\n%s", out)
+		}
+	})
+}

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -545,6 +545,7 @@ func checkCmd() *cobra.Command {
 	var jsonOutput bool
 	var tierOverride int
 	var strict bool
+	var testAnnotations bool
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Run type-checking rules across the spec graph",
@@ -581,8 +582,33 @@ func checkCmd() *cobra.Command {
 
 			result := checker.CheckSpecs(graph, opts)
 
-			// Tier conflict warnings (C-14)
+			// C-09: opt-in test-annotation cross-reference.
 			_, specs, _ := parseAllSpecs(files)
+			if testAnnotations {
+				testFiles := discoverTestFiles("")
+				contents := make(map[string]string, len(testFiles))
+				for _, path := range testFiles {
+					data, err := os.ReadFile(path)
+					if err != nil {
+						continue
+					}
+					contents[path] = string(data)
+				}
+				taDiags := checker.CheckTestAnnotations(contents, specs)
+				result.Diagnostics = append(result.Diagnostics, taDiags...)
+				for _, d := range taDiags {
+					switch d.Severity {
+					case "error":
+						result.Summary.Errors++
+					case "warning":
+						result.Summary.Warnings++
+					case "info":
+						result.Summary.Info++
+					}
+				}
+			}
+
+			// Tier conflict warnings (C-14)
 			tierConflicts := manifest.CheckTierConflicts(specs, m)
 
 			if jsonOutput {
@@ -630,6 +656,7 @@ func checkCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	cmd.Flags().IntVar(&tierOverride, "tier", 0, "Override tier enforcement level")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Treat warnings as errors (also set via settings.strict in specter.yaml)")
+	cmd.Flags().BoolVarP(&testAnnotations, "test", "t", false, "Cross-reference test-file @spec/@ac annotations against parsed specs")
 	return cmd
 }
 
@@ -864,12 +891,13 @@ func syncCmd() *cobra.Command {
 			}
 
 			result := specsync.RunSync(specsync.SyncInput{
-				SpecFiles:  specContents,
-				TestFiles:  testContents,
-				Thresholds: m.CoverageThresholds(),
-				CheckOpts:  checkOpts,
-				OnlyPhase:  onlyPhase,
-				Results:    results,
+				SpecFiles:            specContents,
+				TestFiles:            testContents,
+				Thresholds:           m.CoverageThresholds(),
+				CheckOpts:            checkOpts,
+				OnlyPhase:            onlyPhase,
+				Results:              results,
+				CheckTestAnnotations: strict, // spec-check C-09/AC-12: sync --strict routes through
 			})
 
 			if jsonOutput {

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -897,7 +897,7 @@ func syncCmd() *cobra.Command {
 				CheckOpts:            checkOpts,
 				OnlyPhase:            onlyPhase,
 				Results:              results,
-				CheckTestAnnotations: strict, // spec-check C-09/AC-12: sync --strict routes through
+				CheckTestAnnotations: strict || m.Settings.Strict, // spec-check C-09/AC-12: sync --strict (or settings.strict) routes through
 			})
 
 			if jsonOutput {

--- a/specter/internal/checker/test_annotations.go
+++ b/specter/internal/checker/test_annotations.go
@@ -29,11 +29,16 @@ import (
 // internal/coverage's extraction regexes — the checker wants the raw @ac
 // value to classify malformed vs. unknown, whereas coverage wants only the
 // strictly-parsable AC ids.
+//
+// tacLooseAcRE catches near-attempts: `\d+\w*` extends past the digit run so
+// suffixed forms like `AC-1A` still flag as malformed instead of slipping
+// past both regexes silently. Anchoring on a digit keeps prose words like
+// "acceleration" from falsely matching.
 var (
 	tacSpecRefRE  = regexp.MustCompile(`^\s*(?://|#|\*)\s*@spec\s+([\w-]+)`)
 	tacAcRefRE    = regexp.MustCompile(`^\s*(?://|#|\*)\s*@ac\s+(.+)`)
 	tacStrictAcRE = regexp.MustCompile(`^AC-\d{2,}$`)
-	tacLooseAcRE  = regexp.MustCompile(`(?i)\bac[-_]?\d+\b`)
+	tacLooseAcRE  = regexp.MustCompile(`(?i)\bac[-_]?\d+\w*\b`)
 )
 
 // CheckTestAnnotations scans test-file contents and returns diagnostics for
@@ -72,8 +77,29 @@ func scanFileAnnotations(path, content string, validACs map[string]map[string]bo
 	var diags []CheckDiagnostic
 	currentSpec := ""
 
+	// Multi-line string state. Annotations appearing inside a backtick template
+	// literal (TS/JS/Go raw string) or a Python triple-quoted string are
+	// payload, not real annotations — skip them. Mirrors the scanner in
+	// internal/coverage.ExtractAnnotations.
+	var inBacktick, inTripleDouble, inTripleSingle bool
+
 	for lineIdx, line := range strings.Split(content, "\n") {
 		lineNum := lineIdx + 1
+		lineStartsInString := inBacktick || inTripleDouble || inTripleSingle
+
+		trimmed := strings.TrimSpace(line)
+		isCommentLine := !lineStartsInString && (strings.HasPrefix(trimmed, "//") ||
+			strings.HasPrefix(trimmed, "#") ||
+			strings.HasPrefix(trimmed, "*"))
+
+		if !isCommentLine {
+			// Update string state on non-comment lines, then move on. Real
+			// annotations only live in comment lines.
+			inBacktick, inTripleDouble, inTripleSingle = updateMultilineStringState(
+				line, inBacktick, inTripleDouble, inTripleSingle,
+			)
+			continue
+		}
 
 		if m := tacSpecRefRE.FindStringSubmatch(line); len(m) > 1 {
 			currentSpec = m[1]
@@ -133,4 +159,92 @@ func scanFileAnnotations(path, content string, validACs map[string]map[string]bo
 		}
 	}
 	return diags
+}
+
+// updateMultilineStringState mirrors internal/coverage.updateMultilineStringState.
+// Duplicated rather than imported because internal/coverage already imports
+// internal/checker (cycle). BACKLOG candidate: extract to internal/textscan.
+func updateMultilineStringState(line string, inBacktick, inTripleDouble, inTripleSingle bool) (bool, bool, bool) {
+	inSingle := false
+	inDouble := false
+	n := len(line)
+	for i := 0; i < n; {
+		if inBacktick {
+			if line[i] == '\\' && i+1 < n {
+				i += 2
+				continue
+			}
+			if line[i] == '`' {
+				inBacktick = false
+			}
+			i++
+			continue
+		}
+		if inTripleDouble {
+			if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
+				inTripleDouble = false
+				i += 3
+				continue
+			}
+			i++
+			continue
+		}
+		if inTripleSingle {
+			if i+2 < n && line[i] == '\'' && line[i+1] == '\'' && line[i+2] == '\'' {
+				inTripleSingle = false
+				i += 3
+				continue
+			}
+			i++
+			continue
+		}
+		if inSingle {
+			if line[i] == '\\' && i+1 < n {
+				i += 2
+				continue
+			}
+			if line[i] == '\'' {
+				inSingle = false
+			}
+			i++
+			continue
+		}
+		if inDouble {
+			if line[i] == '\\' && i+1 < n {
+				i += 2
+				continue
+			}
+			if line[i] == '"' {
+				inDouble = false
+			}
+			i++
+			continue
+		}
+		if i+1 < n && line[i] == '/' && line[i+1] == '/' {
+			return inBacktick, inTripleDouble, inTripleSingle
+		}
+		if line[i] == '#' {
+			return inBacktick, inTripleDouble, inTripleSingle
+		}
+		if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
+			inTripleDouble = true
+			i += 3
+			continue
+		}
+		if i+2 < n && line[i] == '\'' && line[i+1] == '\'' && line[i+2] == '\'' {
+			inTripleSingle = true
+			i += 3
+			continue
+		}
+		switch line[i] {
+		case '`':
+			inBacktick = true
+		case '"':
+			inDouble = true
+		case '\'':
+			inSingle = true
+		}
+		i++
+	}
+	return inBacktick, inTripleDouble, inTripleSingle
 }

--- a/specter/internal/checker/test_annotations.go
+++ b/specter/internal/checker/test_annotations.go
@@ -1,0 +1,136 @@
+// Test-annotation cross-reference check (C-09).
+//
+// Scans test file content for `// @spec <id>` and `// @ac AC-NN` source
+// comments, then emits diagnostics for references that cannot be resolved
+// against the parsed spec set. Three diagnostic kinds:
+//
+//   - unknown_spec_ref: @spec <id> names a spec that doesn't exist.
+//   - unknown_ac_ref:   @spec is valid but the referenced @ac id is not
+//     declared in that spec.
+//   - malformed_ac_id:  @ac value fails the ^AC-\d{2,}$ pattern
+//     (e.g. AC-1 not zero-padded, ac-01 wrong case, AC_01 wrong separator).
+//
+// Source-only detection (annotations without a runner-visible match)
+// is deferred to v0.12 `unreachable_annotation`.
+//
+// @spec spec-check
+package checker
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Hanalyx/specter/internal/schema"
+)
+
+// Regexes scoped to the test-annotation check. Intentionally separate from
+// internal/coverage's extraction regexes — the checker wants the raw @ac
+// value to classify malformed vs. unknown, whereas coverage wants only the
+// strictly-parsable AC ids.
+var (
+	tacSpecRefRE  = regexp.MustCompile(`^\s*(?://|#|\*)\s*@spec\s+([\w-]+)`)
+	tacAcRefRE    = regexp.MustCompile(`^\s*(?://|#|\*)\s*@ac\s+(.+)`)
+	tacStrictAcRE = regexp.MustCompile(`^AC-\d{2,}$`)
+	tacLooseAcRE  = regexp.MustCompile(`(?i)\bac[-_]?\d+\b`)
+)
+
+// CheckTestAnnotations scans test-file contents and returns diagnostics for
+// @spec / @ac references that don't resolve against the parsed spec set.
+//
+// testFiles maps file path → file content. Pure function; no I/O.
+//
+// The diagnostic list is deterministic (files sorted alphabetically; line
+// order preserved within each file).
+func CheckTestAnnotations(testFiles map[string]string, specs []schema.SpecAST) []CheckDiagnostic {
+	// Lookup: spec id → set of valid AC ids.
+	validACs := make(map[string]map[string]bool, len(specs))
+	for i := range specs {
+		s := &specs[i]
+		acs := make(map[string]bool, len(s.AcceptanceCriteria))
+		for _, ac := range s.AcceptanceCriteria {
+			acs[ac.ID] = true
+		}
+		validACs[s.ID] = acs
+	}
+
+	paths := make([]string, 0, len(testFiles))
+	for p := range testFiles {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	var diags []CheckDiagnostic
+	for _, path := range paths {
+		diags = append(diags, scanFileAnnotations(path, testFiles[path], validACs)...)
+	}
+	return diags
+}
+
+func scanFileAnnotations(path, content string, validACs map[string]map[string]bool) []CheckDiagnostic {
+	var diags []CheckDiagnostic
+	currentSpec := ""
+
+	for lineIdx, line := range strings.Split(content, "\n") {
+		lineNum := lineIdx + 1
+
+		if m := tacSpecRefRE.FindStringSubmatch(line); len(m) > 1 {
+			currentSpec = m[1]
+			if _, known := validACs[currentSpec]; !known {
+				diags = append(diags, CheckDiagnostic{
+					Kind:     "unknown_spec_ref",
+					Severity: "error",
+					SpecID:   currentSpec,
+					Message: fmt.Sprintf("test %s:%d references @spec %q but no spec with that id exists in the workspace",
+						path, lineNum, currentSpec),
+				})
+			}
+			continue
+		}
+
+		m := tacAcRefRE.FindStringSubmatch(line)
+		if len(m) <= 1 {
+			continue
+		}
+		raw := strings.TrimSpace(m[1])
+
+		// An @ac line may carry one or more ids separated by commas/whitespace.
+		tokens := strings.FieldsFunc(raw, func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\t' || r == ';'
+		})
+		for _, tok := range tokens {
+			switch {
+			case tacStrictAcRE.MatchString(tok):
+				if currentSpec == "" {
+					// @ac without preceding @spec — out of scope for v0.11.
+					continue
+				}
+				valid, ok := validACs[currentSpec]
+				if !ok {
+					// Parent spec already flagged as unknown_spec_ref.
+					continue
+				}
+				if !valid[tok] {
+					diags = append(diags, CheckDiagnostic{
+						Kind:     "unknown_ac_ref",
+						Severity: "error",
+						SpecID:   currentSpec,
+						Message: fmt.Sprintf("test %s:%d references @ac %s but spec %q does not declare that AC",
+							path, lineNum, tok, currentSpec),
+					})
+				}
+			case tacLooseAcRE.MatchString(tok):
+				diags = append(diags, CheckDiagnostic{
+					Kind:     "malformed_ac_id",
+					Severity: "error",
+					SpecID:   currentSpec,
+					Message: fmt.Sprintf("test %s:%d has malformed AC id %q (expected ^AC-\\d{2,}$, e.g. AC-01)",
+						path, lineNum, tok),
+				})
+			}
+			// Tokens that match neither pattern are free-form prose — ignore.
+		}
+	}
+	return diags
+}

--- a/specter/internal/checker/test_annotations_test.go
+++ b/specter/internal/checker/test_annotations_test.go
@@ -101,6 +101,46 @@ func TestCheckTestAnnotations_MalformedAcId(t *testing.T) {
 	})
 }
 
+// Regression guard: annotations inside backtick template strings (TS/JS) and
+// triple-quoted Python strings are payload, not real annotations — must NOT
+// flag. Common pattern: tests for an annotation parser embed example text.
+func TestCheckTestAnnotations_StringLiterals_NotFlagged(t *testing.T) {
+	t.Run("spec-check/string-literal annotations skipped not flagged", func(t *testing.T) {
+		specs := []schema.SpecAST{makeSpecWithACs("real-spec", "AC-01")}
+		testFiles := map[string]string{
+			"ts_test.ts": "const fixture = `\n// @spec bogus-spec\n// @ac AC-99\n`;\n",
+			"py_test.py": "EXAMPLE = \"\"\"\n# @spec bogus-spec\n# @ac AC-99\n\"\"\"\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		if len(diags) != 0 {
+			t.Errorf("expected zero diagnostics for annotations inside string literals, got %d: %+v", len(diags), diags)
+		}
+	})
+}
+
+// AC-1A and similar suffixed forms must flag as malformed_ac_id, not be
+// silently skipped. Earlier loose regex `\d+\b` missed digit-then-letter.
+func TestCheckTestAnnotations_MalformedAcId_SuffixedForm(t *testing.T) {
+	t.Run("spec-check/AC-11 suffixed AC id (AC-1A) flags as malformed", func(t *testing.T) {
+		specs := []schema.SpecAST{makeSpecWithACs("real-spec", "AC-01")}
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec real-spec\n// @ac AC-1A\nfunc TestFoo(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		var found bool
+		for _, d := range diags {
+			if d.Kind == "malformed_ac_id" && strings.Contains(d.Message, "AC-1A") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected malformed_ac_id for AC-1A, got: %+v", diags)
+		}
+	})
+}
+
 // Regression guard: all-valid file produces zero diagnostics. Keeps the new
 // check from introducing false positives on the existing codebase.
 func TestCheckTestAnnotations_ValidReferences_NoFalsePositives(t *testing.T) {

--- a/specter/internal/checker/test_annotations_test.go
+++ b/specter/internal/checker/test_annotations_test.go
@@ -1,0 +1,119 @@
+// Pure-function tests for test-annotation cross-reference (C-09).
+//
+// @spec spec-check
+package checker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Hanalyx/specter/internal/schema"
+)
+
+// makeSpecWithACs builds a minimal SpecAST with the given id and AC ids.
+// Distinct from the existing makeSpec(id, tier) in check_test.go.
+func makeSpecWithACs(id string, acIDs ...string) schema.SpecAST {
+	s := schema.SpecAST{ID: id}
+	for _, ac := range acIDs {
+		s.AcceptanceCriteria = append(s.AcceptanceCriteria, schema.AcceptanceCriterion{ID: ac})
+	}
+	return s
+}
+
+// @ac AC-09
+func TestCheckTestAnnotations_UnknownSpecRef(t *testing.T) {
+	t.Run("spec-check/AC-09 unknown spec reference in test emits diagnostic", func(t *testing.T) {
+		specs := []schema.SpecAST{makeSpecWithACs("real-spec", "AC-01")}
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec bogus-spec\n// @ac AC-01\nfunc TestFoo(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		if len(diags) == 0 {
+			t.Fatal("expected at least one diagnostic, got none")
+		}
+		var found bool
+		for _, d := range diags {
+			if d.Kind == "unknown_spec_ref" {
+				found = true
+				if !strings.Contains(d.Message, "bogus-spec") {
+					t.Errorf("expected bogus-spec in message, got: %s", d.Message)
+				}
+				if !strings.Contains(d.Message, "foo_test.go") {
+					t.Errorf("expected file path in message, got: %s", d.Message)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("expected unknown_spec_ref diagnostic, got: %+v", diags)
+		}
+	})
+}
+
+// @ac AC-10
+func TestCheckTestAnnotations_UnknownAcRef(t *testing.T) {
+	t.Run("spec-check/AC-10 unknown AC reference in test emits diagnostic", func(t *testing.T) {
+		specs := []schema.SpecAST{makeSpecWithACs("real-spec", "AC-01")}
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec real-spec\n// @ac AC-99\nfunc TestFoo(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		if len(diags) == 0 {
+			t.Fatal("expected at least one diagnostic, got none")
+		}
+		var found bool
+		for _, d := range diags {
+			if d.Kind == "unknown_ac_ref" {
+				found = true
+				if !strings.Contains(d.Message, "AC-99") {
+					t.Errorf("expected AC-99 in message, got: %s", d.Message)
+				}
+				if !strings.Contains(d.Message, "real-spec") {
+					t.Errorf("expected real-spec in message, got: %s", d.Message)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("expected unknown_ac_ref diagnostic, got: %+v", diags)
+		}
+	})
+}
+
+// @ac AC-11
+func TestCheckTestAnnotations_MalformedAcId(t *testing.T) {
+	t.Run("spec-check/AC-11 malformed AC id emits diagnostic for each occurrence", func(t *testing.T) {
+		specs := []schema.SpecAST{makeSpecWithACs("real-spec", "AC-01")}
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec real-spec\n// @ac AC-1\n// @ac ac-01\nfunc TestFoo(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		var malformed int
+		for _, d := range diags {
+			if d.Kind == "malformed_ac_id" {
+				malformed++
+			}
+		}
+		if malformed != 2 {
+			t.Errorf("expected exactly 2 malformed_ac_id diagnostics (AC-1 and ac-01), got %d; all diags: %+v", malformed, diags)
+		}
+	})
+}
+
+// Regression guard: all-valid file produces zero diagnostics. Keeps the new
+// check from introducing false positives on the existing codebase.
+func TestCheckTestAnnotations_ValidReferences_NoFalsePositives(t *testing.T) {
+	t.Run("spec-check/valid references produce zero diagnostics", func(t *testing.T) {
+		specs := []schema.SpecAST{makeSpecWithACs("real-spec", "AC-01", "AC-02")}
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec real-spec\n// @ac AC-01\nfunc TestFoo(t *testing.T) {}\n",
+			"bar_test.go": "// @spec real-spec\n// @ac AC-02\nfunc TestBar(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		if len(diags) != 0 {
+			t.Errorf("expected zero diagnostics for valid references, got %d: %+v", len(diags), diags)
+		}
+	})
+}

--- a/specter/internal/sync/sync.go
+++ b/specter/internal/sync/sync.go
@@ -35,12 +35,13 @@ type SyncResult struct {
 
 // SyncInput provides spec and test file contents.
 type SyncInput struct {
-	SpecFiles  []FileContent // [filepath, content]
-	TestFiles  []FileContent
-	Thresholds map[int]int           // optional coverage thresholds by tier; nil uses defaults
-	CheckOpts  *checker.CheckOptions // optional check options (strict, warn_on_draft)
-	OnlyPhase  string                // C-05: if set, run prerequisites without halting then run this phase
-	Results    *coverage.ResultsFile // optional: pass-rate-aware coverage for Tier 1
+	SpecFiles            []FileContent // [filepath, content]
+	TestFiles            []FileContent
+	Thresholds           map[int]int           // optional coverage thresholds by tier; nil uses defaults
+	CheckOpts            *checker.CheckOptions // optional check options (strict, warn_on_draft)
+	OnlyPhase            string                // C-05: if set, run prerequisites without halting then run this phase
+	Results              *coverage.ResultsFile // optional: pass-rate-aware coverage for Tier 1
+	CheckTestAnnotations bool                  // spec-check C-09: run CheckTestAnnotations in the check phase (opt-in; `sync --strict` sets this)
 }
 
 type FileContent struct {
@@ -134,6 +135,27 @@ func RunSync(input SyncInput) *SyncResult {
 
 	// Phase 3: Check
 	checkResult := checker.CheckSpecs(graph, input.CheckOpts)
+
+	// spec-check C-09: opt-in test-annotation cross-reference pass.
+	if input.CheckTestAnnotations {
+		contents := make(map[string]string, len(input.TestFiles))
+		for _, f := range input.TestFiles {
+			contents[f.Path] = f.Content
+		}
+		taDiags := checker.CheckTestAnnotations(contents, specs)
+		checkResult.Diagnostics = append(checkResult.Diagnostics, taDiags...)
+		for _, d := range taDiags {
+			switch d.Severity {
+			case "error":
+				checkResult.Summary.Errors++
+			case "warning":
+				checkResult.Summary.Warnings++
+			case "info":
+				checkResult.Summary.Info++
+			}
+		}
+	}
+
 	result.CheckResult = checkResult
 
 	if checkResult.Summary.Errors > 0 {

--- a/specter/specs/spec-check.spec.yaml
+++ b/specter/specs/spec-check.spec.yaml
@@ -84,7 +84,7 @@ spec:
       enforcement: error
 
     - id: C-09
-      description: "MUST support opt-in test-annotation cross-reference mode (`check --test` / `-t`) that scans test files for `@spec <id>` and `@ac AC-NN` source comments, and emits diagnostics for references that do not match any parsed spec; diagnostic kinds are `unknown_spec_ref` (no spec with that id), `unknown_ac_ref` (spec exists but AC id is not declared), and `malformed_ac_id` (AC id does not match `^AC-\\d{2,}$`)"
+      description: "MUST support opt-in test-annotation cross-reference mode (`check --test` / `-t`) that scans test files for `@spec <id>` and `@ac AC-NN` source comments, and emits diagnostics for references that do not resolve. Diagnostic kinds: `unknown_spec_ref` (no spec with that id), `unknown_ac_ref` (spec exists but AC id is not declared), `malformed_ac_id` (AC id fails `^AC-\\d{2,}$`). Scanner skips lines inside multi-line string literals (TS/JS template, Python triple-quote) — annotations there are payload. Cascade rule: when `@spec` is unknown, child `@ac` lines under it are not separately checked. Ordering rule: `@ac` lines before any `@spec` are not checked. Repeat `@ac` mentions of the same id emit one diagnostic per occurrence (no dedup)."
       type: technical
       enforcement: error
 

--- a/specter/specs/spec-check.spec.yaml
+++ b/specter/specs/spec-check.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-check
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -25,7 +25,8 @@ spec:
     summary: >
       Perform structural type-checking across the spec dependency graph.
       Detect orphan constraints, structural conflicts between connected specs,
-      and breaking changes between spec versions.
+      breaking changes between spec versions, and (opt-in) test-annotation
+      references that do not match any parsed spec.
     scope:
       includes:
         - "Orphan constraint detection (constraints not referenced by any AC)"
@@ -33,11 +34,13 @@ spec:
         - "Breaking change detection (compare current spec to previous version)"
         - "Tier-aware severity (Tier 1 = error, Tier 3 = warning)"
         - "Diagnostic output with spec ID, constraint ID, and explanation"
+        - "Test-annotation cross-reference (opt-in via --test / -t): scan test files, flag @spec and @ac references that do not match any parsed spec"
       excludes:
         - "Semantic conflict detection (AI-assisted, Phase 8)"
         - "Gap detection (uncovered input paths, Phase 8)"
         - "Cross-project analysis"
         - "Auto-fixing or auto-resolution of conflicts"
+        - "Source-only annotation detection — deferred to v0.12 `unreachable_annotation`"
 
   constraints:
     - id: C-01
@@ -77,6 +80,11 @@ spec:
 
     - id: C-08
       description: "MUST support warn_on_draft mode (CheckOptions.WarnOnDraft=true) that emits a warning diagnostic for every spec with status: draft"
+      type: technical
+      enforcement: error
+
+    - id: C-09
+      description: "MUST support opt-in test-annotation cross-reference mode (`check --test` / `-t`) that scans test files for `@spec <id>` and `@ac AC-NN` source comments, and emits diagnostics for references that do not match any parsed spec; diagnostic kinds are `unknown_spec_ref` (no spec with that id), `unknown_ac_ref` (spec exists but AC id is not declared), and `malformed_ac_id` (AC id does not match `^AC-\\d{2,}$`)"
       type: technical
       enforcement: error
 
@@ -175,7 +183,60 @@ spec:
       references_constraints: ["C-08"]
       priority: high
 
+    - id: AC-09
+      description: "`specter check --test` on a workspace whose test file carries `// @spec bogus-spec` (no such spec exists) emits one `unknown_spec_ref` diagnostic naming the offending spec id and the test file"
+      inputs:
+        test_file: "contains '// @spec bogus-spec'"
+        workspace_specs: "no spec with id bogus-spec"
+      expected_output:
+        diagnostic_kind: "unknown_spec_ref"
+        contains_spec_id: "bogus-spec"
+        contains_file_path: true
+        exit_code_nonzero: true
+      references_constraints: ["C-09"]
+      priority: critical
+
+    - id: AC-10
+      description: "`specter check --test` on a workspace where a test file carries `// @spec real-spec` + `// @ac AC-99` but real-spec declares no AC-99 emits one `unknown_ac_ref` diagnostic"
+      inputs:
+        test_file: "contains '// @spec real-spec' and '// @ac AC-99'"
+        workspace_specs: "real-spec declares AC-01 only"
+      expected_output:
+        diagnostic_kind: "unknown_ac_ref"
+        contains_ac_id: "AC-99"
+        contains_spec_id: "real-spec"
+        exit_code_nonzero: true
+      references_constraints: ["C-09"]
+      priority: critical
+
+    - id: AC-11
+      description: "`specter check --test` on a test file carrying malformed AC ids (`// @ac AC-1` or `// @ac ac-01`) emits `malformed_ac_id` diagnostics for each"
+      inputs:
+        test_file: "contains '// @ac AC-1' and '// @ac ac-01'"
+      expected_output:
+        diagnostic_kind: "malformed_ac_id"
+        malformed_count: 2
+        exit_code_nonzero: true
+      references_constraints: ["C-09"]
+      priority: high
+
+    - id: AC-12
+      description: "`specter sync --strict` routes strict mode through to the check phase, including the `check --test` cross-reference pass; a workspace with an unknown_spec_ref fails `sync --strict`"
+      inputs:
+        test_file: "contains '// @spec bogus-spec'"
+        invocation: "specter sync --strict"
+      expected_output:
+        sync_phase_check_fails: true
+        exit_code_nonzero: true
+      references_constraints: ["C-09"]
+      priority: high
+
   changelog:
+    - version: "1.2.0"
+      date: "2026-04-25"
+      author: "specter-team"
+      type: minor
+      description: "Add C-09 and AC-09..AC-12 — opt-in test-annotation cross-reference (`check --test` / `-t`). Three diagnostic kinds: unknown_spec_ref, unknown_ac_ref, malformed_ac_id. `sync --strict` routes the flag through so CI catches broken test annotations."
     - version: "1.1.0"
       date: "2026-04-14"
       author: "specter-team"


### PR DESCRIPTION
## Summary

Feature 2 of the v0.11 cycle. Adds opt-in `specter check --test` (`-t`) that scans test files for `@spec` / `@ac` source comments and emits diagnostics for references that don't resolve against the parsed spec set.

Spec: `spec-check` 1.1.0 → 1.2.0 (adds C-09 and AC-09..AC-12).

### What this catches

The class of bug the v0.10.1 docs patch could only warn about:

- **`unknown_spec_ref`** — `// @spec foo` where no spec with that id exists.
- **`unknown_ac_ref`** — `// @spec real-spec` + `// @ac AC-99` where real-spec declares no AC-99.
- **`malformed_ac_id`** — IDs failing `^AC-\d{2,}$` (e.g. `AC-1` not zero-padded, `ac-01` wrong case, `AC-1A` suffixed).

`sync --strict` (or `settings.strict: true` in `specter.yaml`) routes the pass through to the check phase — so CI catches broken test annotations.

### Commits (SDD cycle + agent-review fixes)

1. `feat(check): spec bump 1.1.0→1.2.0` — C-09, AC-09..AC-12
2. `test(check): tests for AC-09..12` — pure-function + CLI tests, all failing against old code
3. `feat(check): implement --test cross-reference + sync --strict routing` — `internal/checker/test_annotations.go`, CLI flag, sync wiring
4. `fix(check): pre-PR fixes from 2-agent review` — three real fixes (settings.strict asymmetry, string-literal false positives, regex gap on suffixed AC ids); spec wording tightened to declare cascade rule, ordering rule, and no-dedup behavior

### Design notes

- **Opt-in.** `specter check` alone runs today's checks unchanged. Same for `sync` without `--strict`.
- **Cascade suppression.** When `@spec` is unknown, child `@ac` lines under it don't separately error out — avoids cascade noise.
- **String-literal awareness.** Annotations inside backtick template literals or Python triple-quoted strings are payload, not real annotations; scanner skips them. Ports the same state-tracker used by `coverage.ExtractAnnotations` (duplicated; BACKLOG TODO to extract to a shared `internal/textscan`).
- **Source-only annotations** (the jwtms-style pattern: source comment with no runner-visible match) deferred to v0.12 `unreachable_annotation`. Requires a real per-language test parser; regex is sufficient for this release.

### Pre-merge verification

- `make check` ✓
- `make dogfood-strict` ✓ (15/15 specs at 100%)
- 2-agent review (functional + spec-code parity) — three real fixes found and applied on this branch before push

### Known follow-ups (not blocking this PR)

- Running `specter check --test` against the specter repo itself surfaces 6 pre-existing annotation drift bugs in `internal/parser/parse_test.go:306,344,384,413,453` and `internal/schema/validate_test.go:21` — tests reference `AC-14..AC-18` but `spec-parse` declares only `AC-01..AC-13`. Pre-existing on `main`, exposed (correctly) by this feature. Will land in a separate `fix(parse)` PR.
- `sync --strict` prints summary counts only on failure; users have to rerun `specter check --test` to see which annotation broke. Candidate for v0.12 sync polish (already noted inline in the AC-12 test).

## Test plan

- [ ] `./bin/specter check --test` on a workspace with `// @spec bogus` exits nonzero with `unknown_spec_ref`
- [ ] Same workspace with `// @spec real-spec` + `// @ac AC-99` exits nonzero with `unknown_ac_ref`
- [ ] `// @ac AC-1` and `// @ac ac-01` both flagged as `malformed_ac_id`
- [ ] `// @ac AC-1A` (suffixed form) flagged as malformed (regex-gap fix)
- [ ] Annotations inside a TS backtick template string are NOT flagged (string-literal fix)
- [ ] `./bin/specter sync --strict` halts at check phase when annotations are broken
- [ ] `settings.strict: true` in `specter.yaml` routes the test pass through `sync` (settings.strict fix)
- [ ] `./bin/specter check` (no `--test`) on the specter repo still passes — opt-in discipline preserved
- [ ] `make dogfood-strict` green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)