### PR TITLE
fix(vscode): tighten input validation on workspace-scoped settings

### DIFF
--- a/specter/vscode-extension/package.json
+++ b/specter/vscode-extension/package.json
@@ -30,6 +30,12 @@
     "url": "https://github.com/Hanalyx/specter"
   },
   "main": "./out/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Specter executes a CLI binary discovered from PATH or downloaded from GitHub Releases. Workspace-scoped overrides for the binary path and version are ignored in untrusted workspaces."
+    }
+  },
   "activationEvents": [
     "workspaceContains:**/specter.yaml",
     "workspaceContains:**/*.spec.yaml"
@@ -41,7 +47,8 @@
         "specter.binaryPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the specter binary. If empty, Specter will search PATH then ~/.specter/bin/specter, then auto-download."
+          "scope": "machine",
+          "description": "Path to the specter binary. If empty, Specter will search PATH then ~/.specter/bin/specter, then auto-download. Machine-scoped: ignored by workspace and folder settings."
         },
         "specter.autoDownload": {
           "type": "boolean",
@@ -51,7 +58,8 @@
         "specter.version": {
           "type": "string",
           "default": "",
-          "description": "Specter CLI version to auto-download. Empty (default) matches the extension version. Set 'latest' to always track the newest GitHub release, or pin a specific version (e.g. '0.9.2')."
+          "scope": "machine",
+          "description": "Specter CLI version to auto-download. Empty (default) matches the extension version. Set 'latest' to always track the newest GitHub release, or pin a specific version (e.g. '0.9.2'). Machine-scoped: ignored by workspace and folder settings."
         },
         "specter.showInsightsOnFailure": {
           "type": "boolean",

--- a/specter/vscode-extension/src/__tests__/binary.test.ts
+++ b/specter/vscode-extension/src/__tests__/binary.test.ts
@@ -3,7 +3,7 @@
 // Tests for binary discovery and auto-download logic.
 // All functions under test are pure or injectable — no VS Code runtime required.
 
-import { resolveBinaryPath, verifyChecksum, buildDownloadUrl, isBinaryFile } from '../binaryDiscovery';
+import { resolveBinaryPath, verifyChecksum, buildDownloadUrl, isBinaryFile, validateVersion } from '../binaryDiscovery';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -216,5 +216,67 @@ describe('[spec-vscode/AC-50] specter.version config default (C-27)', () => {
     // default, version skew between the Marketplace extension and the
     // GoReleaser-produced GitHub Release reappears. Keep the default empty
     // so downloadBinary reads ctx.extension.packageJSON.version.
+  });
+});
+
+describe('[spec-vscode] validateVersion — input validation for version strings used in URLs', () => {
+  it('accepts plain semver MAJOR.MINOR.PATCH', () => {
+    expect(() => validateVersion('0.10.2')).not.toThrow();
+    expect(() => validateVersion('1.0.0')).not.toThrow();
+    expect(() => validateVersion('123.456.789')).not.toThrow();
+  });
+
+  it('accepts semver with pre-release suffix', () => {
+    expect(() => validateVersion('0.10.0-rc.1')).not.toThrow();
+    expect(() => validateVersion('1.0.0-beta')).not.toThrow();
+    expect(() => validateVersion('0.10.0-pre.20260425')).not.toThrow();
+  });
+
+  it('rejects strings with path separators (URL injection guard)', () => {
+    expect(() => validateVersion('0.10.0/../../attacker/evil/releases/download/v1.0.0')).toThrow();
+    expect(() => validateVersion('0.10.0/extra')).toThrow();
+    expect(() => validateVersion('../../malicious')).toThrow();
+  });
+
+  it('rejects strings with whitespace, query strings, or special URL chars', () => {
+    expect(() => validateVersion('0.10.0 ')).toThrow();
+    expect(() => validateVersion('0.10.0?token=abc')).toThrow();
+    expect(() => validateVersion('0.10.0#frag')).toThrow();
+    expect(() => validateVersion('0.10.0\n0.10.0')).toThrow();
+  });
+
+  it('rejects empty string and non-string inputs', () => {
+    expect(() => validateVersion('')).toThrow();
+    expect(() => validateVersion(undefined as unknown as string)).toThrow();
+    expect(() => validateVersion(null as unknown as string)).toThrow();
+    expect(() => validateVersion(123 as unknown as string)).toThrow();
+  });
+
+  it('rejects "latest" — callers must resolve it to a concrete version first', () => {
+    // resolveLatestVersion() in binaryDiscovery.ts queries the GitHub API and
+    // returns a concrete tag; that result is what flows into URL construction.
+    expect(() => validateVersion('latest')).toThrow();
+  });
+
+  it('buildDownloadUrl propagates the validation error', () => {
+    expect(() => buildDownloadUrl({ version: '0.10.0/evil', os: 'linux', arch: 'amd64' })).toThrow(/invalid specter version/);
+  });
+});
+
+describe('[spec-vscode] package.json declares machine-scope and untrusted-workspace capability', () => {
+  const pkg = require('../../package.json');
+
+  it('specter.binaryPath is machine-scoped', () => {
+    expect(pkg.contributes.configuration.properties['specter.binaryPath'].scope).toBe('machine');
+  });
+
+  it('specter.version is machine-scoped', () => {
+    expect(pkg.contributes.configuration.properties['specter.version'].scope).toBe('machine');
+  });
+
+  it('declares untrustedWorkspaces capability with explanation', () => {
+    expect(pkg.capabilities?.untrustedWorkspaces?.supported).toBe('limited');
+    expect(typeof pkg.capabilities.untrustedWorkspaces.description).toBe('string');
+    expect(pkg.capabilities.untrustedWorkspaces.description.length).toBeGreaterThan(0);
   });
 });

--- a/specter/vscode-extension/src/binaryDiscovery.ts
+++ b/specter/vscode-extension/src/binaryDiscovery.ts
@@ -127,10 +127,35 @@ function normaliseOS(platform: string): string {
 }
 
 /**
+ * Strict semver validation for version strings used in download URLs.
+ * Accepts MAJOR.MINOR.PATCH with an optional pre-release suffix
+ * (alphanumerics, dots, hyphens). The literal string "latest" is NOT
+ * valid here — callers must resolve "latest" via resolveLatestVersion()
+ * before passing the version into URL construction.
+ *
+ * Anything outside this shape is rejected with an Error. Without this
+ * guard, an attacker-controlled `specter.version` setting (e.g. via a
+ * malicious workspace's `.vscode/settings.json`) could inject path
+ * separators or query strings into the download URL and redirect to a
+ * different repo on the same host, bypassing TLS and checksum verification.
+ */
+const VALID_VERSION = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
+
+export function validateVersion(version: string): void {
+  if (typeof version !== 'string' || !VALID_VERSION.test(version)) {
+    throw new Error(
+      `invalid specter version ${JSON.stringify(version)}: ` +
+      `expected MAJOR.MINOR.PATCH (e.g. "0.10.2") or "latest"`,
+    );
+  }
+}
+
+/**
  * Returns the archive file name for a given version / os / arch triple.
  * Matches goreleaser's naming template: specter_{version}_{os}_{arch}.tar.gz
  */
 export function assetName(opts: DownloadUrlOptions): string {
+  validateVersion(opts.version);
   const goOS   = normaliseOS(opts.os);
   const goArch = normaliseArch(opts.arch);
   const ext    = goOS === 'windows' ? '.zip' : '.tar.gz';
@@ -143,6 +168,7 @@ export function assetName(opts: DownloadUrlOptions): string {
  * string (e.g. "0.6.0"), NOT "latest".
  */
 export function buildDownloadUrl(opts: DownloadUrlOptions): string {
+  validateVersion(opts.version);
   return `https://github.com/Hanalyx/specter/releases/download/v${opts.version}/${assetName(opts)}`;
 }
 
@@ -285,6 +311,7 @@ export async function verifyChecksum(content: Buffer, expectedHex: string): Prom
  * filename → sha256 hex string.  goreleaser format: `<sha256>  <filename>`.
  */
 export async function downloadChecksums(version: string): Promise<Map<string, string>> {
+  validateVersion(version);
   const url = `https://github.com/Hanalyx/specter/releases/download/v${version}/checksums.txt`;
   const data = await httpsGet(url);
   const map = new Map<string, string>();

--- a/specter/vscode-extension/src/extension.ts
+++ b/specter/vscode-extension/src/extension.ts
@@ -265,7 +265,7 @@ async function resolveBinary(ctx: vscode.ExtensionContext): Promise<string | nul
     workspaceSetting,
     which: name => {
       try {
-        const out = require('child_process').execSync(`which ${name}`, { encoding: 'utf8' });
+        const out = require('child_process').execFileSync('which', [name], { encoding: 'utf8' });
         return (out as string).trim() || null;
       } catch { return null; }
     },
@@ -980,9 +980,20 @@ function registerDiagnosticHooks(ctx: vscode.ExtensionContext): void {
                   ...(notification.actions ?? []),
                 );
                 if (choice === 'View Diff') {
-                  const terminal = vscode.window.createTerminal('Specter Diff');
-                  terminal.sendText(`specter diff ${doc.uri.fsPath}@HEAD ${doc.uri.fsPath}`);
-                  terminal.show();
+                  const fsPath = doc.uri.fsPath;
+                  // Reject paths containing shell-active characters before
+                  // they reach `terminal.sendText`. The terminal runs the
+                  // user's shell, so an unquoted path with `;`, `|`, `$`,
+                  // backticks, etc. would execute as separate commands.
+                  if (/[\s;|&$`'"\\<>(){}*?!#]/.test(fsPath)) {
+                    vscode.window.showWarningMessage(
+                      `Specter: cannot run diff on a path containing shell metacharacters: ${path.basename(fsPath)}`,
+                    );
+                  } else {
+                    const terminal = vscode.window.createTerminal('Specter Diff');
+                    terminal.sendText(`specter diff ${fsPath}@HEAD ${fsPath}`);
+                    terminal.show();
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary

Hardens four workspace-scoped surfaces in the VS Code extension. All identified during a pre-release security review of v0.11. Generic descriptions; full threat-model writeup will follow disclosure.

| Change | Surface |
|---|---|
| Validate \`specter.version\` against strict semver before URL interpolation | \`binaryDiscovery.ts\` (\`validateVersion\` + 3 call sites) |
| Declare \`specter.binaryPath\` and \`specter.version\` \`"scope": "machine"\` | \`package.json\` |
| Declare \`capabilities.untrustedWorkspaces\` with \`supported: "limited"\` | \`package.json\` |
| Refuse paths containing shell metacharacters before \`terminal.sendText\` | \`extension.ts\` "View Diff" handler |
| Switch \`which\` shim from \`execSync(\`which \${name}\`)\` template string to \`execFileSync('which', [name])\` array form | \`extension.ts\` |

## Verification

- \`npm run typecheck\` clean
- \`npm test\` — 220/220 pass (10 new + 210 pre-existing)
- 10 new unit tests cover the validator (accepts/rejects matrix), \`buildDownloadUrl\` propagation, machine-scope schema, and \`untrustedWorkspaces\` capability.

## Disclosure

Full threat-model details in a private security advisory; this PR's body is intentionally generic. Pairs with \`hotfix/init-bundle\` (sha validation in pre-push) and \`fix/go-version-bump\` (Go 1.25.9 stdlib advisories) for the v0.11.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)