### PR TITLE
feat(init): v0.11 init bundle — install-hook, ai <tool>, pre-push-check

### DIFF
--- a/specter/cmd/specter/init_ai_test.go
+++ b/specter/cmd/specter/init_ai_test.go
@@ -1,0 +1,184 @@
+// CLI integration tests for `specter init --ai <tool>`.
+//
+// @spec spec-manifest
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// @ac AC-30
+func TestInitAIClaude_NoAgentsMd_WritesCLAUDEMd(t *testing.T) {
+	t.Run("spec-manifest/AC-30 --ai claude with no AGENTS.md writes CLAUDE.md inline body", func(t *testing.T) {
+		dir := t.TempDir()
+		_, code := runCLI(t, dir, "init", "--ai", "claude")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		body, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+		if err != nil {
+			t.Fatalf("expected CLAUDE.md, stat err: %v", err)
+		}
+		s := string(body)
+		if !strings.Contains(s, "<!-- specter:begin v1 -->") || !strings.Contains(s, "<!-- specter:end -->") {
+			t.Errorf("expected fenced markers, got:\n%s", s)
+		}
+		if strings.Contains(s, "@AGENTS.md") {
+			t.Errorf("did not expect @AGENTS.md import when AGENTS.md is absent, got:\n%s", s)
+		}
+		if !strings.Contains(s, "specter explain") {
+			t.Errorf("expected inline body referencing specter explain, got:\n%s", s)
+		}
+	})
+}
+
+// @ac AC-31
+func TestInitAICodex_WritesAGENTSMd(t *testing.T) {
+	t.Run("spec-manifest/AC-31 --ai codex writes AGENTS.md", func(t *testing.T) {
+		dir := t.TempDir()
+		_, code := runCLI(t, dir, "init", "--ai", "codex")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		body, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+		if err != nil {
+			t.Fatalf("expected AGENTS.md, stat err: %v", err)
+		}
+		if !strings.Contains(string(body), "<!-- specter:begin v1 -->") {
+			t.Errorf("expected fenced markers, got:\n%s", string(body))
+		}
+	})
+}
+
+// @ac AC-32
+func TestInitAICursor_CreatesNestedDir(t *testing.T) {
+	t.Run("spec-manifest/AC-32 --ai cursor creates .cursor/rules and writes specter.md", func(t *testing.T) {
+		dir := t.TempDir()
+		_, code := runCLI(t, dir, "init", "--ai", "cursor")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		path := filepath.Join(dir, ".cursor", "rules", "specter.md")
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("expected %s, stat err: %v", path, err)
+		}
+		if !strings.Contains(string(body), "<!-- specter:begin v1 -->") {
+			t.Errorf("expected fenced markers, got:\n%s", string(body))
+		}
+	})
+}
+
+// @ac AC-33
+func TestInitAICopilot_CapsAt4KB(t *testing.T) {
+	t.Run("spec-manifest/AC-33 --ai copilot writes ≤4KB body to .github/copilot-instructions.md", func(t *testing.T) {
+		dir := t.TempDir()
+		_, code := runCLI(t, dir, "init", "--ai", "copilot")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		path := filepath.Join(dir, ".github", "copilot-instructions.md")
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("expected %s, stat err: %v", path, err)
+		}
+		if len(body) > 4096 {
+			t.Errorf("expected ≤4096 bytes for copilot, got %d", len(body))
+		}
+	})
+}
+
+// @ac AC-34
+func TestInitAIGemini_WritesGEMINIMd(t *testing.T) {
+	t.Run("spec-manifest/AC-34 --ai gemini writes GEMINI.md", func(t *testing.T) {
+		dir := t.TempDir()
+		_, code := runCLI(t, dir, "init", "--ai", "gemini")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		body, err := os.ReadFile(filepath.Join(dir, "GEMINI.md"))
+		if err != nil {
+			t.Fatalf("expected GEMINI.md, stat err: %v", err)
+		}
+		if !strings.Contains(string(body), "<!-- specter:begin v1 -->") {
+			t.Errorf("expected fenced markers, got:\n%s", string(body))
+		}
+	})
+}
+
+// @ac AC-35
+func TestInitAI_IdempotentReRun_PreservesOutOfFence(t *testing.T) {
+	t.Run("spec-manifest/AC-35 re-running --ai preserves user content outside fence", func(t *testing.T) {
+		dir := t.TempDir()
+
+		_, code := runCLI(t, dir, "init", "--ai", "codex")
+		if code != 0 {
+			t.Fatalf("first run expected exit 0, got %d", code)
+		}
+		path := filepath.Join(dir, "AGENTS.md")
+
+		original, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		userPrefix := "# Project notes from the user\n\nLorem ipsum.\n\n"
+		userSuffix := "\n\n## Trailing user content\n\nMore notes.\n"
+		modified := []byte(userPrefix + string(original) + userSuffix)
+		if err := os.WriteFile(path, modified, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, code = runCLI(t, dir, "init", "--ai", "codex")
+		if code != 0 {
+			t.Fatalf("re-run expected exit 0, got %d", code)
+		}
+
+		final, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(final), userPrefix) {
+			t.Errorf("expected pre-fence user prefix preserved, got:\n%s", string(final))
+		}
+		if !strings.Contains(string(final), userSuffix) {
+			t.Errorf("expected post-fence user suffix preserved, got:\n%s", string(final))
+		}
+	})
+}
+
+// @ac AC-36
+func TestInitAIClaude_WithAgentsMd_UsesImport(t *testing.T) {
+	t.Run("spec-manifest/AC-36 --ai claude with existing AGENTS.md uses @AGENTS.md import", func(t *testing.T) {
+		dir := t.TempDir()
+		// Pre-create AGENTS.md.
+		if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# pre-existing agents file\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, code := runCLI(t, dir, "init", "--ai", "claude")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		body, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(body)
+		if !strings.Contains(s, "@AGENTS.md") {
+			t.Errorf("expected @AGENTS.md import when AGENTS.md exists, got:\n%s", s)
+		}
+		// Should NOT inline the full preflight body.
+		if strings.Contains(s, "specter explain <spec-id>") {
+			t.Errorf("did not expect inline preflight body when AGENTS.md handles it, got:\n%s", s)
+		}
+	})
+}

--- a/specter/cmd/specter/init_hook_test.go
+++ b/specter/cmd/specter/init_hook_test.go
@@ -1,0 +1,106 @@
+// CLI integration tests for `specter init --install-hook`.
+//
+// @spec spec-manifest
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupHookDir creates a temp dir with a .git/hooks/ subdirectory so the hook
+// installer has a target to write to. Mirrors the structure of a real git repo
+// without spinning one up — sufficient for AC-27 file-level checks.
+func setupHookDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// @ac AC-27
+func TestInitInstallHook_WritesExecutableFile(t *testing.T) {
+	t.Run("spec-manifest/AC-27 init --install-hook writes executable .git/hooks/pre-push", func(t *testing.T) {
+		dir := setupHookDir(t)
+
+		_, code := runCLI(t, dir, "init", "--install-hook")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		hookPath := filepath.Join(dir, ".git", "hooks", "pre-push")
+		info, err := os.Stat(hookPath)
+		if err != nil {
+			t.Fatalf("expected hook at %s, stat err: %v", hookPath, err)
+		}
+		if info.Mode()&0111 == 0 {
+			t.Errorf("expected hook to be executable (mode 0755), got mode %v", info.Mode())
+		}
+	})
+}
+
+// @ac AC-27
+func TestInitInstallHook_FencedMarkersPresent(t *testing.T) {
+	t.Run("spec-manifest/AC-27 hook content wrapped in specter:begin/end markers", func(t *testing.T) {
+		dir := setupHookDir(t)
+
+		_, code := runCLI(t, dir, "init", "--install-hook")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		hookPath := filepath.Join(dir, ".git", "hooks", "pre-push")
+		data, err := os.ReadFile(hookPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := string(data)
+		if !strings.Contains(body, "<!-- specter:begin v1 -->") {
+			t.Errorf("expected begin marker, got:\n%s", body)
+		}
+		if !strings.Contains(body, "<!-- specter:end -->") {
+			t.Errorf("expected end marker, got:\n%s", body)
+		}
+	})
+}
+
+// @ac AC-27
+func TestInitInstallHook_IdempotentReRun_PreservesOutOfFence(t *testing.T) {
+	t.Run("spec-manifest/AC-27 re-running --install-hook preserves user content outside fence", func(t *testing.T) {
+		dir := setupHookDir(t)
+
+		_, code := runCLI(t, dir, "init", "--install-hook")
+		if code != 0 {
+			t.Fatalf("first run expected exit 0, got %d", code)
+		}
+		hookPath := filepath.Join(dir, ".git", "hooks", "pre-push")
+
+		// Append user-authored content after the fence.
+		original, err := os.ReadFile(hookPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		userMarker := "\n# user-authored hook content\nrunning_extra_check"
+		if err := os.WriteFile(hookPath, append(original, []byte(userMarker)...), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Re-run.
+		_, code = runCLI(t, dir, "init", "--install-hook")
+		if code != 0 {
+			t.Fatalf("re-run expected exit 0, got %d", code)
+		}
+
+		final, err := os.ReadFile(hookPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(final), userMarker) {
+			t.Errorf("expected user-authored content preserved across re-run, got:\n%s", string(final))
+		}
+	})
+}

--- a/specter/cmd/specter/init_hook_test.go
+++ b/specter/cmd/specter/init_hook_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -44,8 +45,31 @@ func TestInitInstallHook_WritesExecutableFile(t *testing.T) {
 }
 
 // @ac AC-27
+func TestInitInstallHook_HookParsesAsValidShell(t *testing.T) {
+	t.Run("spec-manifest/AC-27 installed hook parses cleanly under sh -n", func(t *testing.T) {
+		dir := setupHookDir(t)
+
+		_, code := runCLI(t, dir, "init", "--install-hook")
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		hookPath := filepath.Join(dir, ".git", "hooks", "pre-push")
+		// Run `sh -n <hook>` to verify shell parses without executing.
+		// This regression-guards against the v0.11 blocker where HTML-comment
+		// markers (`<!--`) were used in the hook script body, parsing as a
+		// `<` redirection and breaking every push with a syntax error.
+		cmd := exec.Command("sh", "-n", hookPath)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("hook is not valid shell — sh -n failed: %v\noutput: %s", err, string(out))
+		}
+	})
+}
+
+// @ac AC-27
 func TestInitInstallHook_FencedMarkersPresent(t *testing.T) {
-	t.Run("spec-manifest/AC-27 hook content wrapped in specter:begin/end markers", func(t *testing.T) {
+	t.Run("spec-manifest/AC-27 hook content wrapped in shell-comment markers", func(t *testing.T) {
 		dir := setupHookDir(t)
 
 		_, code := runCLI(t, dir, "init", "--install-hook")
@@ -59,11 +83,15 @@ func TestInitInstallHook_FencedMarkersPresent(t *testing.T) {
 			t.Fatal(err)
 		}
 		body := string(data)
-		if !strings.Contains(body, "<!-- specter:begin v1 -->") {
-			t.Errorf("expected begin marker, got:\n%s", body)
+		if !strings.Contains(body, "# specter:begin v1") {
+			t.Errorf("expected shell-comment begin marker, got:\n%s", body)
 		}
-		if !strings.Contains(body, "<!-- specter:end -->") {
-			t.Errorf("expected end marker, got:\n%s", body)
+		if !strings.Contains(body, "# specter:end") {
+			t.Errorf("expected shell-comment end marker, got:\n%s", body)
+		}
+		// HTML-comment markers must NOT be present — invalid shell syntax.
+		if strings.Contains(body, "<!--") {
+			t.Errorf("hook must not contain HTML-comment markers (invalid in sh), got:\n%s", body)
 		}
 	})
 }

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -1205,6 +1205,14 @@ func initCmd() *cobra.Command {
 		Short: "Initialize a specter.yaml project manifest",
 		Long:  "Scaffold a specter.yaml file from existing .spec.yaml files in the current directory. Groups all specs into a default domain with sensible settings.\n\nWith --template, creates a draft .spec.yaml file instead of specter.yaml.\n\nWith --refresh, updates only domains.default.specs in an existing manifest; preserves every other field.\n\nWith --install-hook, writes a git pre-push hook that blocks pushes lacking @spec/@ac annotation deltas.\n\nWith --ai <tool>, writes an AI assistant instruction file for the given tool (claude, codex, cursor, copilot, gemini).",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// --install-hook and --ai are different write targets; combining
+			// them silently would skip the second flag (early return). Reject
+			// the combination explicitly so users see the conflict.
+			if installHook && aiTool != "" {
+				fmt.Fprintln(os.Stderr, "error: --install-hook and --ai are different write targets and cannot be combined; run them in separate invocations.")
+				return errSilent
+			}
+
 			// --install-hook: write the git pre-push hook.
 			if installHook {
 				return runInitInstallHook()
@@ -1338,9 +1346,11 @@ func runInitInstallHook() error {
 
 	// PrePushHookScript() returns the full fenced template (shebang + markers
 	// + body). Extract the body so ReplaceFencedRegion adds exactly one set
-	// of markers around it.
-	hookBody := extractFencedBody(manifest.PrePushHookScript())
-	body, err := manifest.ReplaceFencedRegion(existing, "v1", hookBody)
+	// of markers around it. Hook uses shell-comment markers — HTML-comment
+	// markers would be a syntax error in sh.
+	hookMarkers := manifest.ShellMarkers("v1")
+	hookBody := extractFencedBody(manifest.PrePushHookScript(), hookMarkers)
+	body, err := manifest.ReplaceFencedRegion(existing, hookMarkers, hookBody)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error rendering hook: %v\n", err)
 		return errSilent
@@ -1399,9 +1409,11 @@ func runInitAI(tool string) error {
 		existing = string(data)
 	}
 	// Extract the body from the freshly-rendered template (which is fully
-	// fenced) and apply it via ReplaceFencedRegion to the existing file.
-	body := extractFencedBody(rendered)
-	final, err := manifest.ReplaceFencedRegion(existing, "v1", body)
+	// fenced with markdown markers) and apply it via ReplaceFencedRegion to
+	// the existing file.
+	mdMarkers := manifest.MarkdownMarkers("v1")
+	body := extractFencedBody(rendered, mdMarkers)
+	final, err := manifest.ReplaceFencedRegion(existing, mdMarkers, body)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		return errSilent
@@ -1431,15 +1443,13 @@ func runInitAI(tool string) error {
 // stripping the begin/end markers so the body can be re-applied via
 // ReplaceFencedRegion to a target that may already have its own out-of-fence
 // content.
-func extractFencedBody(fenced string) string {
-	const begin = "<!-- specter:begin v1 -->"
-	const end = "<!-- specter:end -->"
-	bIdx := strings.Index(fenced, begin)
-	eIdx := strings.Index(fenced, end)
+func extractFencedBody(fenced string, markers manifest.FencedMarkers) string {
+	bIdx := strings.Index(fenced, markers.Begin)
+	eIdx := strings.Index(fenced, markers.End)
 	if bIdx < 0 || eIdx < 0 || eIdx < bIdx {
 		return fenced
 	}
-	body := fenced[bIdx+len(begin) : eIdx]
+	body := fenced[bIdx+len(markers.Begin) : eIdx]
 	return strings.Trim(body, "\n")
 }
 

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -1329,8 +1329,24 @@ func initCmd() *cobra.Command {
 // fenced region so re-runs replace only the Specter-managed body.
 func runInitInstallHook() error {
 	hookDir := filepath.Join(".git", "hooks")
-	if _, err := os.Stat(".git"); err != nil {
-		fmt.Fprintln(os.Stderr, "error: .git directory not found. Run `specter init --install-hook` from a git repository root.")
+	// Use Lstat (not Stat) so a symlinked `.git` is detected. A workspace
+	// where `.git` is a symlink to an attacker-chosen path could redirect
+	// the hook write to that path, dropping mode-0755 attacker-controlled
+	// shell into an arbitrary location. Refuse to write through symlinks.
+	info, err := os.Lstat(".git")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error: .git not found. Run `specter init --install-hook` from a git repository root.")
+		return errSilent
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		fmt.Fprintln(os.Stderr, "error: .git is a symlink; refusing to install hook through a symlink. Resolve the link or run from the actual repository root.")
+		return errSilent
+	}
+	if !info.IsDir() {
+		// `.git` can be a regular file in worktrees (it contains `gitdir: <path>`).
+		// Worktree support is intentionally out of scope for the v0.11 hook
+		// installer — refuse rather than guess, with a clear pointer.
+		fmt.Fprintln(os.Stderr, "error: .git is not a directory (looks like a git worktree); install the hook from the primary working tree.")
 		return errSilent
 	}
 	if err := os.MkdirAll(hookDir, 0755); err != nil {

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -176,6 +176,7 @@ func main() {
 	root.AddCommand(diffCmd())
 	root.AddCommand(ingestCmd())
 	root.AddCommand(feedbackCmd())
+	root.AddCommand(prePushCheckCmd())
 
 	if err := root.Execute(); err != nil {
 		// errSilent is our sentinel for "command already printed diagnostics

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -1190,18 +1190,30 @@ func loadManifest() (*manifest.Manifest, string) {
 
 func initCmd() *cobra.Command {
 	var (
-		name     string
-		force    bool
-		template string
-		refresh  bool
-		dryRun   bool
+		name        string
+		force       bool
+		template    string
+		refresh     bool
+		dryRun      bool
+		installHook bool
+		aiTool      string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize a specter.yaml project manifest",
-		Long:  "Scaffold a specter.yaml file from existing .spec.yaml files in the current directory. Groups all specs into a default domain with sensible settings.\n\nWith --template, creates a draft .spec.yaml file instead of specter.yaml.\n\nWith --refresh, updates only domains.default.specs in an existing manifest; preserves every other field.",
+		Long:  "Scaffold a specter.yaml file from existing .spec.yaml files in the current directory. Groups all specs into a default domain with sensible settings.\n\nWith --template, creates a draft .spec.yaml file instead of specter.yaml.\n\nWith --refresh, updates only domains.default.specs in an existing manifest; preserves every other field.\n\nWith --install-hook, writes a git pre-push hook that blocks pushes lacking @spec/@ac annotation deltas.\n\nWith --ai <tool>, writes an AI assistant instruction file for the given tool (claude, codex, cursor, copilot, gemini).",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// --install-hook: write the git pre-push hook.
+			if installHook {
+				return runInitInstallHook()
+			}
+
+			// --ai <tool>: write the per-tool AI instruction file.
+			if aiTool != "" {
+				return runInitAI(aiTool)
+			}
+
 			// --template: create a spec file, not specter.yaml
 			if template != "" {
 				return runInitTemplate(template, force)
@@ -1297,8 +1309,137 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringVar(&template, "template", "", "Create a spec file from a template (api-endpoint, service, auth, data-model)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Update domains.default.specs in an existing specter.yaml from the current on-disk spec list; preserves all other fields")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "With --refresh, print the proposed change to stdout without writing the file")
+	cmd.Flags().BoolVar(&installHook, "install-hook", false, "Install a git pre-push hook that blocks pushes lacking @spec/@ac annotation deltas")
+	cmd.Flags().StringVar(&aiTool, "ai", "", "Write an AI assistant instruction file for the named tool (claude, codex, cursor, copilot, gemini)")
 
 	return cmd
+}
+
+// runInitInstallHook implements `specter init --install-hook` (C-22 / AC-27..29).
+// Writes .git/hooks/pre-push with mode 0755, wrapping the hook script in a
+// fenced region so re-runs replace only the Specter-managed body.
+func runInitInstallHook() error {
+	hookDir := filepath.Join(".git", "hooks")
+	if _, err := os.Stat(".git"); err != nil {
+		fmt.Fprintln(os.Stderr, "error: .git directory not found. Run `specter init --install-hook` from a git repository root.")
+		return errSilent
+	}
+	if err := os.MkdirAll(hookDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "error creating %s: %v\n", hookDir, err)
+		return errSilent
+	}
+
+	hookPath := filepath.Join(hookDir, "pre-push")
+	existing := ""
+	if data, err := os.ReadFile(hookPath); err == nil {
+		existing = string(data)
+	}
+
+	// PrePushHookScript() returns the full fenced template (shebang + markers
+	// + body). Extract the body so ReplaceFencedRegion adds exactly one set
+	// of markers around it.
+	hookBody := extractFencedBody(manifest.PrePushHookScript())
+	body, err := manifest.ReplaceFencedRegion(existing, "v1", hookBody)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error rendering hook: %v\n", err)
+		return errSilent
+	}
+	// Ensure the file starts with a shebang. ReplaceFencedRegion preserves
+	// out-of-fence content, so a previously-written shebang survives; if
+	// existing was empty we need to prepend.
+	if !strings.HasPrefix(body, "#!") {
+		body = "#!/bin/sh\n" + body
+	}
+
+	if err := os.WriteFile(hookPath, []byte(body), 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing %s: %v\n", hookPath, err)
+		return errSilent
+	}
+	// WriteFile preserves the requested mode on creation but not on overwrite
+	// of an existing file — chmod explicitly to ensure executable.
+	if err := os.Chmod(hookPath, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "error chmod %s: %v\n", hookPath, err)
+		return errSilent
+	}
+
+	fmt.Printf("Installed git pre-push hook at %s\n", hookPath)
+	fmt.Println("Hook blocks pushes that change implementation files without @spec/@ac annotation deltas.")
+	fmt.Println("Bypass with: git push --no-verify")
+	return nil
+}
+
+// runInitAI implements `specter init --ai <tool>` (C-23 / AC-30..36).
+// Writes the per-tool instruction file with the v0.11 fenced template.
+func runInitAI(tool string) error {
+	target, err := manifest.AITargetPath(tool)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return errSilent
+	}
+
+	// AC-36: claude with existing AGENTS.md uses @AGENTS.md import instead of inlining.
+	hasAgentsMd := false
+	if tool == "claude" {
+		if _, err := os.Stat("AGENTS.md"); err == nil {
+			hasAgentsMd = true
+		}
+	}
+
+	rendered, err := manifest.RenderAIInstructions(tool, hasAgentsMd)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return errSilent
+	}
+
+	// If the target already exists, replace only the fenced region; preserve
+	// out-of-fence content byte-for-byte (AC-35).
+	existing := ""
+	if data, err := os.ReadFile(target); err == nil {
+		existing = string(data)
+	}
+	// Extract the body from the freshly-rendered template (which is fully
+	// fenced) and apply it via ReplaceFencedRegion to the existing file.
+	body := extractFencedBody(rendered)
+	final, err := manifest.ReplaceFencedRegion(existing, "v1", body)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return errSilent
+	}
+
+	// Create parent dir if needed (AC-32 / AC-33).
+	if dir := filepath.Dir(target); dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "error creating %s: %v\n", dir, err)
+			return errSilent
+		}
+	}
+
+	if err := os.WriteFile(target, []byte(final), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing %s: %v\n", target, err)
+		return errSilent
+	}
+
+	fmt.Printf("Wrote %s instruction file at %s (%d bytes)\n", tool, target, len(final))
+	if tool == "claude" && hasAgentsMd {
+		fmt.Println("Detected existing AGENTS.md — CLAUDE.md uses @AGENTS.md import to avoid duplicating the template.")
+	}
+	return nil
+}
+
+// extractFencedBody pulls the in-fence body out of a freshly-rendered template,
+// stripping the begin/end markers so the body can be re-applied via
+// ReplaceFencedRegion to a target that may already have its own out-of-fence
+// content.
+func extractFencedBody(fenced string) string {
+	const begin = "<!-- specter:begin v1 -->"
+	const end = "<!-- specter:end -->"
+	bIdx := strings.Index(fenced, begin)
+	eIdx := strings.Index(fenced, end)
+	if bIdx < 0 || eIdx < 0 || eIdx < bIdx {
+		return fenced
+	}
+	body := fenced[bIdx+len(begin) : eIdx]
+	return strings.Trim(body, "\n")
 }
 
 // runInitRefresh implements `specter init --refresh` (C-17 through C-21).

--- a/specter/cmd/specter/prepush.go
+++ b/specter/cmd/specter/prepush.go
@@ -1,0 +1,116 @@
+// `specter pre-push-check` — internal subcommand invoked by the git
+// pre-push hook installed via `specter init --install-hook`. Reads git's
+// pre-push stdin format, runs `git diff` for each ref, and exits non-zero
+// when ShouldBlockPush returns true.
+//
+// Hidden from `specter --help` because users don't invoke it directly.
+//
+// @spec spec-manifest
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Hanalyx/specter/internal/manifest"
+	"github.com/spf13/cobra"
+)
+
+func prePushCheckCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "pre-push-check",
+		Short:  "Internal: read git pre-push stdin and decide whether to block",
+		Long:   "Invoked by the git pre-push hook installed via `specter init --install-hook`. Not intended for direct use.",
+		Hidden: true,
+		Args:   cobra.ArbitraryArgs, // git passes hook args; we don't use them
+		RunE: func(cmd *cobra.Command, args []string) error {
+			specs, err := manifest.ParsePushSpecs(os.Stdin)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "specter pre-push-check:", err)
+				return errSilent
+			}
+			if len(specs) == 0 {
+				return nil
+			}
+
+			for _, p := range specs {
+				// Skip deleted-branch refs (no impl change to evaluate).
+				if p.LocalSha == manifest.ZeroSha {
+					continue
+				}
+
+				base := pickDiffBase(p)
+				if base == "" {
+					// Couldn't determine a base — skip rather than block.
+					// Common case: brand-new branch with no merge-base
+					// against any remote ref. The next push (after the
+					// branch lands) will have a real base.
+					continue
+				}
+
+				files, err := gitDiffFilenames(base, p.LocalSha)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "specter pre-push-check: git diff --name-only %s..%s: %v\n", base, p.LocalSha, err)
+					continue
+				}
+				diff, err := gitDiffUnified(base, p.LocalSha)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "specter pre-push-check: git diff %s..%s: %v\n", base, p.LocalSha, err)
+					continue
+				}
+
+				summary := manifest.SummarizePushDiff(files, diff)
+				if manifest.ShouldBlockPush(summary) {
+					fmt.Fprint(os.Stderr, manifest.FormatBlockedPushMessage(summary))
+					return errSilent
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// pickDiffBase chooses the commit-range base for one pushed ref. For an
+// existing remote ref, base = remote sha. For a new branch (remote sha is
+// ZeroSha), use the merge-base against `origin/HEAD` if available, else
+// skip (return ""). Skipping is safer than blocking on first push — there's
+// no "before" to compare against.
+func pickDiffBase(p manifest.PushSpec) string {
+	if p.RemoteSha != manifest.ZeroSha {
+		return p.RemoteSha
+	}
+	// New branch — try merge-base against origin/HEAD.
+	out, err := exec.Command("git", "merge-base", p.LocalSha, "origin/HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitDiffFilenames returns the list of changed file paths between base and head.
+func gitDiffFilenames(base, head string) ([]string, error) {
+	out, err := exec.Command("git", "diff", "--name-only", base+".."+head).Output()
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+// gitDiffUnified returns the unified-diff output between base and head.
+// `-U0` keeps the diff small (no surrounding context); we only care about
+// added/removed annotation lines.
+func gitDiffUnified(base, head string) (string, error) {
+	out, err := exec.Command("git", "diff", "-U0", base+".."+head).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/specter/cmd/specter/prepush_test.go
+++ b/specter/cmd/specter/prepush_test.go
@@ -1,0 +1,158 @@
+// CLI integration tests for `specter pre-push-check`.
+//
+// @spec spec-manifest
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFileAt(dir, name, content string) error {
+	return os.WriteFile(filepath.Join(dir, name), []byte(content), 0644)
+}
+
+// runGitInDir runs a git command in dir and returns stdout. Fatals on error.
+func runGitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// setupGitRepo creates a fresh git repo in t.TempDir(), seeds it with one
+// commit, and returns the repo path.
+func setupBareGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	runGitInDir(t, dir, "init", "--initial-branch=main")
+	runGitInDir(t, dir, "config", "user.email", "test@example.com")
+	runGitInDir(t, dir, "config", "user.name", "Test User")
+	runGitInDir(t, dir, "config", "commit.gpgsign", "false")
+
+	// Initial commit so HEAD is valid.
+	if err := writeFileAt(dir, "README.md", "# initial\n"); err != nil {
+		t.Fatal(err)
+	}
+	runGitInDir(t, dir, "add", "README.md")
+	runGitInDir(t, dir, "commit", "-m", "initial")
+
+	return dir
+}
+
+// runCLIWithStdin runs the specter binary with the given stdin and args from
+// the given dir. Returns stdout+stderr combined and exit code.
+func runCLIWithStdin(t *testing.T, dir, stdin string, args ...string) (string, int) {
+	t.Helper()
+	bin, err := filepath.Abs(filepath.Join("..", "..", "bin", "specter"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("unexpected exec error: %v", err)
+	}
+	return string(out), code
+}
+
+// @ac AC-28
+func TestPrePushCheck_ImplOnlyDiff_Blocks(t *testing.T) {
+	t.Run("spec-manifest/AC-28 pre-push-check blocks push with impl-only diff", func(t *testing.T) {
+		dir := setupBareGitRepo(t)
+		baseSha := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+		// Add an impl change with no @spec/@ac annotation.
+		if err := writeFileAt(dir, "foo.go", "package main\nfunc bar() {}\n"); err != nil {
+			t.Fatal(err)
+		}
+		runGitInDir(t, dir, "add", "foo.go")
+		runGitInDir(t, dir, "commit", "-m", "add foo")
+		headSha := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+		stdin := fmt.Sprintf("refs/heads/main %s refs/heads/main %s\n", headSha, baseSha)
+		out, code := runCLIWithStdin(t, dir, stdin, "pre-push-check")
+
+		if code == 0 {
+			t.Fatalf("expected nonzero exit for impl-only diff, got 0; output:\n%s", out)
+		}
+		if !strings.Contains(out, "push blocked") && !strings.Contains(out, "annotation") {
+			t.Errorf("expected blocked-push diagnostic in output, got:\n%s", out)
+		}
+	})
+}
+
+// @ac AC-28
+func TestPrePushCheck_AnnotationDelta_Allows(t *testing.T) {
+	t.Run("spec-manifest/AC-28 pre-push-check allows push when annotation delta present", func(t *testing.T) {
+		dir := setupBareGitRepo(t)
+		baseSha := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+		if err := writeFileAt(dir, "foo.go", "package main\nfunc bar() {}\n"); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeFileAt(dir, "foo_test.go", "package main\n\n// @spec spec-foo\n// @ac AC-01\nfunc TestBar(t *testing.T) {}\n"); err != nil {
+			t.Fatal(err)
+		}
+		runGitInDir(t, dir, "add", ".")
+		runGitInDir(t, dir, "commit", "-m", "add foo + test")
+		headSha := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+		stdin := fmt.Sprintf("refs/heads/main %s refs/heads/main %s\n", headSha, baseSha)
+		out, code := runCLIWithStdin(t, dir, stdin, "pre-push-check")
+
+		if code != 0 {
+			t.Fatalf("expected exit 0 for impl + annotation delta, got %d; output:\n%s", code, out)
+		}
+	})
+}
+
+// @ac AC-28
+func TestPrePushCheck_DocsOnly_Allows(t *testing.T) {
+	t.Run("spec-manifest/AC-28 pre-push-check allows docs-only diff", func(t *testing.T) {
+		dir := setupBareGitRepo(t)
+		baseSha := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+		if err := writeFileAt(dir, "NOTES.md", "# notes\n"); err != nil {
+			t.Fatal(err)
+		}
+		runGitInDir(t, dir, "add", "NOTES.md")
+		runGitInDir(t, dir, "commit", "-m", "add notes")
+		headSha := runGitInDir(t, dir, "rev-parse", "HEAD")
+
+		stdin := fmt.Sprintf("refs/heads/main %s refs/heads/main %s\n", headSha, baseSha)
+		_, code := runCLIWithStdin(t, dir, stdin, "pre-push-check")
+
+		if code != 0 {
+			t.Errorf("expected exit 0 for docs-only diff, got %d", code)
+		}
+	})
+}
+
+// @ac AC-28
+func TestPrePushCheck_DeletedBranch_Allows(t *testing.T) {
+	t.Run("spec-manifest/AC-28 pre-push-check skips deleted-branch refs", func(t *testing.T) {
+		dir := setupBareGitRepo(t)
+		// Deleted branch: local sha = ZeroSha. Nothing to inspect.
+		stdin := "refs/heads/gone 0000000000000000000000000000000000000000 refs/heads/gone abc\n"
+		_, code := runCLIWithStdin(t, dir, stdin, "pre-push-check")
+
+		if code != 0 {
+			t.Errorf("expected exit 0 for deleted-branch ref, got %d", code)
+		}
+	})
+}

--- a/specter/cmd/specter/prepush_test.go
+++ b/specter/cmd/specter/prepush_test.go
@@ -49,16 +49,17 @@ func setupBareGitRepo(t *testing.T) string {
 	return dir
 }
 
-// runCLIWithStdin runs the specter binary with the given stdin and args from
-// the given dir. Returns stdout+stderr combined and exit code.
+// runCLIWithStdin runs the specter CLI with the given stdin and args from
+// the given dir. Uses the self-invocation pattern (see cli_test.go's runCLI):
+// re-invokes the test binary with SPECTER_TEST=1 so the test process acts
+// as the CLI. This avoids needing a pre-built ./bin/specter at test time —
+// CI runs `go test` before `go build`, so a hardcoded path to the built
+// binary fails with "no such file or directory".
 func runCLIWithStdin(t *testing.T, dir, stdin string, args ...string) (string, int) {
 	t.Helper()
-	bin, err := filepath.Abs(filepath.Join("..", "..", "bin", "specter"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	cmd := exec.Command(bin, args...)
+	cmd := exec.Command(os.Args[0], args...)
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "SPECTER_TEST=1")
 	cmd.Stdin = strings.NewReader(stdin)
 	out, err := cmd.CombinedOutput()
 	code := 0

--- a/specter/cmd/specter/prepush_test.go
+++ b/specter/cmd/specter/prepush_test.go
@@ -148,7 +148,7 @@ func TestPrePushCheck_DeletedBranch_Allows(t *testing.T) {
 	t.Run("spec-manifest/AC-28 pre-push-check skips deleted-branch refs", func(t *testing.T) {
 		dir := setupBareGitRepo(t)
 		// Deleted branch: local sha = ZeroSha. Nothing to inspect.
-		stdin := "refs/heads/gone 0000000000000000000000000000000000000000 refs/heads/gone abc\n"
+		stdin := "refs/heads/gone 0000000000000000000000000000000000000000 refs/heads/gone aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
 		_, code := runCLIWithStdin(t, dir, stdin, "pre-push-check")
 
 		if code != 0 {

--- a/specter/internal/manifest/ai_templates.go
+++ b/specter/internal/manifest/ai_templates.go
@@ -151,9 +151,18 @@ func aiClaudeImportBody() string {
 canonical project preflight, Convention A examples, and validation gate.)`
 }
 
+// CopilotMaxBytes is the hard cap on the rendered Copilot instruction file.
+// Copilot's code-review surface reads only the first 4KB of its instructions
+// file; anything beyond is silently dropped, including load-bearing rules.
+const CopilotMaxBytes = 4096
+
 // RenderAIInstructions returns the full fenced-region body for one tool.
 // hasAgentsMd is consulted only for tool="claude" (AC-36): present means
 // emit the @AGENTS.md import; absent means inline the full body.
+//
+// AC-33 guard: if the rendered copilot body exceeds CopilotMaxBytes, this
+// function returns an error rather than silently shipping a truncated file.
+// Future template growth must be paired with copilot-specific trimming.
 func RenderAIInstructions(tool string, hasAgentsMd bool) (string, error) {
 	if _, err := AITargetPath(tool); err != nil {
 		return "", err
@@ -169,5 +178,12 @@ func RenderAIInstructions(tool string, hasAgentsMd bool) (string, error) {
 		body = AIInstructionBody()
 	}
 
-	return ReplaceFencedRegion("", "v1", body)
+	rendered, err := ReplaceFencedRegion("", MarkdownMarkers("v1"), body)
+	if err != nil {
+		return "", err
+	}
+	if tool == "copilot" && len(rendered) > CopilotMaxBytes {
+		return "", fmt.Errorf("copilot body is %d bytes, exceeds the %d-byte cap; trim aiCopilotBody before merge", len(rendered), CopilotMaxBytes)
+	}
+	return rendered, nil
 }

--- a/specter/internal/manifest/ai_templates.go
+++ b/specter/internal/manifest/ai_templates.go
@@ -1,0 +1,173 @@
+// Per-tool AI instruction templates for `init --ai <tool>`.
+//
+// Body content reflects the v0.11 design synthesis (see specter/BACKLOG.md
+// "init --ai <tool>" entry): preflight self-check at the top, Convention A
+// example, validation gate, on-demand `specter explain` references, no spec
+// content dumped (the AI asks Specter for it on demand).
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"fmt"
+)
+
+// AITargetPath maps each tool keyword to its on-disk instruction file path.
+//
+// AC-30..34: claude → CLAUDE.md, codex → AGENTS.md, cursor → .cursor/rules/specter.md,
+// copilot → .github/copilot-instructions.md, gemini → GEMINI.md.
+func AITargetPath(tool string) (string, error) {
+	switch tool {
+	case "claude":
+		return "CLAUDE.md", nil
+	case "codex":
+		return "AGENTS.md", nil
+	case "cursor":
+		return ".cursor/rules/specter.md", nil
+	case "copilot":
+		return ".github/copilot-instructions.md", nil
+	case "gemini":
+		return "GEMINI.md", nil
+	}
+	return "", fmt.Errorf("unknown ai tool %q (supported: claude, codex, cursor, copilot, gemini)", tool)
+}
+
+// AIInstructionBody returns the v0.11 instruction template — the "project
+// guide" body that sits inside the fenced region for codex / cursor / gemini
+// (and for claude when no AGENTS.md is present).
+//
+// Length target ≤80 lines per Anthropic's CLAUDE.md guidance. Imperative
+// voice; reserved MUST/NEVER for the highest-stakes rule. Convention A
+// good/bad pair. Preflight self-check at the top. Load-bearing rule
+// repeated at the top and bottom (primacy + recency).
+func AIInstructionBody() string {
+	return `# Specter project — read before writing code
+
+Specs in ` + "`specs/*.spec.yaml`" + ` are the Single Source of Truth. Code is
+derived from specs; when they disagree, the spec wins.
+
+## Before you edit code
+
+1. Identify which spec governs the file you're about to change
+   (filename pattern: ` + "`specs/spec-<area>.spec.yaml`" + `).
+2. Run ` + "`specter explain <spec-id>`" + ` and read the AC list it prints.
+3. State the spec ID and the AC IDs your change touches before producing code.
+
+## Tests trace to ACs (Convention A)
+
+Every new test carries the spec ID and AC ID in its runner-visible name.
+
+Good (Go):
+
+` + "```go" + `
+t.Run("spec-coverage/AC-19 failed result demotes all tiers", func(t *testing.T) {
+    ...
+})
+` + "```" + `
+
+Good (Jest / Vitest):
+
+` + "```ts" + `
+describe("[spec-extension/AC-12] command registration", () => { ... })
+` + "```" + `
+
+Bad — invisible to coverage, will fail the gate:
+
+` + "```go" + `
+func TestFailedResult(t *testing.T) { ... }
+` + "```" + `
+
+## Validation
+
+Run ` + "`make dogfood-strict`" + ` before declaring work done. Exit 0 is the gate.
+The strictness level for this project is in ` + "`specter.yaml`" + `.
+
+## Boundaries
+
+- Do not edit ` + "`specs/*.spec.yaml`" + ` to make code pass. Update the code,
+  or propose a spec change in your reply for human review.
+- If no spec covers your change, stop and ask which spec to read or create.
+
+## On-demand reference
+
+- ` + "`specter explain <spec-id>`" + ` — canonical spec content. Read it; do not guess.
+- ` + "`specter explain schema`" + ` — schema field reference.
+- ` + "`specter explain annotation`" + ` — test-annotation reference.
+
+Reminder: read the spec before writing code. Tests without ` + "`@spec`/`@ac`" + `
+annotations are invisible to ` + "`coverage --strict`" + ` and will fail the gate.`
+}
+
+// aiCopilotBody returns a tightened body for Copilot's 4096-byte cap.
+// Strips longer examples; keeps the load-bearing rules (preflight + Convention A
+// + validation gate + explain references).
+func aiCopilotBody() string {
+	return `# Specter project — read before writing code
+
+Specs in ` + "`specs/*.spec.yaml`" + ` are the Single Source of Truth. Code is
+derived from specs; the spec wins when they disagree.
+
+## Before you edit code
+
+1. Identify the matching spec (` + "`specs/spec-<area>.spec.yaml`" + `).
+2. Run ` + "`specter explain <spec-id>`" + ` and read its ACs.
+3. State the spec ID and AC IDs your change touches before writing code.
+
+## Tests trace to ACs (Convention A)
+
+Every test's runner-visible name includes the spec ID and AC ID.
+
+Good: ` + "`t.Run(\"spec-x/AC-01 ...\", func(t *testing.T) { ... })`" + `
+Good: ` + "`describe(\"[spec-x/AC-01] ...\", () => { ... })`" + `
+Bad:  ` + "`func TestFoo(t *testing.T) { ... }`" + ` — invisible to coverage.
+
+## Validation
+
+Run ` + "`make dogfood-strict`" + ` before declaring work done. Exit 0 is the gate.
+
+## Boundaries
+
+- Do not edit specs to make code pass. Update code, or propose a spec change for review.
+- If no spec covers your change, stop and ask which spec to read or create.
+
+## On-demand reference
+
+- ` + "`specter explain <spec-id>`" + ` — canonical spec content.
+- ` + "`specter explain schema`" + ` — schema field reference.
+- ` + "`specter explain annotation`" + ` — test-annotation reference.
+
+Reminder: read the spec before writing code. Untraced tests fail ` + "`coverage --strict`" + `.`
+}
+
+// aiClaudeImportBody returns the body Claude's CLAUDE.md uses when an
+// AGENTS.md is already present. Uses Claude's @AGENTS.md import directive
+// to reference the canonical body without duplicating it.
+func aiClaudeImportBody() string {
+	return `@AGENTS.md
+
+## Claude-specific notes
+
+(Add Claude-specific guidance here. The @AGENTS.md import above carries the
+canonical project preflight, Convention A examples, and validation gate.)`
+}
+
+// RenderAIInstructions returns the full fenced-region body for one tool.
+// hasAgentsMd is consulted only for tool="claude" (AC-36): present means
+// emit the @AGENTS.md import; absent means inline the full body.
+func RenderAIInstructions(tool string, hasAgentsMd bool) (string, error) {
+	if _, err := AITargetPath(tool); err != nil {
+		return "", err
+	}
+
+	var body string
+	switch {
+	case tool == "claude" && hasAgentsMd:
+		body = aiClaudeImportBody()
+	case tool == "copilot":
+		body = aiCopilotBody()
+	default:
+		body = AIInstructionBody()
+	}
+
+	return ReplaceFencedRegion("", "v1", body)
+}

--- a/specter/internal/manifest/ai_templates_test.go
+++ b/specter/internal/manifest/ai_templates_test.go
@@ -1,0 +1,146 @@
+// Pure-function tests for the per-tool AI instruction templates used by
+// `init --ai <tool>`.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// Body content checks: the v0.11 instruction template must include the
+// preflight self-check, Convention A example, validation gate, and on-demand
+// explain references — the four load-bearing pieces from the BACKLOG synthesis.
+func TestAIInstructionBody_ContainsPreflightAndExamples(t *testing.T) {
+	t.Run("spec-manifest/AC-30 instruction body contains preflight and convention A", func(t *testing.T) {
+		body := AIInstructionBody()
+
+		// Preflight self-check / read-spec-first.
+		if !strings.Contains(strings.ToLower(body), "before you") &&
+			!strings.Contains(strings.ToLower(body), "before editing") {
+			t.Errorf("expected preflight phrasing ('before you' / 'before editing'), got:\n%s", body)
+		}
+		// Convention A example with runner-visible spec-id/AC-NN form.
+		if !strings.Contains(body, "spec-") || !strings.Contains(body, "AC-") {
+			t.Errorf("expected Convention A example referencing spec-id and AC-NN, got:\n%s", body)
+		}
+		// Validation gate.
+		if !strings.Contains(body, "make dogfood-strict") &&
+			!strings.Contains(body, "specter coverage --strict") {
+			t.Errorf("expected validation gate command (make dogfood-strict or specter coverage --strict), got:\n%s", body)
+		}
+		// On-demand reference: explain commands.
+		if !strings.Contains(body, "specter explain") {
+			t.Errorf("expected reference to `specter explain`, got:\n%s", body)
+		}
+	})
+}
+
+// AC-30 / AC-31 / AC-34: claude (no AGENTS.md) / codex / gemini all emit the
+// inline body wrapped in fenced markers.
+func TestRenderAIInstructions_ClaudeNoAgents_InlineBody(t *testing.T) {
+	t.Run("spec-manifest/AC-30 claude with no AGENTS.md inlines body", func(t *testing.T) {
+		got, err := RenderAIInstructions("claude", false)
+		if err != nil {
+			t.Fatalf("RenderAIInstructions claude: %v", err)
+		}
+		if !strings.Contains(got, "<!-- specter:begin v1 -->") || !strings.Contains(got, "<!-- specter:end -->") {
+			t.Errorf("expected fenced markers, got:\n%s", got)
+		}
+		if !strings.Contains(got, "specter explain") {
+			t.Errorf("expected inline body present (specter explain reference), got:\n%s", got)
+		}
+		if strings.Contains(got, "@AGENTS.md") {
+			t.Errorf("did not expect @AGENTS.md import when AGENTS.md is absent, got:\n%s", got)
+		}
+	})
+}
+
+// AC-36: claude with existing AGENTS.md writes the @AGENTS.md import, NOT
+// the inline body.
+func TestRenderAIInstructions_ClaudeWithAgents_UsesImport(t *testing.T) {
+	t.Run("spec-manifest/AC-36 claude with existing AGENTS.md uses @AGENTS.md import", func(t *testing.T) {
+		got, err := RenderAIInstructions("claude", true)
+		if err != nil {
+			t.Fatalf("RenderAIInstructions claude (with AGENTS.md): %v", err)
+		}
+		if !strings.Contains(got, "@AGENTS.md") {
+			t.Errorf("expected @AGENTS.md import when AGENTS.md is present, got:\n%s", got)
+		}
+		// Should NOT inline the full preflight body — that's in AGENTS.md.
+		if strings.Contains(got, "specter explain <spec-id>") {
+			t.Errorf("did not expect inline preflight body when AGENTS.md handles it, got:\n%s", got)
+		}
+	})
+}
+
+func TestRenderAIInstructions_Codex_InlineBody(t *testing.T) {
+	t.Run("spec-manifest/AC-31 codex inlines body in AGENTS.md target", func(t *testing.T) {
+		got, err := RenderAIInstructions("codex", false)
+		if err != nil {
+			t.Fatalf("RenderAIInstructions codex: %v", err)
+		}
+		if !strings.Contains(got, "<!-- specter:begin v1 -->") {
+			t.Errorf("expected fenced markers, got:\n%s", got)
+		}
+		if !strings.Contains(got, "specter explain") {
+			t.Errorf("expected inline body, got:\n%s", got)
+		}
+	})
+}
+
+// AC-33: copilot body capped at 4096 bytes for the code-review surface.
+func TestRenderAIInstructions_Copilot_Capped4KB(t *testing.T) {
+	t.Run("spec-manifest/AC-33 copilot body capped at 4KB", func(t *testing.T) {
+		got, err := RenderAIInstructions("copilot", false)
+		if err != nil {
+			t.Fatalf("RenderAIInstructions copilot: %v", err)
+		}
+		if len(got) > 4096 {
+			t.Errorf("expected copilot body ≤ 4096 bytes, got %d bytes", len(got))
+		}
+		// Even with truncation, the load-bearing rule (read spec before code)
+		// must survive — that's the priority guidance.
+		if !strings.Contains(got, "specter explain") {
+			t.Errorf("expected truncated copilot body to retain `specter explain` reference, got:\n%s", got)
+		}
+	})
+}
+
+// Unknown tool argument errors clearly.
+func TestRenderAIInstructions_UnknownTool_Errors(t *testing.T) {
+	t.Run("spec-manifest/unknown ai tool errors out", func(t *testing.T) {
+		_, err := RenderAIInstructions("notesnook", false)
+		if err == nil {
+			t.Fatal("expected error for unknown tool, got nil")
+		}
+	})
+}
+
+// AITargetPath maps each tool to its on-disk file path. Pure lookup.
+func TestAITargetPath(t *testing.T) {
+	t.Run("spec-manifest/AC-30..34 AI target paths per tool", func(t *testing.T) {
+		cases := map[string]string{
+			"claude":  "CLAUDE.md",
+			"codex":   "AGENTS.md",
+			"cursor":  ".cursor/rules/specter.md",
+			"copilot": ".github/copilot-instructions.md",
+			"gemini":  "GEMINI.md",
+		}
+		for tool, want := range cases {
+			got, err := AITargetPath(tool)
+			if err != nil {
+				t.Errorf("AITargetPath(%q): %v", tool, err)
+				continue
+			}
+			if got != want {
+				t.Errorf("AITargetPath(%q) = %q, want %q", tool, got, want)
+			}
+		}
+
+		if _, err := AITargetPath("unknown-tool"); err == nil {
+			t.Errorf("expected error for unknown tool, got nil")
+		}
+	})
+}

--- a/specter/internal/manifest/ai_templates_test.go
+++ b/specter/internal/manifest/ai_templates_test.go
@@ -91,19 +91,21 @@ func TestRenderAIInstructions_Codex_InlineBody(t *testing.T) {
 }
 
 // AC-33: copilot body capped at 4096 bytes for the code-review surface.
+// Guard is enforced by RenderAIInstructions returning an error if the body
+// exceeds CopilotMaxBytes — not by happenstance of body length.
 func TestRenderAIInstructions_Copilot_Capped4KB(t *testing.T) {
 	t.Run("spec-manifest/AC-33 copilot body capped at 4KB", func(t *testing.T) {
 		got, err := RenderAIInstructions("copilot", false)
 		if err != nil {
 			t.Fatalf("RenderAIInstructions copilot: %v", err)
 		}
-		if len(got) > 4096 {
-			t.Errorf("expected copilot body ≤ 4096 bytes, got %d bytes", len(got))
+		if len(got) > CopilotMaxBytes {
+			t.Errorf("expected copilot body ≤ %d bytes, got %d bytes", CopilotMaxBytes, len(got))
 		}
-		// Even with truncation, the load-bearing rule (read spec before code)
-		// must survive — that's the priority guidance.
+		// Load-bearing rule (read spec before code) must survive even at
+		// the size limit — that's the priority guidance.
 		if !strings.Contains(got, "specter explain") {
-			t.Errorf("expected truncated copilot body to retain `specter explain` reference, got:\n%s", got)
+			t.Errorf("expected copilot body to retain `specter explain` reference, got:\n%s", got)
 		}
 	})
 }

--- a/specter/internal/manifest/fenced.go
+++ b/specter/internal/manifest/fenced.go
@@ -1,0 +1,79 @@
+// Fenced-region read/write helpers for `init --install-hook` and
+// `init --ai <tool>`. Both commands write content into a file alongside
+// user-authored content; the fenced markers let re-runs replace only the
+// Specter-managed region byte-for-byte preserving everything outside.
+//
+// Marker format (HTML comments so they render as nothing in markdown
+// previews; safely ignored by shells via the `# ...` line comments):
+//
+//	<!-- specter:begin v1 -->
+//	... specter-managed content ...
+//	<!-- specter:end -->
+//
+// The version tag (v1) lets future Specter releases migrate the format
+// without ambiguity. Today only v1 is recognized.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ReplaceFencedRegion replaces (or appends) the specter-managed region in
+// `original`, leaving everything outside the fence byte-for-byte unchanged.
+//
+// Behavior:
+//   - If both begin and end markers are present: replace just the in-fence body.
+//   - If neither marker is present: append the fenced block (with a leading
+//     blank line if `original` is non-empty and doesn't already end with \n).
+//   - If only one marker is present: error rather than guess. Operator
+//     intervention required to avoid corrupting hand-edited files.
+func ReplaceFencedRegion(original, version, body string) (string, error) {
+	begin := fmt.Sprintf("<!-- specter:begin %s -->", version)
+	end := "<!-- specter:end -->"
+
+	beginIdx := strings.Index(original, begin)
+	endIdx := strings.Index(original, end)
+
+	switch {
+	case beginIdx >= 0 && endIdx >= 0:
+		if endIdx < beginIdx {
+			return "", fmt.Errorf("malformed fenced region: end marker appears before begin marker")
+		}
+		// Cut from begin marker up to (and including) end marker.
+		endStop := endIdx + len(end)
+		var b strings.Builder
+		b.WriteString(original[:beginIdx])
+		b.WriteString(begin)
+		b.WriteString("\n")
+		b.WriteString(strings.TrimRight(body, "\n"))
+		b.WriteString("\n")
+		b.WriteString(end)
+		b.WriteString(original[endStop:])
+		return b.String(), nil
+
+	case beginIdx >= 0 || endIdx >= 0:
+		return "", errors.New("unterminated fenced region: only one of <!-- specter:begin --> / <!-- specter:end --> markers found; refusing to overwrite to avoid corruption")
+
+	default:
+		// Append a fresh fenced block.
+		var b strings.Builder
+		b.WriteString(original)
+		if len(original) > 0 && !strings.HasSuffix(original, "\n") {
+			b.WriteString("\n")
+		}
+		if len(original) > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(begin)
+		b.WriteString("\n")
+		b.WriteString(strings.TrimRight(body, "\n"))
+		b.WriteString("\n")
+		b.WriteString(end)
+		b.WriteString("\n")
+		return b.String(), nil
+	}
+}

--- a/specter/internal/manifest/fenced.go
+++ b/specter/internal/manifest/fenced.go
@@ -3,12 +3,12 @@
 // user-authored content; the fenced markers let re-runs replace only the
 // Specter-managed region byte-for-byte preserving everything outside.
 //
-// Marker format (HTML comments so they render as nothing in markdown
-// previews; safely ignored by shells via the `# ...` line comments):
-//
-//	<!-- specter:begin v1 -->
-//	... specter-managed content ...
-//	<!-- specter:end -->
+// Marker format depends on target file syntax:
+//   - Markdown / HTML: HTML-comment markers render as nothing in previews.
+//     Use MarkdownMarkers.
+//   - Shell scripts: HTML comments are not shell comments — `<!--` parses
+//     as a redirection token (`<` plus `!--`), causing a syntax error on
+//     the next newline. Use ShellMarkers (`#`-prefixed).
 //
 // The version tag (v1) lets future Specter releases migrate the format
 // without ambiguity. Today only v1 is recognized.
@@ -22,6 +22,33 @@ import (
 	"strings"
 )
 
+// FencedMarkers names the begin/end strings that wrap the Specter-managed
+// region in a generated file. Use MarkdownMarkers for AI instruction files;
+// ShellMarkers for the pre-push hook.
+type FencedMarkers struct {
+	Begin string
+	End   string
+}
+
+// MarkdownMarkers wraps content in HTML comments. Renders invisibly in
+// rendered markdown; safe in any markdown-compatible file.
+func MarkdownMarkers(version string) FencedMarkers {
+	return FencedMarkers{
+		Begin: fmt.Sprintf("<!-- specter:begin %s -->", version),
+		End:   "<!-- specter:end -->",
+	}
+}
+
+// ShellMarkers wraps content in shell-comment lines. Required for any file
+// parsed by `sh` / `bash` / `zsh` (e.g., git hooks). HTML-comment markers
+// would be a syntax error in shell.
+func ShellMarkers(version string) FencedMarkers {
+	return FencedMarkers{
+		Begin: fmt.Sprintf("# specter:begin %s", version),
+		End:   "# specter:end",
+	}
+}
+
 // ReplaceFencedRegion replaces (or appends) the specter-managed region in
 // `original`, leaving everything outside the fence byte-for-byte unchanged.
 //
@@ -31,9 +58,9 @@ import (
 //     blank line if `original` is non-empty and doesn't already end with \n).
 //   - If only one marker is present: error rather than guess. Operator
 //     intervention required to avoid corrupting hand-edited files.
-func ReplaceFencedRegion(original, version, body string) (string, error) {
-	begin := fmt.Sprintf("<!-- specter:begin %s -->", version)
-	end := "<!-- specter:end -->"
+func ReplaceFencedRegion(original string, markers FencedMarkers, body string) (string, error) {
+	begin := markers.Begin
+	end := markers.End
 
 	beginIdx := strings.Index(original, begin)
 	endIdx := strings.Index(original, end)

--- a/specter/internal/manifest/fenced_test.go
+++ b/specter/internal/manifest/fenced_test.go
@@ -18,7 +18,7 @@ func TestFencedRegion_ReplaceFenced_PreservesOutOfFence(t *testing.T) {
 			"# Trailing user content\nMore of the user's notes.\n"
 		newBody := "fresh body line 1\nfresh body line 2"
 
-		got, err := ReplaceFencedRegion(original, "v1", newBody)
+		got, err := ReplaceFencedRegion(original, MarkdownMarkers("v1"), newBody)
 		if err != nil {
 			t.Fatalf("ReplaceFencedRegion: %v", err)
 		}
@@ -43,7 +43,7 @@ func TestFencedRegion_NoExistingFence_AppendsFenced(t *testing.T) {
 		original := "# Pre-existing user content\n"
 		newBody := "specter body"
 
-		got, err := ReplaceFencedRegion(original, "v1", newBody)
+		got, err := ReplaceFencedRegion(original, MarkdownMarkers("v1"), newBody)
 		if err != nil {
 			t.Fatalf("ReplaceFencedRegion: %v", err)
 		}
@@ -65,7 +65,7 @@ func TestFencedRegion_NoExistingFence_AppendsFenced(t *testing.T) {
 // Empty input: write the fenced region as-is.
 func TestFencedRegion_EmptyInput_WritesFencedOnly(t *testing.T) {
 	t.Run("spec-manifest/fenced empty input writes only fence", func(t *testing.T) {
-		got, err := ReplaceFencedRegion("", "v1", "body")
+		got, err := ReplaceFencedRegion("", MarkdownMarkers("v1"), "body")
 		if err != nil {
 			t.Fatalf("ReplaceFencedRegion: %v", err)
 		}
@@ -82,7 +82,7 @@ func TestFencedRegion_EmptyInput_WritesFencedOnly(t *testing.T) {
 func TestFencedRegion_UnterminatedFence_ReturnsError(t *testing.T) {
 	t.Run("spec-manifest/fenced unterminated marker errors out", func(t *testing.T) {
 		original := "<!-- specter:begin v1 -->\nbody"
-		_, err := ReplaceFencedRegion(original, "v1", "new")
+		_, err := ReplaceFencedRegion(original, MarkdownMarkers("v1"), "new")
 		if err == nil {
 			t.Fatal("expected error for unterminated fence, got nil")
 		}

--- a/specter/internal/manifest/fenced_test.go
+++ b/specter/internal/manifest/fenced_test.go
@@ -1,0 +1,90 @@
+// Pure-function tests for the fenced-region read/write helpers used by
+// `init --install-hook` and `init --ai <tool>`.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// AC-35 backbone: re-running init replaces only the in-fence content;
+// out-of-fence content is preserved byte-for-byte.
+func TestFencedRegion_ReplaceFenced_PreservesOutOfFence(t *testing.T) {
+	t.Run("spec-manifest/AC-35 fenced replace preserves out-of-fence content", func(t *testing.T) {
+		original := "# User intro\n\nSome notes the user wrote.\n" +
+			"<!-- specter:begin v1 -->\nold body\n<!-- specter:end -->\n" +
+			"# Trailing user content\nMore of the user's notes.\n"
+		newBody := "fresh body line 1\nfresh body line 2"
+
+		got, err := ReplaceFencedRegion(original, "v1", newBody)
+		if err != nil {
+			t.Fatalf("ReplaceFencedRegion: %v", err)
+		}
+		if !strings.Contains(got, "# User intro\n\nSome notes the user wrote.\n") {
+			t.Errorf("expected pre-fence content preserved, got:\n%s", got)
+		}
+		if !strings.Contains(got, "# Trailing user content\nMore of the user's notes.\n") {
+			t.Errorf("expected post-fence content preserved, got:\n%s", got)
+		}
+		if !strings.Contains(got, "fresh body line 1\nfresh body line 2") {
+			t.Errorf("expected new body in fence, got:\n%s", got)
+		}
+		if strings.Contains(got, "old body") {
+			t.Errorf("expected old body removed, got:\n%s", got)
+		}
+	})
+}
+
+// First-write case: input has no fence yet.
+func TestFencedRegion_NoExistingFence_AppendsFenced(t *testing.T) {
+	t.Run("spec-manifest/fenced first-write appends fenced region", func(t *testing.T) {
+		original := "# Pre-existing user content\n"
+		newBody := "specter body"
+
+		got, err := ReplaceFencedRegion(original, "v1", newBody)
+		if err != nil {
+			t.Fatalf("ReplaceFencedRegion: %v", err)
+		}
+		if !strings.Contains(got, "# Pre-existing user content") {
+			t.Errorf("expected user content preserved")
+		}
+		if !strings.Contains(got, "<!-- specter:begin v1 -->") {
+			t.Errorf("expected begin marker added")
+		}
+		if !strings.Contains(got, "<!-- specter:end -->") {
+			t.Errorf("expected end marker added")
+		}
+		if !strings.Contains(got, "specter body") {
+			t.Errorf("expected new body present")
+		}
+	})
+}
+
+// Empty input: write the fenced region as-is.
+func TestFencedRegion_EmptyInput_WritesFencedOnly(t *testing.T) {
+	t.Run("spec-manifest/fenced empty input writes only fence", func(t *testing.T) {
+		got, err := ReplaceFencedRegion("", "v1", "body")
+		if err != nil {
+			t.Fatalf("ReplaceFencedRegion: %v", err)
+		}
+		if !strings.Contains(got, "<!-- specter:begin v1 -->") || !strings.Contains(got, "<!-- specter:end -->") {
+			t.Errorf("expected both markers, got:\n%s", got)
+		}
+		if !strings.Contains(got, "body") {
+			t.Errorf("expected body present, got:\n%s", got)
+		}
+	})
+}
+
+// Mismatched markers: begin without end, or vice versa, must error rather than silently corrupting the file.
+func TestFencedRegion_UnterminatedFence_ReturnsError(t *testing.T) {
+	t.Run("spec-manifest/fenced unterminated marker errors out", func(t *testing.T) {
+		original := "<!-- specter:begin v1 -->\nbody"
+		_, err := ReplaceFencedRegion(original, "v1", "new")
+		if err == nil {
+			t.Fatal("expected error for unterminated fence, got nil")
+		}
+	})
+}

--- a/specter/internal/manifest/hook.go
+++ b/specter/internal/manifest/hook.go
@@ -42,8 +42,11 @@ func ShouldBlockPush(diff PushDiffSummary) bool {
 }
 
 // PrePushHookScript returns the shell script body written to
-// .git/hooks/pre-push. Wrapped in <!-- specter:begin v1 --> / <!-- specter:end -->
-// markers so re-running `init --install-hook` replaces only the fenced region.
+// .git/hooks/pre-push. Wrapped in shell-comment markers
+// (`# specter:begin v1` / `# specter:end`) so re-running `init --install-hook`
+// replaces only the fenced region. HTML-comment markers (used in the AI
+// instruction files) would be invalid shell syntax — `<!--` parses as a
+// `<` redirection and would cause every push to fail with a syntax error.
 //
 // The script delegates classification to `specter pre-push-check`, which
 // reads git's pre-push stdin format (one line per ref) and exits non-zero
@@ -67,11 +70,14 @@ fi
 
 specter pre-push-check "$@"
 `
+	markers := ShellMarkers("v1")
 	var b strings.Builder
 	b.WriteString("#!/bin/sh\n")
-	b.WriteString("<!-- specter:begin v1 -->\n")
+	b.WriteString(markers.Begin)
+	b.WriteString("\n")
 	b.WriteString(body)
-	b.WriteString("<!-- specter:end -->\n")
+	b.WriteString(markers.End)
+	b.WriteString("\n")
 	return b.String()
 }
 

--- a/specter/internal/manifest/hook.go
+++ b/specter/internal/manifest/hook.go
@@ -1,0 +1,125 @@
+// Pre-push hook script generation and diff-classification logic for
+// `init --install-hook`. The on-disk hook is a small shell script that
+// invokes `specter pre-push-check` (a hidden subcommand); the actual
+// classification logic lives in the pure ShouldBlockPush function so it
+// can be tested without spawning git.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PushDiffSummary describes a single push's diff in terms the hook needs to
+// decide block vs. allow. Implementation files are .go / .ts / .js / .py /
+// etc; test files match *_test.* / *.test.*; spec files end in .spec.yaml;
+// doc files are .md or under docs/. AnnotationDelta is true when ANY line
+// added in the diff (across any file) contains "@spec " or "@ac ".
+type PushDiffSummary struct {
+	ImplFilesChanged []string
+	TestFilesChanged []string
+	DocFilesChanged  []string
+	SpecFilesChanged []string
+	AnnotationDelta  bool
+}
+
+// ShouldBlockPush decides whether the pre-push hook should reject the push.
+//
+// The rule (AC-28): block if and only if the diff includes implementation
+// file changes AND no annotation delta. Pure docs / spec / test changes are
+// always allowed; impl changes paired with an @spec/@ac delta are allowed.
+//
+// Rationale: the discipline being enforced is "every code change traces to
+// a test annotation that traces to a spec." Pure docs/spec/test pushes
+// don't need a code-side annotation; impl changes do.
+func ShouldBlockPush(diff PushDiffSummary) bool {
+	if len(diff.ImplFilesChanged) == 0 {
+		return false
+	}
+	return !diff.AnnotationDelta
+}
+
+// PrePushHookScript returns the shell script body written to
+// .git/hooks/pre-push. Wrapped in <!-- specter:begin v1 --> / <!-- specter:end -->
+// markers so re-running `init --install-hook` replaces only the fenced region.
+//
+// The script delegates classification to `specter pre-push-check`, which
+// reads git's pre-push stdin format (one line per ref) and exits non-zero
+// when ShouldBlockPush returns true.
+//
+// `git push --no-verify` skips this hook entirely — that's git's behavior,
+// not Specter's. Documented in the hook script comments for AC-29.
+func PrePushHookScript() string {
+	const body = `# Specter pre-push hook (v0.11+).
+#
+# Blocks pushes that change implementation files without adding or
+# updating @spec / @ac annotations. Bypass with: git push --no-verify
+#
+# Reads git's standard pre-push stdin format and delegates to
+# 'specter pre-push-check' for the diff analysis.
+
+if ! command -v specter >/dev/null 2>&1; then
+  echo "specter pre-push hook: 'specter' binary not found on PATH; skipping check" >&2
+  exit 0
+fi
+
+specter pre-push-check "$@"
+`
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
+	b.WriteString("<!-- specter:begin v1 -->\n")
+	b.WriteString(body)
+	b.WriteString("<!-- specter:end -->\n")
+	return b.String()
+}
+
+// IsImplFile reports whether path looks like an implementation source file
+// (.go, .ts/.tsx, .js/.jsx, .py, .rs, .java, .c/.cc/.cpp/.h/.hpp). Test files
+// (matching *_test.* or *.test.*) and spec files (*.spec.yaml) are excluded.
+func IsImplFile(path string) bool {
+	if isTestFile(path) || isSpecFile(path) || isDocFile(path) {
+		return false
+	}
+	for _, ext := range []string{".go", ".ts", ".tsx", ".js", ".jsx", ".py", ".rs", ".java", ".c", ".cc", ".cpp", ".h", ".hpp"} {
+		if strings.HasSuffix(path, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTestFile(path string) bool {
+	return strings.HasSuffix(path, "_test.go") ||
+		strings.HasSuffix(path, "_test.py") ||
+		strings.HasSuffix(path, ".test.ts") ||
+		strings.HasSuffix(path, ".test.tsx") ||
+		strings.HasSuffix(path, ".test.js") ||
+		strings.HasSuffix(path, ".test.jsx") ||
+		strings.HasSuffix(path, ".spec.ts") ||
+		strings.HasSuffix(path, ".spec.tsx") ||
+		strings.HasSuffix(path, ".spec.js")
+}
+
+func isSpecFile(path string) bool {
+	return strings.HasSuffix(path, ".spec.yaml") || strings.HasSuffix(path, ".spec.yml")
+}
+
+func isDocFile(path string) bool {
+	return strings.HasSuffix(path, ".md") || strings.HasPrefix(path, "docs/")
+}
+
+// FormatBlockedPushMessage renders the human-facing message printed to stderr
+// when ShouldBlockPush returns true. Names the impl files and points at the
+// likely fix.
+func FormatBlockedPushMessage(diff PushDiffSummary) string {
+	var b strings.Builder
+	b.WriteString("specter pre-push: push blocked\n\n")
+	b.WriteString(fmt.Sprintf("  %d implementation file(s) changed but no @spec / @ac annotation delta found:\n", len(diff.ImplFilesChanged)))
+	for _, f := range diff.ImplFilesChanged {
+		b.WriteString("    - " + f + "\n")
+	}
+	b.WriteString("\n  Either add a test that annotates the affected ACs, or push with `git push --no-verify` to bypass.\n")
+	return b.String()
+}

--- a/specter/internal/manifest/hook_test.go
+++ b/specter/internal/manifest/hook_test.go
@@ -1,0 +1,86 @@
+// Pure-function tests for the pre-push hook script generation and
+// diff-analysis logic used by `init --install-hook`.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// AC-28: hook blocks impl-only diffs; passes annotation-delta diffs and
+// docs/spec/test-only diffs.
+func TestShouldBlockPush_ImplOnly_Blocks(t *testing.T) {
+	t.Run("spec-manifest/AC-28 impl-only diff blocks push", func(t *testing.T) {
+		diff := PushDiffSummary{
+			ImplFilesChanged:   []string{"internal/foo/bar.go"},
+			TestFilesChanged:   nil,
+			DocFilesChanged:    nil,
+			SpecFilesChanged:   nil,
+			AnnotationDelta:    false,
+		}
+		if !ShouldBlockPush(diff) {
+			t.Errorf("expected impl-only diff to block, did not")
+		}
+	})
+}
+
+func TestShouldBlockPush_AnnotationDelta_Allows(t *testing.T) {
+	t.Run("spec-manifest/AC-28 annotation-delta diff allows push", func(t *testing.T) {
+		diff := PushDiffSummary{
+			ImplFilesChanged: []string{"internal/foo/bar.go"},
+			TestFilesChanged: []string{"internal/foo/bar_test.go"},
+			AnnotationDelta:  true, // a test gained @ac
+		}
+		if ShouldBlockPush(diff) {
+			t.Errorf("expected annotation-delta diff to allow push, did not")
+		}
+	})
+}
+
+func TestShouldBlockPush_DocsOrSpecsOnly_Allows(t *testing.T) {
+	t.Run("spec-manifest/AC-28 docs-or-specs-only diff allows push", func(t *testing.T) {
+		diff := PushDiffSummary{
+			DocFilesChanged:  []string{"README.md"},
+			SpecFilesChanged: []string{"specs/spec-foo.spec.yaml"},
+			AnnotationDelta:  false,
+		}
+		if ShouldBlockPush(diff) {
+			t.Errorf("expected docs/specs-only diff to allow push, did not")
+		}
+	})
+}
+
+func TestShouldBlockPush_TestsOnly_Allows(t *testing.T) {
+	t.Run("spec-manifest/AC-28 tests-only diff allows push", func(t *testing.T) {
+		diff := PushDiffSummary{
+			TestFilesChanged: []string{"internal/foo/bar_test.go"},
+			AnnotationDelta:  true,
+		}
+		if ShouldBlockPush(diff) {
+			t.Errorf("expected tests-only with annotation delta to allow push, did not")
+		}
+	})
+}
+
+// AC-27: hook script content shape — must contain the fenced markers and
+// invoke the specter pre-push helper.
+func TestPrePushHookScript_ContainsFencedMarkers(t *testing.T) {
+	t.Run("spec-manifest/AC-27 hook script wrapped in fenced markers", func(t *testing.T) {
+		script := PrePushHookScript()
+
+		if !strings.HasPrefix(script, "#!") {
+			t.Errorf("expected shebang at top of hook script, got:\n%s", script)
+		}
+		if !strings.Contains(script, "<!-- specter:begin v1 -->") {
+			t.Errorf("expected begin marker in hook, got:\n%s", script)
+		}
+		if !strings.Contains(script, "<!-- specter:end -->") {
+			t.Errorf("expected end marker in hook, got:\n%s", script)
+		}
+		if !strings.Contains(script, "specter") {
+			t.Errorf("expected hook to reference specter binary, got:\n%s", script)
+		}
+	})
+}

--- a/specter/internal/manifest/hook_test.go
+++ b/specter/internal/manifest/hook_test.go
@@ -14,11 +14,11 @@ import (
 func TestShouldBlockPush_ImplOnly_Blocks(t *testing.T) {
 	t.Run("spec-manifest/AC-28 impl-only diff blocks push", func(t *testing.T) {
 		diff := PushDiffSummary{
-			ImplFilesChanged:   []string{"internal/foo/bar.go"},
-			TestFilesChanged:   nil,
-			DocFilesChanged:    nil,
-			SpecFilesChanged:   nil,
-			AnnotationDelta:    false,
+			ImplFilesChanged: []string{"internal/foo/bar.go"},
+			TestFilesChanged: nil,
+			DocFilesChanged:  nil,
+			SpecFilesChanged: nil,
+			AnnotationDelta:  false,
 		}
 		if !ShouldBlockPush(diff) {
 			t.Errorf("expected impl-only diff to block, did not")

--- a/specter/internal/manifest/hook_test.go
+++ b/specter/internal/manifest/hook_test.go
@@ -64,20 +64,25 @@ func TestShouldBlockPush_TestsOnly_Allows(t *testing.T) {
 	})
 }
 
-// AC-27: hook script content shape — must contain the fenced markers and
-// invoke the specter pre-push helper.
+// AC-27: hook script content shape — must contain shell-comment fenced
+// markers (HTML-comment markers would be invalid shell syntax) and invoke
+// the specter pre-push helper.
 func TestPrePushHookScript_ContainsFencedMarkers(t *testing.T) {
-	t.Run("spec-manifest/AC-27 hook script wrapped in fenced markers", func(t *testing.T) {
+	t.Run("spec-manifest/AC-27 hook script wrapped in shell-comment markers", func(t *testing.T) {
 		script := PrePushHookScript()
 
 		if !strings.HasPrefix(script, "#!") {
 			t.Errorf("expected shebang at top of hook script, got:\n%s", script)
 		}
-		if !strings.Contains(script, "<!-- specter:begin v1 -->") {
-			t.Errorf("expected begin marker in hook, got:\n%s", script)
+		if !strings.Contains(script, "# specter:begin v1") {
+			t.Errorf("expected shell-comment begin marker in hook, got:\n%s", script)
 		}
-		if !strings.Contains(script, "<!-- specter:end -->") {
-			t.Errorf("expected end marker in hook, got:\n%s", script)
+		if !strings.Contains(script, "# specter:end") {
+			t.Errorf("expected shell-comment end marker in hook, got:\n%s", script)
+		}
+		// HTML-comment markers must NOT be present — they would break sh parsing.
+		if strings.Contains(script, "<!--") {
+			t.Errorf("hook must not contain HTML-comment markers (invalid shell syntax), got:\n%s", script)
 		}
 		if !strings.Contains(script, "specter") {
 			t.Errorf("expected hook to reference specter binary, got:\n%s", script)

--- a/specter/internal/manifest/prepush.go
+++ b/specter/internal/manifest/prepush.go
@@ -20,6 +20,14 @@ import (
 // branches and as the local sha for deleted branches.
 const ZeroSha = "0000000000000000000000000000000000000000"
 
+// validShaRE constrains LocalSha and RemoteSha to git's canonical 40-char
+// lowercase hex form. Without this guard, a sha-shaped token from stdin
+// could carry a leading `--` and flow into `git diff --name-only X..Y`
+// as a flag rather than a ref. Refer to the pre-push hook contract: git
+// emits 40-char hex (or all-zeros sentinel) on every line; anything else
+// is malformed input and we reject it.
+var validShaRE = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
 // PushSpec describes one ref being pushed, parsed from a single line of
 // git's pre-push stdin format: `local_ref local_sha remote_ref remote_sha`.
 type PushSpec struct {
@@ -32,7 +40,8 @@ type PushSpec struct {
 // ParsePushSpecs reads git's pre-push stdin (one line per ref, four
 // space-separated tokens) and returns the parsed specs in order.
 // Empty input returns an empty slice with nil error. Malformed lines
-// (wrong token count) return an error.
+// (wrong token count, or sha fields not matching the canonical 40-char
+// hex form) return an error.
 func ParsePushSpecs(r io.Reader) ([]PushSpec, error) {
 	var specs []PushSpec
 	scanner := bufio.NewScanner(r)
@@ -44,6 +53,14 @@ func ParsePushSpecs(r io.Reader) ([]PushSpec, error) {
 		tokens := strings.Fields(line)
 		if len(tokens) != 4 {
 			return nil, fmt.Errorf("pre-push line must have 4 fields (local_ref local_sha remote_ref remote_sha), got %d: %q", len(tokens), line)
+		}
+		// Reject sha fields that don't match git's 40-char hex form.
+		// This is the canonical input shape from `git push`'s stdin.
+		if !validShaRE.MatchString(tokens[1]) {
+			return nil, fmt.Errorf("pre-push line has malformed local_sha %q (expected 40-char hex)", tokens[1])
+		}
+		if !validShaRE.MatchString(tokens[3]) {
+			return nil, fmt.Errorf("pre-push line has malformed remote_sha %q (expected 40-char hex)", tokens[3])
 		}
 		specs = append(specs, PushSpec{
 			LocalRef:  tokens[0],

--- a/specter/internal/manifest/prepush.go
+++ b/specter/internal/manifest/prepush.go
@@ -58,11 +58,11 @@ func ParsePushSpecs(r io.Reader) ([]PushSpec, error) {
 	return specs, nil
 }
 
-// annotationLineRE matches an `@spec ` or `@ac ` reference anywhere on a
-// line. Lines beginning with `+` or `-` (added or removed) in unified
-// diff output count as annotation delta; lines beginning with `+++` or
-// `---` are file headers and don't.
-var annotationLineRE = regexp.MustCompile(`@spec\s|@ac\s`)
+// annotationLineRE matches a real `@spec` or `@ac` annotation — i.e. one
+// preceded by a source-comment marker (`//`, `#`, or `*`). Prose mentions
+// like "fixes the @spec foo issue" no longer count, since the AC-28 gate
+// is about test-annotation deltas, not arbitrary text containing @spec.
+var annotationLineRE = regexp.MustCompile(`(?://|#|\*)\s*@(?:spec|ac)\s`)
 
 // HasAnnotationDelta reports whether the unified-diff output contains any
 // added or removed line carrying `@spec ` or `@ac `. Pure scan over the

--- a/specter/internal/manifest/prepush.go
+++ b/specter/internal/manifest/prepush.go
@@ -1,0 +1,115 @@
+// Pre-push hook helpers: parse git's pre-push stdin format, detect
+// annotation deltas in unified-diff output, and roll the result into a
+// PushDiffSummary that ShouldBlockPush can consume.
+//
+// All functions here are pure (no I/O). The CLI subcommand
+// `specter pre-push-check` shells out to git and feeds the results in.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// ZeroSha is git's "no commit" sentinel. Used as the remote sha for new
+// branches and as the local sha for deleted branches.
+const ZeroSha = "0000000000000000000000000000000000000000"
+
+// PushSpec describes one ref being pushed, parsed from a single line of
+// git's pre-push stdin format: `local_ref local_sha remote_ref remote_sha`.
+type PushSpec struct {
+	LocalRef  string
+	LocalSha  string
+	RemoteRef string
+	RemoteSha string
+}
+
+// ParsePushSpecs reads git's pre-push stdin (one line per ref, four
+// space-separated tokens) and returns the parsed specs in order.
+// Empty input returns an empty slice with nil error. Malformed lines
+// (wrong token count) return an error.
+func ParsePushSpecs(r io.Reader) ([]PushSpec, error) {
+	var specs []PushSpec
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		tokens := strings.Fields(line)
+		if len(tokens) != 4 {
+			return nil, fmt.Errorf("pre-push line must have 4 fields (local_ref local_sha remote_ref remote_sha), got %d: %q", len(tokens), line)
+		}
+		specs = append(specs, PushSpec{
+			LocalRef:  tokens[0],
+			LocalSha:  tokens[1],
+			RemoteRef: tokens[2],
+			RemoteSha: tokens[3],
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read pre-push stdin: %w", err)
+	}
+	return specs, nil
+}
+
+// annotationLineRE matches an `@spec ` or `@ac ` reference anywhere on a
+// line. Lines beginning with `+` or `-` (added or removed) in unified
+// diff output count as annotation delta; lines beginning with `+++` or
+// `---` are file headers and don't.
+var annotationLineRE = regexp.MustCompile(`@spec\s|@ac\s`)
+
+// HasAnnotationDelta reports whether the unified-diff output contains any
+// added or removed line carrying `@spec ` or `@ac `. Pure scan over the
+// diff text. Headers (+++ / ---) and context lines (no leading + or -)
+// are ignored.
+//
+// We count both additions and removals as "delta" — a removed @ac is
+// still a change to the annotation set, and a code commit that drops a
+// test annotation should not be invisible to the gate.
+func HasAnnotationDelta(diff string) bool {
+	for _, line := range strings.Split(diff, "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		// Skip diff file headers.
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		if line[0] != '+' && line[0] != '-' {
+			continue
+		}
+		// `+` or `-` followed by the line content.
+		body := line[1:]
+		if annotationLineRE.MatchString(body) {
+			return true
+		}
+	}
+	return false
+}
+
+// SummarizePushDiff combines file categorization (IsImplFile / isTestFile /
+// isSpecFile / isDocFile) with HasAnnotationDelta into one PushDiffSummary
+// that ShouldBlockPush can consume directly.
+func SummarizePushDiff(filenames []string, diff string) PushDiffSummary {
+	var s PushDiffSummary
+	for _, f := range filenames {
+		switch {
+		case isTestFile(f):
+			s.TestFilesChanged = append(s.TestFilesChanged, f)
+		case isSpecFile(f):
+			s.SpecFilesChanged = append(s.SpecFilesChanged, f)
+		case isDocFile(f):
+			s.DocFilesChanged = append(s.DocFilesChanged, f)
+		case IsImplFile(f):
+			s.ImplFilesChanged = append(s.ImplFilesChanged, f)
+		}
+	}
+	s.AnnotationDelta = HasAnnotationDelta(diff)
+	return s
+}

--- a/specter/internal/manifest/prepush_test.go
+++ b/specter/internal/manifest/prepush_test.go
@@ -134,6 +134,19 @@ func TestHasAnnotationDelta_ContextLineIgnored(t *testing.T) {
 	})
 }
 
+// Prose mentions of @spec / @ac in non-comment-context (e.g., commit message
+// text in a diff, doc prose) must NOT count as an annotation delta. Otherwise
+// any commit whose message mentions an annotation could bypass the gate.
+func TestHasAnnotationDelta_ProseMentionIgnored(t *testing.T) {
+	t.Run("spec-manifest/AC-28 HasAnnotationDelta ignores prose mentions of @spec", func(t *testing.T) {
+		// Added line is plain text (no comment marker before @spec).
+		diff := "+++ b/CHANGELOG.md\n+fixes the @spec foo bug\n+see @ac AC-01 for details\n"
+		if HasAnnotationDelta(diff) {
+			t.Errorf("expected prose mentions not to count as annotation delta, got true")
+		}
+	})
+}
+
 func TestHasAnnotationDelta_DiffHeaderIgnored(t *testing.T) {
 	t.Run("spec-manifest/AC-28 HasAnnotationDelta ignores +++/--- diff headers", func(t *testing.T) {
 		// The +++ b/foo.go header isn't an added line of code; must not

--- a/specter/internal/manifest/prepush_test.go
+++ b/specter/internal/manifest/prepush_test.go
@@ -12,9 +12,21 @@ import (
 // "local_ref local_sha remote_ref remote_sha"). ParsePushSpecs must handle
 // the common cases: single ref, multiple refs, new branch (remote sha is
 // ZeroSha), deleted branch (local sha is ZeroSha), and trailing whitespace.
+//
+// Test inputs use 40-char hex shas matching git's canonical pre-push stdin
+// format. Earlier tests used abbreviated forms (`abc123`, `aaa`); those are
+// not what git actually emits and are now rejected by ParsePushSpecs's
+// validShaRE guard (added to defeat flag-injection via crafted shas).
+const (
+	sha40A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	sha40B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	sha40C = "cccccccccccccccccccccccccccccccccccccccc"
+	sha40D = "dddddddddddddddddddddddddddddddddddddddd"
+)
+
 func TestParsePushSpecs_SingleRef(t *testing.T) {
 	t.Run("spec-manifest/AC-28 ParsePushSpecs single ref", func(t *testing.T) {
-		input := "refs/heads/main abc123 refs/heads/main def456\n"
+		input := "refs/heads/main " + sha40A + " refs/heads/main " + sha40B + "\n"
 		specs, err := ParsePushSpecs(strings.NewReader(input))
 		if err != nil {
 			t.Fatal(err)
@@ -22,7 +34,7 @@ func TestParsePushSpecs_SingleRef(t *testing.T) {
 		if len(specs) != 1 {
 			t.Fatalf("expected 1 spec, got %d", len(specs))
 		}
-		if specs[0].LocalRef != "refs/heads/main" || specs[0].LocalSha != "abc123" {
+		if specs[0].LocalRef != "refs/heads/main" || specs[0].LocalSha != sha40A {
 			t.Errorf("got %+v", specs[0])
 		}
 	})
@@ -30,7 +42,8 @@ func TestParsePushSpecs_SingleRef(t *testing.T) {
 
 func TestParsePushSpecs_MultipleRefs(t *testing.T) {
 	t.Run("spec-manifest/AC-28 ParsePushSpecs multiple refs", func(t *testing.T) {
-		input := "refs/heads/feat/a aaa refs/heads/feat/a 111\nrefs/heads/feat/b bbb refs/heads/feat/b 222\n"
+		input := "refs/heads/feat/a " + sha40A + " refs/heads/feat/a " + sha40B + "\n" +
+			"refs/heads/feat/b " + sha40C + " refs/heads/feat/b " + sha40D + "\n"
 		specs, err := ParsePushSpecs(strings.NewReader(input))
 		if err != nil {
 			t.Fatal(err)
@@ -43,7 +56,7 @@ func TestParsePushSpecs_MultipleRefs(t *testing.T) {
 
 func TestParsePushSpecs_NewBranch_ZeroRemoteSha(t *testing.T) {
 	t.Run("spec-manifest/AC-28 ParsePushSpecs new branch carries zero remote sha", func(t *testing.T) {
-		input := "refs/heads/new abc123 refs/heads/new " + ZeroSha + "\n"
+		input := "refs/heads/new " + sha40A + " refs/heads/new " + ZeroSha + "\n"
 		specs, err := ParsePushSpecs(strings.NewReader(input))
 		if err != nil {
 			t.Fatal(err)
@@ -56,7 +69,7 @@ func TestParsePushSpecs_NewBranch_ZeroRemoteSha(t *testing.T) {
 
 func TestParsePushSpecs_DeletedBranch_ZeroLocalSha(t *testing.T) {
 	t.Run("spec-manifest/AC-28 ParsePushSpecs deleted branch carries zero local sha", func(t *testing.T) {
-		input := "refs/heads/gone " + ZeroSha + " refs/heads/gone abc123\n"
+		input := "refs/heads/gone " + ZeroSha + " refs/heads/gone " + sha40A + "\n"
 		specs, err := ParsePushSpecs(strings.NewReader(input))
 		if err != nil {
 			t.Fatal(err)
@@ -85,6 +98,60 @@ func TestParsePushSpecs_MalformedLine(t *testing.T) {
 		_, err := ParsePushSpecs(strings.NewReader(input))
 		if err == nil {
 			t.Fatal("expected error on malformed line, got nil")
+		}
+	})
+}
+
+// Reject sha tokens that don't match git's canonical 40-char hex form.
+// Without this guard, a sha-shaped token like "--upload-pack=evil" would
+// flow into `git diff --name-only X..Y` and be parsed as a flag.
+func TestParsePushSpecs_RejectsNonHexSha(t *testing.T) {
+	t.Run("spec-manifest/AC-28 ParsePushSpecs rejects non-hex local_sha", func(t *testing.T) {
+		// 40 chars, but contains uppercase + non-hex.
+		input := "refs/heads/main --upload-pack=evil refs/heads/main " + ZeroSha + "\n"
+		_, err := ParsePushSpecs(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error on non-hex local_sha, got nil")
+		}
+		if !strings.Contains(err.Error(), "local_sha") {
+			t.Errorf("expected error to name local_sha, got: %v", err)
+		}
+	})
+	t.Run("spec-manifest/AC-28 ParsePushSpecs rejects non-hex remote_sha", func(t *testing.T) {
+		input := "refs/heads/main aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main GARBAGE\n"
+		_, err := ParsePushSpecs(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error on non-hex remote_sha, got nil")
+		}
+		if !strings.Contains(err.Error(), "remote_sha") {
+			t.Errorf("expected error to name remote_sha, got: %v", err)
+		}
+	})
+	t.Run("spec-manifest/AC-28 ParsePushSpecs rejects too-short sha", func(t *testing.T) {
+		input := "refs/heads/main abc refs/heads/main " + ZeroSha + "\n"
+		_, err := ParsePushSpecs(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error on short sha, got nil")
+		}
+	})
+	t.Run("spec-manifest/AC-28 ParsePushSpecs accepts canonical 40-char hex sha", func(t *testing.T) {
+		input := "refs/heads/main aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+		specs, err := ParsePushSpecs(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("expected canonical sha to parse, got error: %v", err)
+		}
+		if len(specs) != 1 {
+			t.Errorf("expected 1 spec, got %d", len(specs))
+		}
+	})
+	t.Run("spec-manifest/AC-28 ParsePushSpecs accepts ZeroSha sentinel", func(t *testing.T) {
+		// Already covered by TestParsePushSpecs_NewBranch_ZeroRemoteSha and
+		// TestParsePushSpecs_DeletedBranch_ZeroLocalSha but verifying the new
+		// regex doesn't reject the sentinel.
+		input := "refs/heads/new aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/new " + ZeroSha + "\n"
+		_, err := ParsePushSpecs(strings.NewReader(input))
+		if err != nil {
+			t.Errorf("expected ZeroSha to be valid hex, got error: %v", err)
 		}
 	})
 }

--- a/specter/internal/manifest/prepush_test.go
+++ b/specter/internal/manifest/prepush_test.go
@@ -1,0 +1,182 @@
+// Pure-function tests for the pre-push hook helpers used by `specter pre-push-check`.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// AC-28: pre-push hook reads git's stdin format (one line per ref:
+// "local_ref local_sha remote_ref remote_sha"). ParsePushSpecs must handle
+// the common cases: single ref, multiple refs, new branch (remote sha is
+// ZeroSha), deleted branch (local sha is ZeroSha), and trailing whitespace.
+func TestParsePushSpecs_SingleRef(t *testing.T) {
+	t.Run("spec-manifest/AC-28 ParsePushSpecs single ref", func(t *testing.T) {
+		input := "refs/heads/main abc123 refs/heads/main def456\n"
+		specs, err := ParsePushSpecs(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].LocalRef != "refs/heads/main" || specs[0].LocalSha != "abc123" {
+			t.Errorf("got %+v", specs[0])
+		}
+	})
+}
+
+func TestParsePushSpecs_MultipleRefs(t *testing.T) {
+	t.Run("spec-manifest/AC-28 ParsePushSpecs multiple refs", func(t *testing.T) {
+		input := "refs/heads/feat/a aaa refs/heads/feat/a 111\nrefs/heads/feat/b bbb refs/heads/feat/b 222\n"
+		specs, err := ParsePushSpecs(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(specs) != 2 {
+			t.Fatalf("expected 2 specs, got %d", len(specs))
+		}
+	})
+}
+
+func TestParsePushSpecs_NewBranch_ZeroRemoteSha(t *testing.T) {
+	t.Run("spec-manifest/AC-28 ParsePushSpecs new branch carries zero remote sha", func(t *testing.T) {
+		input := "refs/heads/new abc123 refs/heads/new " + ZeroSha + "\n"
+		specs, err := ParsePushSpecs(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if specs[0].RemoteSha != ZeroSha {
+			t.Errorf("expected remote sha = ZeroSha for new branch, got %q", specs[0].RemoteSha)
+		}
+	})
+}
+
+func TestParsePushSpecs_DeletedBranch_ZeroLocalSha(t *testing.T) {
+	t.Run("spec-manifest/AC-28 ParsePushSpecs deleted branch carries zero local sha", func(t *testing.T) {
+		input := "refs/heads/gone " + ZeroSha + " refs/heads/gone abc123\n"
+		specs, err := ParsePushSpecs(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if specs[0].LocalSha != ZeroSha {
+			t.Errorf("expected local sha = ZeroSha for deleted branch, got %q", specs[0].LocalSha)
+		}
+	})
+}
+
+func TestParsePushSpecs_EmptyInput(t *testing.T) {
+	t.Run("spec-manifest/AC-28 ParsePushSpecs empty stdin returns empty slice", func(t *testing.T) {
+		specs, err := ParsePushSpecs(strings.NewReader(""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(specs) != 0 {
+			t.Errorf("expected no specs from empty input, got %d", len(specs))
+		}
+	})
+}
+
+func TestParsePushSpecs_MalformedLine(t *testing.T) {
+	t.Run("spec-manifest/AC-28 ParsePushSpecs malformed line returns error", func(t *testing.T) {
+		input := "only-three tokens here\n"
+		_, err := ParsePushSpecs(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error on malformed line, got nil")
+		}
+	})
+}
+
+// AC-28: HasAnnotationDelta reports whether the unified-diff output contains
+// any added line (starting with `+` but not `+++`) carrying `@spec ` or `@ac `.
+func TestHasAnnotationDelta_AddedSpecLine(t *testing.T) {
+	t.Run("spec-manifest/AC-28 HasAnnotationDelta detects added @spec line", func(t *testing.T) {
+		diff := "+++ b/foo_test.go\n+// @spec spec-foo\n+// @ac AC-01\n"
+		if !HasAnnotationDelta(diff) {
+			t.Errorf("expected delta detected, got false")
+		}
+	})
+}
+
+func TestHasAnnotationDelta_RemovedAnnotationOnly(t *testing.T) {
+	t.Run("spec-manifest/AC-28 HasAnnotationDelta ignores removed-only annotations", func(t *testing.T) {
+		// Only `-` lines (deletion) — count as a delta? A removed annotation
+		// is a code change that loses test coverage, but it's still a change
+		// to the annotation set. Decision: count as delta. (Removing a test
+		// without a replacement is something coverage --strict will catch
+		// downstream; the hook just needs "annotation lines moved at all".)
+		diff := "+++ b/foo_test.go\n-// @ac AC-01\n"
+		if !HasAnnotationDelta(diff) {
+			t.Errorf("expected removed-only annotation to count as delta, got false")
+		}
+	})
+}
+
+func TestHasAnnotationDelta_NoChange(t *testing.T) {
+	t.Run("spec-manifest/AC-28 HasAnnotationDelta returns false when no @spec/@ac lines added or removed", func(t *testing.T) {
+		diff := "+++ b/foo.go\n+func bar() {}\n-func baz() {}\n"
+		if HasAnnotationDelta(diff) {
+			t.Errorf("expected no delta, got true")
+		}
+	})
+}
+
+func TestHasAnnotationDelta_ContextLineIgnored(t *testing.T) {
+	t.Run("spec-manifest/AC-28 HasAnnotationDelta ignores context lines mentioning @spec", func(t *testing.T) {
+		// Context lines (no leading + or -) appear in unified diff but are
+		// unchanged — not part of the delta.
+		diff := " // @spec foo\n+func bar() {}\n"
+		if HasAnnotationDelta(diff) {
+			t.Errorf("expected context line not to count as delta, got true")
+		}
+	})
+}
+
+func TestHasAnnotationDelta_DiffHeaderIgnored(t *testing.T) {
+	t.Run("spec-manifest/AC-28 HasAnnotationDelta ignores +++/--- diff headers", func(t *testing.T) {
+		// The +++ b/foo.go header isn't an added line of code; must not
+		// match the @spec/@ac scan even though it begins with +.
+		diff := "+++ b/foo.go\n--- a/foo.go\n+func x() {}\n"
+		if HasAnnotationDelta(diff) {
+			t.Errorf("expected diff headers not to count as delta, got true")
+		}
+	})
+}
+
+// SummarizePushDiff combines file categorization (existing IsImplFile etc.)
+// with annotation-delta detection into one PushDiffSummary that ShouldBlockPush
+// can consume directly.
+func TestSummarizePushDiff_ImplOnlyNoAnnotation(t *testing.T) {
+	t.Run("spec-manifest/AC-28 SummarizePushDiff impl-only no-annotation produces blocking summary", func(t *testing.T) {
+		filenames := []string{"internal/foo/bar.go"}
+		diff := "+++ b/internal/foo/bar.go\n+func bar() {}\n"
+		s := SummarizePushDiff(filenames, diff)
+
+		if len(s.ImplFilesChanged) != 1 || s.ImplFilesChanged[0] != "internal/foo/bar.go" {
+			t.Errorf("expected impl files = [internal/foo/bar.go], got %+v", s.ImplFilesChanged)
+		}
+		if s.AnnotationDelta {
+			t.Errorf("expected no annotation delta, got true")
+		}
+		if !ShouldBlockPush(s) {
+			t.Errorf("expected ShouldBlockPush = true for impl-only no-annotation")
+		}
+	})
+}
+
+func TestSummarizePushDiff_ImplPlusAnnotation(t *testing.T) {
+	t.Run("spec-manifest/AC-28 SummarizePushDiff impl + annotation delta allows push", func(t *testing.T) {
+		filenames := []string{"internal/foo/bar.go", "internal/foo/bar_test.go"}
+		diff := "+++ b/internal/foo/bar_test.go\n+// @spec spec-foo\n+// @ac AC-01\n"
+		s := SummarizePushDiff(filenames, diff)
+
+		if !s.AnnotationDelta {
+			t.Errorf("expected annotation delta, got false")
+		}
+		if ShouldBlockPush(s) {
+			t.Errorf("expected ShouldBlockPush = false for impl + annotation delta")
+		}
+	})
+}

--- a/specter/specs/spec-manifest.spec.yaml
+++ b/specter/specs/spec-manifest.spec.yaml
@@ -155,7 +155,7 @@ spec:
       enforcement: error
 
     - id: C-22
-      description: "`specter init --install-hook` MUST write a `.git/hooks/pre-push` shell script (mode 0755) that blocks pushes whose diff changes implementation files but adds or updates no `@spec` / `@ac` annotations. The hook MUST exit 0 on changes that include either an annotation delta or only doc/spec/test files; MUST exit non-zero with a clear message otherwise; and MUST be bypassable via `git push --no-verify`. The hook script body is wrapped in `<!-- specter:begin v1 --> ... <!-- specter:end -->` markers so future re-runs replace only the fenced region."
+      description: "`specter init --install-hook` MUST write a `.git/hooks/pre-push` shell script (mode 0755) that blocks pushes whose diff changes implementation files but adds or updates no `@spec` / `@ac` annotations. The hook MUST exit 0 on changes that include either an annotation delta or only doc/spec/test files; MUST exit non-zero with a clear message otherwise; and MUST be bypassable via `git push --no-verify`. The hook script body is wrapped in shell-comment markers `# specter:begin v1` / `# specter:end` (HTML-comment markers would be invalid shell syntax — `<!--` parses as a redirection token), and re-runs replace only the fenced region. The installed hook MUST parse cleanly under `sh -n`."
       type: technical
       enforcement: error
 

--- a/specter/specs/spec-manifest.spec.yaml
+++ b/specter/specs/spec-manifest.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-manifest
-  version: "1.6.0"
+  version: "1.7.0"
   status: draft
   tier: 2
 
@@ -151,6 +151,16 @@ spec:
 
     - id: C-21
       description: "`--refresh` and `--force` MUST be mutually exclusive. `specter init --refresh --force` MUST exit non-zero with a clear error message naming the conflict. Rationale: `--force` rewrites everything (operator accepts loss); `--refresh` preserves everything except `domains.default.specs` (operator wants a surgical update). Combining them is incoherent and almost always a mistake."
+      type: technical
+      enforcement: error
+
+    - id: C-22
+      description: "`specter init --install-hook` MUST write a `.git/hooks/pre-push` shell script (mode 0755) that blocks pushes whose diff changes implementation files but adds or updates no `@spec` / `@ac` annotations. The hook MUST exit 0 on changes that include either an annotation delta or only doc/spec/test files; MUST exit non-zero with a clear message otherwise; and MUST be bypassable via `git push --no-verify`. The hook script body is wrapped in `<!-- specter:begin v1 --> ... <!-- specter:end -->` markers so future re-runs replace only the fenced region."
+      type: technical
+      enforcement: error
+
+    - id: C-23
+      description: "`specter init --ai <tool>` MUST write a per-tool AI instruction file with a `<!-- specter:begin v1 --> ... <!-- specter:end -->` fenced region containing the v0.11 instruction template (preflight, Convention A, validation gate, on-demand explain references). The fenced region's tool-target path is: `claude` → `CLAUDE.md`, `codex` → `AGENTS.md`, `cursor` → `.cursor/rules/specter.md`, `copilot` → `.github/copilot-instructions.md` (body capped at 4KB), `gemini` → `GEMINI.md`. Re-runs MUST replace only the fenced region; out-of-fence content is preserved byte-for-byte. `--ai claude` checks for an existing `AGENTS.md` and writes `@AGENTS.md` import directive instead of inlining the body when one exists."
       type: technical
       enforcement: error
 
@@ -414,6 +424,116 @@ spec:
       references_constraints: ["C-21"]
       priority: medium
 
+    - id: AC-27
+      description: "`specter init --install-hook` in a workspace whose `.git/` directory exists writes `.git/hooks/pre-push` and chmods it to 0755 (executable). Re-running the same command in-place replaces only the fenced region; content outside the markers is preserved byte-for-byte."
+      inputs:
+        command: "specter init --install-hook"
+      expected_output:
+        file_written: ".git/hooks/pre-push"
+        mode: "0755"
+        idempotent_re_run: true
+      references_constraints: ["C-22"]
+      priority: critical
+
+    - id: AC-28
+      description: "Pre-push hook installed by `init --install-hook` exits non-zero on a diff containing implementation file changes (`*.go`, `*.ts`, etc.) with no corresponding `@spec` / `@ac` annotation delta in the same diff. Diff containing only doc/spec/test changes (or any annotation delta) exits 0."
+      inputs:
+        diff_with_impl_only: "internal/foo/bar.go modified, no @spec/@ac change"
+        diff_with_annotation_delta: "test file gained `// @ac AC-05`"
+      expected_output:
+        impl_only_exit_code: "non-zero"
+        annotation_delta_exit_code: 0
+      references_constraints: ["C-22"]
+      priority: critical
+
+    - id: AC-29
+      description: "`git push --no-verify` bypasses the installed pre-push hook entirely and pushes successfully even on a diff that the hook would otherwise reject."
+      inputs:
+        diff: "implementation change with no annotation delta"
+        invocation: "git push --no-verify"
+      expected_output:
+        push_succeeds: true
+        hook_was_skipped: true
+      references_constraints: ["C-22"]
+      priority: high
+
+    - id: AC-30
+      description: "`specter init --ai claude` in a workspace with no AGENTS.md writes `CLAUDE.md` containing the inline v0.11 instruction body wrapped in fenced markers."
+      inputs:
+        command: "specter init --ai claude"
+        workspace_has_agents_md: false
+      expected_output:
+        file_written: "CLAUDE.md"
+        body_is_inline: true
+        fenced_markers_present: true
+      references_constraints: ["C-23"]
+      priority: critical
+
+    - id: AC-31
+      description: "`specter init --ai codex` writes `AGENTS.md` containing the v0.11 instruction body wrapped in fenced markers."
+      inputs:
+        command: "specter init --ai codex"
+      expected_output:
+        file_written: "AGENTS.md"
+        fenced_markers_present: true
+      references_constraints: ["C-23"]
+      priority: critical
+
+    - id: AC-32
+      description: "`specter init --ai cursor` writes `.cursor/rules/specter.md` (creating the parent directory if needed) containing the v0.11 instruction body wrapped in fenced markers."
+      inputs:
+        command: "specter init --ai cursor"
+      expected_output:
+        file_written: ".cursor/rules/specter.md"
+        parent_dir_created: true
+        fenced_markers_present: true
+      references_constraints: ["C-23"]
+      priority: critical
+
+    - id: AC-33
+      description: "`specter init --ai copilot` writes `.github/copilot-instructions.md` (creating the parent directory if needed) with the body capped at 4096 bytes (Copilot's code-review limit). Truncation, if needed, preserves the most-load-bearing rules at the top."
+      inputs:
+        command: "specter init --ai copilot"
+      expected_output:
+        file_written: ".github/copilot-instructions.md"
+        body_size_le_4096_bytes: true
+      references_constraints: ["C-23"]
+      priority: high
+
+    - id: AC-34
+      description: "`specter init --ai gemini` writes `GEMINI.md` containing the v0.11 instruction body wrapped in fenced markers."
+      inputs:
+        command: "specter init --ai gemini"
+      expected_output:
+        file_written: "GEMINI.md"
+        fenced_markers_present: true
+      references_constraints: ["C-23"]
+      priority: critical
+
+    - id: AC-35
+      description: "Re-running `specter init --ai <tool>` in a workspace where the target file has been edited outside the fenced region replaces only the content between the markers; user-authored content outside the markers is preserved byte-for-byte."
+      inputs:
+        first_run: "specter init --ai codex"
+        user_edit: "appended user notes after </specter:end>"
+        second_run: "specter init --ai codex"
+      expected_output:
+        out_of_fence_content_preserved: true
+        in_fence_content_replaced: true
+      references_constraints: ["C-23"]
+      priority: critical
+
+    - id: AC-36
+      description: "`specter init --ai claude` in a workspace where `AGENTS.md` already exists writes `CLAUDE.md` whose fenced body is `@AGENTS.md` (Claude's import directive) plus an empty `## Claude-specific notes` section, NOT the inline instruction body. This avoids duplicating the instruction template across both files."
+      inputs:
+        workspace_has_agents_md: true
+        command: "specter init --ai claude"
+      expected_output:
+        file_written: "CLAUDE.md"
+        fenced_body_contains: "@AGENTS.md"
+        fenced_body_omits_inline_template: true
+      references_constraints: ["C-23"]
+      priority: high
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.0.0"
@@ -423,6 +543,11 @@ spec:
       relationship: requires
 
   changelog:
+    - version: "1.7.0"
+      date: "2026-04-25"
+      author: "specter-team"
+      type: minor
+      description: "v0.11 init bundle. Add C-22/AC-27..29 for `init --install-hook`: writes a git pre-push hook that blocks pushes with implementation diffs lacking @spec/@ac annotation deltas. Add C-23/AC-30..36 for `init --ai <tool>`: writes per-tool AI instruction file (claude/codex/cursor/copilot/gemini) with idempotent fenced markers so re-runs preserve out-of-fence content. Both use the `<!-- specter:begin v1 --> ... <!-- specter:end -->` block format. Closes the v0.10.x docs/code drift class by giving the AI a concise project guide that asks Specter for spec content on demand instead of dumping it pre-loaded."
     - version: "1.6.0"
       date: "2026-04-20"
       author: "specter-team"


### PR DESCRIPTION
## Summary

Wave B of the v0.11 cycle. Bundles Features 3 + 4 + the wiring subcommand:

- **`specter init --install-hook`** — writes `.git/hooks/pre-push` (mode 0755) that blocks pushes whose diff changes implementation files but adds no `@spec`/`@ac` annotation delta.
- **`specter init --ai <tool>`** — writes per-tool AI instruction file (claude, codex, cursor, copilot, gemini) with the v0.11 design-synthesis template.
- **`specter pre-push-check`** (hidden subcommand) — wires up the hook end-to-end: reads git's pre-push stdin format, runs `git diff`, classifies impl/test/spec/doc, calls `ShouldBlockPush`, exits with the right code.

Spec: `spec-manifest` 1.6.0 → 1.7.0 (adds C-22, C-23, AC-27..AC-36).

### What's in the box

**Pure functions** in `internal/manifest/`:
- `fenced.go` — `ReplaceFencedRegion` with `FencedMarkers` parameter so shell scripts use `# specter:begin v1` markers and markdown files use HTML-comment markers (`<!--`).
- `hook.go` — `PrePushHookScript()`, `ShouldBlockPush(PushDiffSummary)`, file categorization (`IsImplFile`, `isTestFile`, `isSpecFile`, `isDocFile`).
- `ai_templates.go` — `AITargetPath`, `AIInstructionBody` (full template), `aiCopilotBody` (4KB-capped variant), `aiClaudeImportBody` (`@AGENTS.md` import for claude when AGENTS.md exists), `RenderAIInstructions`.
- `prepush.go` — `ParsePushSpecs` (git stdin format), `HasAnnotationDelta`, `SummarizePushDiff`.

**CLI** in `cmd/specter/`:
- `init --install-hook` and `init --ai <tool>` flags wired into `initCmd`.
- `pre-push-check` registered as a hidden subcommand. Reads stdin → runs `git diff` per ref → builds summary → exits non-zero on block.

**AI instruction template** reflects the v0.11 BACKLOG design synthesis:
- Preflight self-check at the top (read spec before code).
- Convention A good/bad code examples.
- `make dogfood-strict` validation gate.
- On-demand references to `specter explain` (no spec content dumped).
- ~80-line cap; copilot variant fits in Copilot's 4096-byte code-review window.

### Commits (SDD cycle + agent-review fixes)

1. `feat(init): spec bump 1.6.0→1.7.0` — C-22, C-23, AC-27..AC-36
2. `test(init): tests for AC-27..36` — pure (fenced/hook/ai_templates) + CLI (init_hook/init_ai), all failing against old code
3. `feat(init): implement v0.11 init bundle — install-hook + ai <tool>` — internal/manifest + CLI wiring
4. `feat(init): implement pre-push-check subcommand wiring up the hook` — internal/manifest/prepush.go + cmd/specter/prepush.go + 4 integration tests with real git repos
5. `fix(init): pre-PR fixes from 2-agent review` — see below

### Agent review (2-agent functional + spec-code parity, mandatory per Docs Review Policy)

**Blocker fixed before push:** the originally-installed hook was invalid shell. HTML-comment markers (`<!--`) parse as a `<` redirection in `sh`, breaking every push with a syntax error. Tests didn't catch it because none ran the script through `sh`. Fix: refactor `ReplaceFencedRegion` to take a `FencedMarkers` parameter, add `ShellMarkers` constant for shell scripts. New regression test runs `sh -n` on the installed hook — would have caught the original bug.

**Material fixes:**
- AC-28 regex tightened to require comment-marker context (`//`/`#`/`*`). Prose mentions of `@spec` in a CHANGELOG diff no longer count as annotation delta.
- AC-33 cap is now an enforced guard, not happenstance: `RenderAIInstructions` returns an error if the rendered copilot body exceeds 4096 bytes. Future template growth that overflows fails at test time.

**Minor UX fix:**
- `init --install-hook --ai claude` previously silently ran only the hook (early-return on first matching flag). Now errors with a clear message that the two flags are different write targets.

### Pre-merge verification

- `make check` ✓
- `make dogfood-strict` ✓ (15/15 specs at 100%)
- Smoke-tested end-to-end:
  - Installed hook parses with `sh -n`
  - `init --ai <tool>` writes correct paths for all 5 tools
  - Idempotent re-run preserves user content outside fenced markers byte-for-byte
  - Claude with existing `AGENTS.md` uses `@AGENTS.md` import (not inline body)
  - `pre-push-check` blocks impl-only diffs and allows annotation-delta diffs in real git repos

### Known follow-ups (deferred to v0.12 / not blocking)

- New-branch first-push without `origin/HEAD` merge-base: hook silently skips. Documented in code comment; could log a one-line stderr diagnostic.
- `sync` printing summary counts only on check failure — flagged in earlier feat/check-test PR (#74).
- `gitDiffFilenames` uses `\n` split rather than `-z` — paths with embedded newlines mis-parse. Low real-world risk.
- `AGENTS.md` as a directory passes the `os.Stat` check and triggers `@AGENTS.md` import (corner case; harmless).
- Husky / pre-existing-hook composability: works correctly via fenced-region append; could warn the user about the merge.

## Test plan

- [ ] Build a fresh binary, install hook in a real git repo (`mkdir -p /tmp/x/.git/hooks && cd /tmp/x && /path/to/specter init --install-hook`)
- [ ] `sh -n .git/hooks/pre-push` parses cleanly
- [ ] `init --ai claude/codex/cursor/copilot/gemini` writes the right files
- [ ] `init --ai claude` with existing `AGENTS.md` writes `@AGENTS.md` import
- [ ] Idempotent re-run of `init --ai codex`: prepend/append user content, re-run, verify preserved
- [ ] `init --install-hook --ai claude` errors with mutual-exclusivity message
- [ ] Real git push of impl-only commit: hook blocks
- [ ] Same with annotation delta: hook allows
- [ ] `git push --no-verify`: bypasses (git's behavior)
- [ ] `make dogfood-strict` green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)