### PR TITLE
ci: close three pre-release testing gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,24 @@ jobs:
           bin/specter coverage
           bin/specter sync
 
+      # Mechanical eval gate: jest + go test -json → ingest → coverage --strict.
+      # Closes the gap where regular CI ran non-strict coverage only — strict
+      # was enforced locally via `make dogfood-strict` but not by CI.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: specter/vscode-extension/package-lock.json
+
+      - name: VS Code extension — install + jest
+        working-directory: specter/vscode-extension
+        run: |
+          npm ci
+          npm test
+
+      - name: Mechanical eval gate — make dogfood-strict
+        run: make dogfood-strict
+
       - name: Validate PR title (Conventional Commits)
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/pre-release-test.yml
+++ b/.github/workflows/pre-release-test.yml
@@ -6,9 +6,16 @@ name: Pre-Release Test Suite
 # Tier 3: Real-world validation against 12 open-source repos
 
 on:
+  # Tag push: catch-all safety net before the GitHub Release publishes.
   push:
     tags:
       - "v*"
+  # PR to main: gates every working-branch → main merge before the tag exists.
+  # Closes the ordering gap where Tier 3 (real-world matrix) only ran AFTER
+  # tagging, by which time release.yml had already started building artifacts.
+  pull_request:
+    branches: [main]
+    paths: ['specter/**', '.github/**']
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## Summary

Closes three pre-release testing gaps surfaced during the v0.11 cycle review. CI now enforces the same gates that local \`make\` targets enforce.

| Gap | Impact | Fix |
|---|---|---|
| 1 | \`coverage --strict\` not enforced in CI — only \`coverage\` (annotation count) ran. PRs breaking strict mode could merge. | Add \`make dogfood-strict\` step to \`ci.yml\`. |
| 2 | VS Code extension jest suite not in CI. TS-side regressions slipped through to merge. | Add Node 20 setup + \`npm ci\` + \`npm test\` to \`ci.yml\` (also a prerequisite for dogfood-strict). |
| 3 | Tier 3 real-world matrix (12 OSS repos) only fired on tag push, parallel with \`release.yml\`. GitHub Release published artifacts before regression validation completed. Wrong order. | Add \`on: pull_request: branches: [main]\` trigger to \`pre-release-test.yml\`. Full Tier 1+2+3 now gates working-branch → main merges. |

CI-only changes. No Specter behavior change. No spec bumps.

## Why this matters now

The 5 in-flight v0.11 PRs (\`#73\`/\`#74\`/\`#81\`/\`#82\`/\`#83\`) all passed CI when CI did not enforce strictness or run jest. The integration smoke test I ran locally confirmed the merged stack is clean — but that was a manual run, not a CI gate. Landing this PR before the v0.11 stack ensures the next PRs (and the merge to main) carry the stronger gate.

## In-flight PR impact

The 5 v0.11 PRs need to rebase against \`release/v0.11\` after this lands to pick up the new gates. If any PR fails the new gates after rebase, the bug was already there — CI just couldn't see it.

## Test plan

- [ ] CI runs on this PR — confirm Node 20 setup + npm ci + npm test + dogfood-strict all execute cleanly.
- [ ] Open a quick noop PR to \`release/v0.11\` after this lands and confirm the same gates fire.
- [ ] Manual dispatch of \`pre-release-test.yml\` to confirm Tier 3 matrix still works after the trigger change.
- [ ] When the v0.11 working-branch → main PR is opened, confirm \`pre-release-test.yml\` runs as a merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)