### PR TITLE
chore: bump go directive to 1.25.9

### DIFF
--- a/.github/workflows/pre-release-test.yml
+++ b/.github/workflows/pre-release-test.yml
@@ -51,13 +51,9 @@ jobs:
         run: go test -race ./...
 
       - name: Vulnerability scan
-        # govulncheck@latest requires go1.25+. Install go1.25.9 for this step
-        # only — the rest of the workflow uses the version from go.mod (1.22.2).
         run: |
-          go install golang.org/dl/go1.25.9@latest
-          ~/go/bin/go1.25.9 download
-          ~/go/bin/go1.25.9 install golang.org/x/vuln/cmd/govulncheck@latest
-          ~/go/bin/go1.25.9 run golang.org/x/vuln/cmd/govulncheck@latest ./...
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
 
       - name: Build
         run: go build -o bin/specter ./cmd/specter/

--- a/specter/go.mod
+++ b/specter/go.mod
@@ -1,6 +1,6 @@
 module github.com/Hanalyx/specter
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary

Bumps the \`go\` directive in \`go.mod\` from \`1.25.8\` to \`1.25.9\`. Five stdlib advisories landed in 1.25.9; building releases against 1.25.8 ships those bugs even though \`govulncheck\` (which runs on 1.25.9 in pre-release-test.yml via a manual install dance) reports green at the symbol level.

Also drops the \`go1.25.9 install\` workaround in \`pre-release-test.yml\`. Once \`go.mod\` tracks the latest patch, \`actions/setup-go\` pulls 1.25.9 natively and \`govulncheck@latest\` runs without the manual download step.

## Verification

- \`make check\` green
- No code change beyond the directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)