### PR TITLE
docs(v0.11): release notes, explainer, python followup plan, security section

### DIFF
--- a/specter/CHANGELOG.md
+++ b/specter/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Specter (CLI + VS Code extension) documented here. The pr
 
 **Theme: AI loop discipline + adoption hardening.**
 
-Five new features close order-of-operations gaps. Four GH issues closed from real adopter friction. Full walkthrough in `docs/explainer/v0.11-ai-loop-discipline.md`.
+Five new features close order-of-operations gaps; four GH issues from real adopter friction are fixed (#75, #76, #78, #79 cheap fix). Full walkthrough in `docs/explainer/v0.11-ai-loop-discipline.md`.
 
 ### Added
 
@@ -62,7 +62,7 @@ Five tools, one command per tool:
 
 Body wrapped in `<!-- specter:begin v1 -->` / `<!-- specter:end -->` markers. Re-runs replace only the fenced region; out-of-fence content preserved byte-for-byte.
 
-Body teaches the AI to (1) read the spec before writing code, (2) use Convention A annotations with good/bad examples, (3) run `make dogfood-strict` before declaring work done, (4) ask Specter for spec content on demand via `specter explain` rather than from a pre-loaded snapshot.
+Body teaches the AI to (1) read the spec before writing code, (2) use Convention A annotations with good/bad examples, (3) run `make dogfood-strict` before declaring work done, (4) call `specter explain` for spec content on demand.
 
 `--ai claude` checks for an existing `AGENTS.md` and writes `@AGENTS.md` import directive instead of inlining the body, avoiding duplication.
 
@@ -98,7 +98,7 @@ settings:
 
 Used when `--tests` is unset. Supports `**` (recursive). List form unions matches.
 
-Spec: `spec-manifest` C-25, AC-39.
+Spec: `spec-manifest` C-25, AC-39. Closes GH #78.
 
 ### Fixed
 
@@ -133,8 +133,7 @@ Spec: `spec-ingest` 1.2.0 → 1.3.0 (C-12, AC-12).
 
 ### Changed
 
-- `specter.yaml` parsing is now strict about unknown keys at the top level and under `settings:`. Existing manifests with typos that were silently ignored will start failing. Error messages include did-you-mean suggestions when the offending key is close to a valid one.
-- `loadManifest()` (internal) now returns an error when an existing `specter.yaml` fails to parse, rather than silently falling back to defaults. Library helpers (`noSpecsMessage`, `discoverSpecs`) tolerate missing manifests; RunE handlers fail-fast on invalid ones.
+- `loadManifest()` (internal) now returns an error when an existing `specter.yaml` fails to parse, rather than silently falling back to defaults. Library helpers (`noSpecsMessage`, `discoverSpecs`) tolerate missing manifests; RunE handlers fail-fast on invalid ones. Combined with the unknown-key rejection above, every typo in `specter.yaml` now surfaces at parse time.
 - `discoverTestFiles` no longer falls through to walking `.` when an explicit glob matches zero files. The empty result is surfaced (and warned about) instead of hidden behind a noisy walk.
 - `specter coverage --strict` exit codes: 0 (pass), 2 (strictness violation under zero-tolerance), 3 (approval-gate violation under zero-tolerance), errSilent (tier-threshold failure under threshold mode).
 

--- a/specter/CHANGELOG.md
+++ b/specter/CHANGELOG.md
@@ -131,6 +131,16 @@ The bigger fix (a `pytest-specter` plugin) is tracked for a follow-up.
 
 Spec: `spec-ingest` 1.2.0 → 1.3.0 (C-12, AC-12).
 
+### Security
+
+A pre-release security review identified hardening opportunities across the VS Code extension, the CLI, and the build. All addressed in v0.11.0:
+
+- **VS Code extension** — `specter.binaryPath` and `specter.version` are now declared `"scope": "machine"`, so workspace-level overrides are ignored. `specter.version` is additionally validated against strict semver (`^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$`) before being interpolated into download URLs. `package.json` declares `capabilities.untrustedWorkspaces` with `supported: "limited"`. The "View Diff" terminal command refuses paths containing shell metacharacters before reaching `terminal.sendText`. The `which` shim switched from `execSync` template strings to `execFileSync` array form.
+- **CLI — pre-push hook** (new in v0.11.0): `ParsePushSpecs` validates `local_sha` and `remote_sha` against git's canonical 40-char hex form. `init --install-hook` uses `os.Lstat` and refuses to write through a `.git` symlink or worktree pointer file.
+- **Build** — `go.mod` directive bumped from `1.25.8` to `1.25.9`, picking up five stdlib advisories (TLS, x509, archive/tar, html/template).
+
+No CVEs were assigned; the findings were caught pre-release. The disclosure note in `docs/explainer/v0.11-ai-loop-discipline.md` covers the threat model and mitigations.
+
 ### Changed
 
 - `loadManifest()` (internal) now returns an error when an existing `specter.yaml` fails to parse, rather than silently falling back to defaults. Library helpers (`noSpecsMessage`, `discoverSpecs`) tolerate missing manifests; RunE handlers fail-fast on invalid ones. Combined with the unknown-key rejection above, every typo in `specter.yaml` now surfaces at parse time.

--- a/specter/CHANGELOG.md
+++ b/specter/CHANGELOG.md
@@ -4,6 +4,169 @@ All notable changes to Specter (CLI + VS Code extension) documented here. The pr
 
 ---
 
+## v0.11.0 — 2026-04-25 (DRAFT)
+
+**Theme: AI loop discipline + adoption hardening.**
+
+Five new features close order-of-operations gaps. Four GH issues closed from real adopter friction. Full walkthrough in `docs/explainer/v0.11-ai-loop-discipline.md`.
+
+### Added
+
+#### `specter explain` — three new read-only surfaces
+
+Stdout-only. File writes are scoped to `init --ai <tool>` (below).
+
+- `specter explain annotation` — prints the test-annotation reference (Convention A title form, Convention B runtime-log form, source-comment annotations that pair with either).
+- `specter explain schema` — prints the full schema field reference. Walks JSON `$ref` into `$defs` so nested fields under `spec.acceptance_criteria.items.*` and `spec.constraints.items.*` resolve.
+- `specter explain schema <field-path>` — prints single-field detail (type, default, enum, description). Returns non-zero with a `did you mean?` suggestion within Levenshtein 3 on unknown paths.
+- `specter explain <spec-id>` (no AC suffix) — now renders a spec card: tier, coverage %, per-AC test files. Previously showed only COVERED/UNCOVERED labels.
+
+Spec: `spec-explain` 1.0.0 → 1.1.0 (C-09..C-12, AC-07..AC-10).
+
+#### `specter check --test` (`-t`) — test-annotation cross-reference
+
+Opt-in flag. Scans test files for `@spec` / `@ac` source comments and emits diagnostics for references that don't resolve against parsed specs. Three diagnostic kinds:
+
+- `unknown_spec_ref` — `// @spec foo` where no spec with that id exists.
+- `unknown_ac_ref` — `// @spec real-spec` + `// @ac AC-99` where the named spec doesn't declare that AC.
+- `malformed_ac_id` — IDs failing `^AC-\d{2,}$` (`AC-1` not zero-padded, `ac-01` wrong case, `AC-1A` suffixed).
+
+Skips lines inside multi-line string literals (TS template strings, Python triple-quoted strings). Cascade rule: when `@spec` is unknown, child `@ac` lines are not separately checked. `specter sync --strict` (and `settings.strict: true`) routes the check through.
+
+Spec: `spec-check` 1.1.0 → 1.2.0 (C-09, AC-09..AC-12).
+
+#### `specter init --install-hook` — git pre-push hook
+
+Writes `.git/hooks/pre-push` (mode 0755) that blocks pushes whose diff changes implementation files but adds or updates no `@spec` / `@ac` annotations. Hook delegates to a hidden `specter pre-push-check` subcommand that reads git's pre-push stdin format, runs `git diff` per ref, and exits non-zero on impl-only diffs.
+
+- Doc / spec / test changes always pass.
+- Diffs touching impl AND adding an annotation delta in any test file pass.
+- New branches without `origin/HEAD` merge-base are skipped (no "before" to compare against).
+- `git push --no-verify` bypasses (git's behavior, not Specter's).
+
+Hook script wrapped in shell-comment fenced markers (`# specter:begin v1` / `# specter:end`). Re-runs replace only the fenced region.
+
+Spec: `spec-manifest` C-22, AC-27..AC-29.
+
+#### `specter init --ai <tool>` — per-tool AI instruction file
+
+Five tools, one command per tool:
+
+| `--ai <tool>` | Target file |
+|---|---|
+| `claude` | `CLAUDE.md` |
+| `codex` | `AGENTS.md` |
+| `cursor` | `.cursor/rules/specter.md` (creates parent dir) |
+| `copilot` | `.github/copilot-instructions.md` (capped at 4096 bytes) |
+| `gemini` | `GEMINI.md` |
+
+Body wrapped in `<!-- specter:begin v1 -->` / `<!-- specter:end -->` markers. Re-runs replace only the fenced region; out-of-fence content preserved byte-for-byte.
+
+Body teaches the AI to (1) read the spec before writing code, (2) use Convention A annotations with good/bad examples, (3) run `make dogfood-strict` before declaring work done, (4) ask Specter for spec content on demand via `specter explain` rather than from a pre-loaded snapshot.
+
+`--ai claude` checks for an existing `AGENTS.md` and writes `@AGENTS.md` import directive instead of inlining the body, avoiding duplication.
+
+Spec: `spec-manifest` C-23, AC-30..AC-36.
+
+#### `settings.strictness` — three-level coverage gate
+
+```yaml
+settings:
+  strictness: threshold     # annotation | threshold (default) | zero-tolerance
+```
+
+| Level | Behavior |
+|---|---|
+| `annotation` | Pre-v0.10 behavior. `coverage --strict` rejected as incoherent. |
+| `threshold` (default) | v0.10.x `--strict` behavior. Tier threshold applies after demotion. |
+| `zero-tolerance` | Any non-passed annotated AC exits 2. `approval_gate: true` with unset `approval_date` exits 3 (distinct). |
+
+Override per invocation with `--strictness <level>`. CLI flag and manifest field validated against the same enum; typos at either layer error with valid values listed.
+
+Spec: `spec-manifest` C-24, AC-37..AC-38; `spec-coverage` C-24..C-26, AC-27..AC-29.
+
+#### `settings.tests_glob` — default test-discovery pattern
+
+```yaml
+settings:
+  tests_glob: "tests/**/*.py"           # string form
+  # OR
+  tests_glob:                           # list form
+    - "backend/**/*_test.go"
+    - "frontend/**/*.test.ts"
+```
+
+Used when `--tests` is unset. Supports `**` (recursive). List form unions matches.
+
+Spec: `spec-manifest` C-25, AC-39.
+
+### Fixed
+
+#### GH #75 — silent 0% on empty test discovery (under `--strict`)
+
+`specter coverage --strict` no longer falls through to `filepath.Walk(".")` when the configured glob matches zero files. Instead, it warns above the coverage table:
+
+```
+warn: no test files contained @spec/@ac annotations — coverage will report 0% for every spec
+      set settings.tests_glob in specter.yaml or pass --tests <glob>
+```
+
+Under `strictness: zero-tolerance`, the warning escalates to a hard error.
+
+Spec: `spec-coverage` C-27, AC-30.
+
+#### GH #76 — `specter.yaml` settings block silently accepted unknown keys
+
+`ParseManifest` now errors on unknown top-level and `settings:` keys with did-you-mean suggestions (Levenshtein ≤ 3) and the full list of valid keys. Existing manifests with typo'd keys will start failing on parse — fix the typo or remove the field.
+
+Spec: `spec-manifest` C-26, AC-40.
+
+#### GH #79 (cheap fix) — ingest body regex accepts `#` and `*`
+
+`specter ingest`'s body-text annotation extractor (used to scan JUnit `<system-out>`) previously accepted `//` only. Now accepts `//`, `#`, `*` — the same three markers the source-file scanner already accepts. Cross-language Convention B output flows through ingest without language-specific kludges.
+
+Pytest users can `print("# @spec my-spec")` from inside a test and ingest extracts identically to a Go test's `t.Log("// @spec my-spec")`.
+
+The bigger fix (a `pytest-specter` plugin) is tracked for a follow-up.
+
+Spec: `spec-ingest` 1.2.0 → 1.3.0 (C-12, AC-12).
+
+### Changed
+
+- `specter.yaml` parsing is now strict about unknown keys at the top level and under `settings:`. Existing manifests with typos that were silently ignored will start failing. Error messages include did-you-mean suggestions when the offending key is close to a valid one.
+- `loadManifest()` (internal) now returns an error when an existing `specter.yaml` fails to parse, rather than silently falling back to defaults. Library helpers (`noSpecsMessage`, `discoverSpecs`) tolerate missing manifests; RunE handlers fail-fast on invalid ones.
+- `discoverTestFiles` no longer falls through to walking `.` when an explicit glob matches zero files. The empty result is surfaced (and warned about) instead of hidden behind a noisy walk.
+- `specter coverage --strict` exit codes: 0 (pass), 2 (strictness violation under zero-tolerance), 3 (approval-gate violation under zero-tolerance), errSilent (tier-threshold failure under threshold mode).
+
+### Internal
+
+- New package `internal/explain` — pure functions for schema walking and annotation reference rendering.
+- New `internal/manifest/string_or_list.go` — custom `UnmarshalYAML` accepting scalar or sequence.
+- New `internal/manifest/fenced.go` — `ReplaceFencedRegion` helper for idempotent file regions, used by both `init --install-hook` and `init --ai <tool>`.
+- New `internal/manifest/{hook,ai_templates,prepush}.go` — pure logic for hook script, instruction templates, and pre-push diff classification.
+- New `cmd/specter/glob.go` — `**`-aware glob matcher (no new dependency); used by `discoverTestFiles` when an explicit glob is provided.
+- `internal/parser.SchemaBytes()` exposes the embedded JSON schema for consumers that need to walk it.
+
+### Spec versions
+
+| Spec | v0.10.2 | v0.11.0 |
+|---|---|---|
+| spec-explain | 1.0.0 | 1.1.0 |
+| spec-check | 1.1.0 | 1.2.0 |
+| spec-ingest | 1.2.0 | 1.3.0 |
+| spec-manifest | 1.6.0 | 1.8.0 |
+| spec-coverage | 1.10.0 | 1.11.0 |
+
+### Migration
+
+Most projects: drop-in. `settings.strictness` defaults to `threshold` (matches v0.10.x `--strict`); `tests_glob` is opt-in.
+
+Projects with typos in `specter.yaml`: the parse error will surface on first invocation. Fix the offending key (the error names the closest valid key).
+
+Python projects using pytest with `# @spec` source comments: `coverage` already worked via the source-file scanner. `coverage --strict` now also works if you wire the autouse-fixture pattern in `conftest.py` (documented in `docs/explainer/v0.11-ai-loop-discipline.md`).
+
+---
+
 ## v0.10.2 — 2026-04-23
 
 **Theme: docs/code parity fixes from jwtms Wave 0/1 integration.**

--- a/specter/V0_12_PYTHON_FOLLOWUP_PLAN.md
+++ b/specter/V0_12_PYTHON_FOLLOWUP_PLAN.md
@@ -1,0 +1,166 @@
+# v0.12 Python adoption follow-up plan
+
+Working document. Picks up where the v0.11 cycle's Wave D left off. Two GH issues + one bigger ergonomic remain. Each can land independently after the v0.11 stack merges.
+
+## Scope
+
+| # | Issue | Effort | Depends on |
+|---|---|---|---|
+| 1 | GH #77 — language-aware `specter explain` | ~half day | PR #73 (explain bundle) merged |
+| 2 | GH #80 — source-only diagnostic hint under `--strict` | ~half day | PR #82 (settings-hardening) merged |
+| 3 | GH #79 — `pytest-specter` plugin (the "better fix") | ~3 days | None; stand-alone |
+
+Each is its own PR. Order is flexible. Land #1 and #2 first because they're spec-bump-shaped (concrete contract); #3 is a separate Python package, larger lift.
+
+---
+
+## Item 1 — GH #77: language-aware `specter explain`
+
+### Problem
+
+`specter explain my-spec:AC-01` shows a Go `// @spec` example even when the project is clearly Python. The detection logic exists (`detectAnnotationLanguages` in `cmd/specter/main.go`) but only fires when `.py` files are found in test discovery. A Python project where test discovery walks the wrong directory falls back to the Go default.
+
+### Spec delta
+
+`spec-explain` 1.1.0 → 1.2.0 (assumes PR #73 merged first).
+
+- **C-13**: When `explain` shows an annotation example for an uncovered AC, the example MUST teach the dual-channel pattern for the detected language. For Python specifically, the example MUST include the autouse-fixture conftest pattern (or the documented `pytest-specter` plugin invocation if available) — not just the `# @spec` source comment, because source comments alone don't satisfy `coverage --strict`.
+- **AC-11**: `specter explain my-spec:AC-01` in a project where `discoverTestFiles` returns at least one `.py` file prints (a) the source-comment annotation, (b) the conftest autouse-fixture pattern with `pytest.mark.spec(...)` invocation, (c) the required `pytest.ini` setting (`junit_logging = system-out`). The Go example is NOT shown.
+- **AC-12**: Same scenario for `.go` test files. Convention A `t.Run` example shown; Python example NOT shown.
+- **AC-13**: Empty test discovery falls back to a generic example that explicitly notes the dual-channel requirement and links to the v0.11 explainer.
+
+### Files touched
+
+- `specter/specs/spec-explain.spec.yaml` — version bump, add C-13, AC-11..AC-13.
+- `cmd/specter/main.go` — `explainDetailMode` (around line 1735) — extend the per-language case statement. Python case grows from ~5 lines to ~30 (autouse fixture + pytest.ini snippet).
+- `cmd/specter/explain_bundle_test.go` (or new `explain_python_test.go`) — three tests: AC-11 (Python full pattern), AC-12 (Go regression — Python example NOT shown), AC-13 (empty discovery generic example).
+
+### Open question
+
+How much should `explain` print? The full pytest setup is ~30 lines. Two options:
+
+- **Inline**: print the full pattern. Cost: longer output. Benefit: copy-pasteable.
+- **Reference**: print the source-comment + `pytest.mark.spec(...)` pattern, then point at `specter explain pytest-setup` (a new sub-surface) for the conftest. Cost: extra command. Benefit: keeps `explain my-spec:AC-01` short.
+
+Recommend inline for v0.12 first cut. Promote to reference if user feedback says output is too long.
+
+---
+
+## Item 2 — GH #80: source-only diagnostic hint under `--strict`
+
+### Problem
+
+When `coverage --strict` finds source annotations (`// @ac` or `# @ac` in a test file) but no matching `.specter-results.json` entry for that AC, the report demotes the AC silently. The user sees 0% coverage with no signal that the issue is "test exists, runtime annotation missing." The dual-channel design is invisible.
+
+### Spec delta
+
+`spec-coverage` 1.11.0 → 1.12.0 (assumes PR #82 merged first).
+
+- **C-28**: Under `--strict`, when an annotated AC has at least one matching source-file annotation but no matching results-file entry, `specter coverage` MUST emit a per-AC stderr hint of the form:
+
+  ```
+  hint: AC-01 has source annotation in tests/foo.py:42 but no matching pass in .specter-results.json
+        — did your test runner emit Convention A/B annotations? See docs/explainer/v0.10-ci-gated-coverage.md
+  ```
+
+  One hint per affected AC, printed before the coverage table. Limit to the first 5 affected ACs to keep CI logs compact; suppress with `--quiet`.
+
+- **AC-31**: Workspace where `.specter-results.json` exists but is empty AND test files have `// @ac AC-01` source comments: `coverage --strict` exits with the threshold-failure code AND prints the per-AC hint for AC-01 above the table.
+- **AC-32**: When the same AC has both source annotation AND a matching results entry: no hint (the hint is a diagnostic for the missing-runtime-channel case only).
+- **AC-33**: `--quiet` suppresses the hints. `--json` includes them in a top-level `diagnostic_hints` array.
+
+### Files touched
+
+- `specter/specs/spec-coverage.spec.yaml` — version bump, add C-28, AC-31..AC-33.
+- `internal/coverage/coverage.go` — `BuildCoverageReportStrict` already has the data needed (`AnnotationMatch` per file/spec/AC + `ResultsFile` entries). Add a helper `DiagnoseSourceOnlyACs` that returns `[]SourceOnlyHint` containing (spec_id, ac_id, source_files []string).
+- `cmd/specter/main.go` (coverage command) — print the hints above the table when `--strict` and not `--quiet`. Include in JSON output when `--json`.
+- `internal/coverage/coverage_test.go` — three new tests covering AC-31..AC-33.
+
+### Notes
+
+The `tests/foo.py:42` precision (file + line) requires preserving line numbers through the annotation extraction. Currently `AnnotationMatch` carries the file path but not the line. Two options:
+
+- **Cheap**: print the file path only, no line. Less useful but a 5-minute change.
+- **Better**: extend `AnnotationMatch` with `Line int` and update the extractor in `internal/coverage/coverage.go` to track it. Touches `coverage.ExtractAnnotations` callers (parse loop, sync, watch).
+
+Recommend the better path. The line number is the difference between "useful hint" and "vague signal."
+
+---
+
+## Item 3 — GH #79: `pytest-specter` plugin (the "better fix")
+
+### Problem
+
+The v0.11 cheap fix (regex broadening) means a pytest user can write `print("# @spec my-spec")` from a test and ingest extracts cleanly. But that's manual: every test needs the `print` call, or a hand-written `conftest.py` autouse fixture.
+
+The plugin formalizes the autouse pattern, ships it on PyPI, and gives Python users `pip install pytest-specter` + a marker decorator:
+
+```python
+import pytest
+
+@pytest.mark.spec("my-spec", "AC-01")
+def test_user_create_valid():
+    ...
+```
+
+The plugin handles the conftest autouse fixture, the `pytest.ini` setting (`junit_logging = system-out`), and the marker registration. Test runners need zero Specter-specific code; just the import and the decorator.
+
+### Scope
+
+- Separate Python package, hosted in the Specter repo under `python/pytest-specter/` or in a sibling repo.
+- Standard `pyproject.toml` build, published to PyPI as `pytest-specter`.
+- Three files of substance: `pytest_specter/__init__.py` (plugin entrypoint), `pytest_specter/_emit.py` (the autouse fixture), `tests/test_plugin.py` (verification against a real pytest run).
+- README documenting installation (`pip install pytest-specter`) + usage (`@pytest.mark.spec(...)`) + the resulting JUnit `<system-out>` shape.
+
+### Spec delta
+
+This is a sibling tool, not a Specter feature. No spec bump in the main Specter repo. A new `spec-pytest-plugin.spec.yaml` could live under the plugin's own directory if we want to dogfood SDD on the plugin itself — defer that decision until the plugin is closer to release.
+
+### Files touched
+
+New files only. No changes to the Specter Go binary or specs.
+
+```
+python/
+  pytest-specter/
+    pyproject.toml
+    pytest_specter/
+      __init__.py
+      _emit.py
+    tests/
+      test_plugin.py
+    README.md
+    LICENSE
+```
+
+### Test plan
+
+- Unit: marker registration works, autouse fixture only fires for marked tests.
+- Integration: `pytest --junitxml=out.xml` on a fixture project produces a JUnit file whose `<system-out>` carries `// @spec ...` and `// @ac ...` lines for marked tests.
+- E2E: `specter ingest --junit out.xml && specter coverage` produces 100% coverage for the marked ACs.
+
+### Decisions to settle
+
+1. **Where does the plugin live?** Same repo (`python/pytest-specter/`) keeps the dogfood loop tight; separate repo (`Hanalyx/pytest-specter`) makes pip install + PyPI release lifecycle cleaner. Recommend separate repo to keep release cadences independent.
+2. **Marker syntax.** `pytest.mark.spec("my-spec", "AC-01")` (positional) vs `pytest.mark.spec(spec_id="my-spec", ac_id="AC-01")` (keyword). Recommend support both; positional is shorter for the common case.
+3. **Multi-AC tests.** A single test that covers AC-01 AND AC-02 — does the marker accept a list? Recommend yes: `pytest.mark.spec("my-spec", ["AC-01", "AC-02"])` emits two `// @ac` lines.
+
+---
+
+## Suggested merge order
+
+1. Land v0.11 stack (PRs #73, #74, #81, #82, #83) and tag v0.11.0.
+2. Open `feat/python-explain-aware` (Item 1) targeting `release/v0.12` or `main`. Small PR, ~half day.
+3. Open `feat/coverage-source-only-hint` (Item 2) targeting same base. Small PR, ~half day.
+4. Tag v0.12.0 once both land. Items 1 + 2 are the bulk of v0.12's Python adoption story.
+5. Spin up `pytest-specter` repo (Item 3) on its own cadence. Initial release can pre-date or post-date Specter v0.12 — they're decoupled.
+
+---
+
+## What this plan does not cover
+
+- VS Code surface for `settings.strictness` (sidebar showing strictness-level state). Tracked in BACKLOG separately; not Python-specific.
+- Flake handling (`--deny-flaky`). Deferred from v0.10.
+- Full per-language `init --ai <tool>` templates (Python-specific instruction body). The current template is language-agnostic; per-language variants are a v0.13 candidate.
+
+When these three Python items land, the adoption story for Python pytest projects matches the Go story: write a marker, run pytest, run ingest, run `coverage --strict`, ship.

--- a/specter/docs/explainer/v0.11-ai-loop-discipline.md
+++ b/specter/docs/explainer/v0.11-ai-loop-discipline.md
@@ -1,0 +1,248 @@
+# v0.11 — AI loop discipline + adoption hardening
+
+**Target audience:** teams running Specter on a real codebase, plus their AI coding assistants (Claude, Codex, Cursor, Copilot, Gemini CLI).
+**What shipped:** `specter explain` bundle, `specter check --test`, `specter init --install-hook`, `specter init --ai <tool>`, `settings.strictness` three-level gate, plus four GH-issue fixes from real adopters.
+**What it closes:** the gap between "Specter has the right opinion" and "the AI / the developer / the CI pipeline actually follows it."
+
+---
+
+## Why this exists
+
+v0.10 closed the eval-phase hole: test outcome is now mechanical, not a promise. The next gap was order-of-operations. Tests get written, but not before the code. AI assistants generate plausible code without reading the spec. CI catches the absence of a test annotation only after the developer has already pushed. Manifests silently accept typos. Empty test-discovery silently reports 0% coverage.
+
+Each of these is small. Together they mean a green CI run can hide a real adoption problem. v0.11 closes them.
+
+---
+
+## 1. `specter explain` bundle
+
+`explain` was already a read-only diagnostic for `<spec-id>:<AC-NN>`. v0.11 extends it with three new surfaces, all stdout-only.
+
+```bash
+specter explain annotation                         # test-annotation reference
+specter explain schema                             # full schema field reference
+specter explain schema spec.acceptance_criteria.items.approval_gate  # one field
+specter explain spec-coverage                      # spec card: tier, coverage %, per-AC test files
+```
+
+The schema walker resolves JSON `$ref`s, so nested fields under `spec.acceptance_criteria.items.*` and `spec.constraints.items.*` show up alongside top-level fields. `explain schema <unknown-path>` returns a non-zero exit with a `did you mean?` suggestion within Levenshtein 3.
+
+The AC-less spec card (`specter explain spec-coverage`) replaces v1.0's two-column COVERED/UNCOVERED list. It now shows tier, coverage percentage, and the test files covering each AC — so "where is AC-19 tested?" is one command away instead of a grep.
+
+**Why it matters:** these are the surfaces an AI assistant will hit on demand instead of the team pre-loading spec content into the context window. Pair with `init --ai <tool>` (below), which writes an instruction file telling the AI to *call* `specter explain` rather than guess.
+
+---
+
+## 2. `specter check --test` (`-t`) — test-annotation cross-reference
+
+`specter check` already validates spec-side structure (orphan constraints, structural conflicts, version-bump classification). v0.11 adds the test-side counterpart:
+
+```bash
+specter check --test    # opt-in for v0.11; default-on candidate later
+```
+
+Three diagnostic kinds:
+
+- **`unknown_spec_ref`** — `// @spec foo` in a test where no spec with that id exists.
+- **`unknown_ac_ref`** — `// @spec real-spec` + `// @ac AC-99` where `real-spec` declares no AC-99.
+- **`malformed_ac_id`** — IDs failing `^AC-\d{2,}$`: `AC-1` (not zero-padded), `ac-01` (wrong case), `AC-1A` (suffix).
+
+Each diagnostic names the offending file, line, and reference. Cascade rule: when `@spec` is unknown, child `@ac` lines under it are not separately checked. Annotations inside multi-line string literals (TS template strings, Python triple-quoted strings) are payload, not real annotations — the scanner skips them.
+
+`specter sync --strict` (and `settings.strict: true`) routes the check through automatically, so CI catches broken annotations before merge.
+
+**Why it matters:** the v0.10.1 docs patch could only warn about this class of bug (annotation drift between tests and specs). v0.11 enforces it.
+
+---
+
+## 3. `specter init --install-hook` — git pre-push hook
+
+Every push that changes implementation files but adds or updates no `@spec` / `@ac` annotation gets blocked locally:
+
+```bash
+specter init --install-hook
+# Writes .git/hooks/pre-push (mode 0755) wrapped in shell-comment fenced markers
+# (# specter:begin v1 ... # specter:end) so future re-runs replace only the
+# Specter-managed region — your hand-edits outside the fence survive.
+```
+
+The hook delegates to a hidden `specter pre-push-check` subcommand that reads git's pre-push stdin format, runs `git diff` for each ref, and exits non-zero on impl-only diffs. Doc / spec / test changes always pass. Diffs that touch impl AND add an annotation delta (in any test file) pass.
+
+Bypass with the standard `git push --no-verify`. New branches without an `origin/HEAD` merge-base are skipped (no "before" to compare against; the next push catches up).
+
+**Why it matters:** the discipline being enforced is "every code change traces to a test annotation that traces to a spec." Reviewers used to ask for that in PR comments. Now the hook asks first, locally, before the push leaves the developer's machine.
+
+---
+
+## 4. `specter init --ai <tool>` — AI instruction file
+
+Five tools, one command per tool:
+
+```bash
+specter init --ai claude     # writes CLAUDE.md
+specter init --ai codex      # writes AGENTS.md
+specter init --ai cursor     # writes .cursor/rules/specter.md (creates parent dir)
+specter init --ai copilot    # writes .github/copilot-instructions.md (capped at 4 KB)
+specter init --ai gemini     # writes GEMINI.md
+```
+
+The body is wrapped in `<!-- specter:begin v1 -->` / `<!-- specter:end -->` markers. Re-runs replace only the fenced region; everything you write outside the markers is preserved byte-for-byte.
+
+The instruction body teaches the AI four things, in order:
+
+1. **Read the spec before writing code** (preflight self-check). The AI must state which spec ID and AC IDs the change touches before producing code.
+2. **Use Convention A annotations** (runner-visible spec-id/AC-NN in the test title). Includes good/bad examples for Go and TypeScript.
+3. **Run `make dogfood-strict` (or your project's equivalent) before declaring work done.**
+4. **Ask Specter for spec content on demand** via `specter explain <spec-id>`, `specter explain schema`, `specter explain annotation` — not from a pre-loaded snapshot in the instruction file.
+
+The body intentionally does **not** dump spec content. A 249-spec workspace would produce a 10000-line `CLAUDE.md`, churn on every spec edit, and consume the AI's context budget. The instruction file is a project guide, not a manual.
+
+`--ai claude` checks for an existing `AGENTS.md` and writes `@AGENTS.md` import directive instead of inlining the body, avoiding template duplication when the same project ships both.
+
+**Why it matters:** an AI that has read the spec writes different code than one that hasn't. The instruction file is the cheapest way to make that read happen without writing prompt-engineering glue per tool.
+
+---
+
+## 5. `settings.strictness` — three-level coverage gate
+
+`coverage --strict` had one mode: demote non-passed annotated ACs, apply tier thresholds, exit on threshold failure. v0.11 makes the level explicit in `specter.yaml`:
+
+```yaml
+settings:
+  strictness: threshold     # annotation | threshold (default) | zero-tolerance
+```
+
+| Level | Behavior |
+|---|---|
+| `annotation` | Pre-v0.10 behavior. Counts `// @ac` annotations only; ignores `.specter-results.json`. `coverage --strict` is rejected as incoherent. For new adopters mid-migration. |
+| `threshold` (default) | Today's v0.10.x `--strict` behavior. Demote non-passed annotated ACs, then apply tier thresholds. Spec passes if it clears its tier threshold after demotion. `approval_gate` is metadata. |
+| `zero-tolerance` | Strictest. Any annotated AC with `status != passed` exits 2. Any AC with `approval_gate: true` and unset `approval_date` exits 3 (distinct exit code). Tier threshold is irrelevant — one failing test fails the run. |
+
+Override per invocation with `--strictness <level>`. The CLI flag and the manifest field are validated against the same enum; typos at either layer error with the three valid values listed.
+
+**Why it matters:** "strict" was conflated with "tier threshold." A team can reasonably want 100% coverage with loose strictness (mid-migration) or 50% coverage with zero-tolerance (mature Tier 1 specs). The three levels separate those intentions.
+
+---
+
+## 6. Settings surface hardening (closes GH #75, #76, #78)
+
+Three real bugs from a Python user on v0.10.2:
+
+**#76 — `specter.yaml settings:` block silently accepted unknown keys.** Users wrote `tests_glob: "tests/**/*.py"` (a plausible-but-non-existent key name), got no warning, ran `coverage --strict`, got silent 0%. v0.11 errors with did-you-mean:
+
+```
+error: unknown settings key "settings.test_glob" — did you mean "tests_glob"?
+       (valid keys: coverage, exclude, specs_dir, strict, strictness,
+        tests_glob, tier_overrides, warn_on_draft)
+```
+
+**#78 — no `settings.tests_glob`.** The `test_glob:` typo above was actually trying to set a missing field. v0.11 adds it:
+
+```yaml
+settings:
+  tests_glob: "tests/**/*.py"           # string form
+  # OR
+  tests_glob:                           # list form
+    - "backend/**/*_test.go"
+    - "frontend/**/*.test.ts"
+```
+
+Used as the default test-discovery pattern when `--tests` is unset. Supports `**` (recursive). List form unions the matches.
+
+**#75 — silent 0% on empty test discovery.** `coverage --strict` no longer falls through to `filepath.Walk(".")` when the glob matches nothing. Instead, it warns:
+
+```
+warn: no test files contained @spec/@ac annotations — coverage will report 0% for every spec
+      set settings.tests_glob in specter.yaml or pass --tests <glob>
+```
+
+Under `strictness: zero-tolerance`, the warning escalates to a hard error. The signal reaches the operator before they spend an hour debugging "why is everything failing?".
+
+---
+
+## 7. Python adoption (closes GH #79 cheap fix)
+
+`specter ingest`'s body-text annotation extractor previously accepted `// @spec` only. A pytest user who wrote `print("# @spec my-spec")` from inside a test (the natural Python idiom) saw the annotation captured into JUnit `<system-out>` and then dropped by ingest because `#` didn't match.
+
+v0.11 broadens the regex to accept `//`, `#`, and `*` — the same three markers the source-file scanner already accepts. Cross-language Convention B output now flows through ingest without language-specific kludges.
+
+```python
+# tests/conftest.py — pytest pattern
+import pytest
+
+def pytest_configure(config):
+    config.addinivalue_line("markers",
+        "spec(spec_id, ac_id): bind a test to a Specter AC")
+
+@pytest.fixture(autouse=True)
+def _emit_spec_annotations(request):
+    marker = request.node.get_closest_marker("spec")
+    if marker:
+        spec_id, ac_id = marker.args
+        print(f"# @spec {spec_id}")
+        print(f"# @ac {ac_id}")
+```
+
+Then a test:
+
+```python
+@pytest.mark.spec("my-spec", "AC-01")
+def test_thing(): ...
+```
+
+In `pytest.ini`:
+
+```ini
+[pytest]
+junit_logging = system-out
+junit_log_passing_tests = true
+```
+
+`pytest-specter` (a plugin formalizing this pattern) is tracked for a follow-up release. The regex broadening unblocks pytest adoption today.
+
+---
+
+## Migration
+
+For most projects, v0.11 is a drop-in. Three explicit steps:
+
+1. **Optional: set `settings.strictness` and `settings.tests_glob` in `specter.yaml`.** If you don't, the defaults match v0.10.x behavior — `strictness: threshold`, `tests_glob` unset (falls through to default walk).
+2. **Optional: install the pre-push hook.** `specter init --install-hook` from your repo root.
+3. **Optional: write an AI instruction file.** Pick the tool you use and run `specter init --ai <tool>`.
+
+For projects that hit GH #75 or #76: typos in `specter.yaml` will now error instead of silently being ignored. If you have an unknown key today, you'll see the error on first parse with v0.11. The error message names the closest valid key.
+
+For Python users: pytest tests with `# @spec` source comments now work for `coverage`. To make `coverage --strict` work, add the `conftest.py` autouse-fixture pattern above (or wait for `pytest-specter`).
+
+---
+
+## What v0.11 does not do (and why)
+
+**No language-aware `specter explain`.** GH #77 — `explain my-spec:AC-01` shows a Go example to Python users. The detection logic exists (extension-based) but doesn't show the pytest setup. Tracked for a follow-up; needs design work on how much to print.
+
+**No source-only diagnostic hint.** GH #80 — when `coverage --strict` finds source annotations but no matching `.specter-results.json` entry, it should emit a hint pointing at the dual-channel requirement. Tracked.
+
+**No `pytest-specter` plugin.** GH #79's better fix. The cheap fix (regex broadening) unblocks today; the plugin makes the ergonomic better.
+
+**No VS Code surface for `settings.strictness`.** The sidebar still shows tier-threshold-based status. Surfacing strictness state is a v0.12 candidate.
+
+**No flake handling.** Still deferred. Real-world patterns from v0.10/v0.11 usage will inform the design.
+
+---
+
+## The bigger picture
+
+Before v0.11, Specter could tell you that the test for AC-07 ran in CI and passed (v0.10's contribution). That's necessary but not sufficient. v0.11 closes three more gaps:
+
+- **Order of operations is mechanical.** The pre-push hook blocks unannotated diffs locally; the AI instruction file pushes spec context to the AI before it writes code; `check --test` enforces test-annotation hygiene at CI time.
+- **The configuration surface is honest.** Typos error. Unknown keys error. Empty test-discovery warns. `strictness` is explicit.
+- **Adoption is broader.** Python's natural idiom flows through ingest without kludges. Five major AI tools have a one-command path to a project-aware instruction file.
+
+The loop closes a little further each release:
+
+- **v0.9.x** — test existence is mechanical.
+- **v0.10** — test outcome is mechanical.
+- **v0.11** — order of operations is mechanical, and the configuration is honest. You're here.
+- **v0.12** — Python ergonomics, AI hooks for hard enforcement (PreToolUse / PostToolUse compact), VS Code strictness surface.
+
+Each piece is narrow and does one thing. Together they make spec-driven development something a tool can verify across the full loop instead of something a team promises.

--- a/specter/docs/explainer/v0.11-ai-loop-discipline.md
+++ b/specter/docs/explainer/v0.11-ai-loop-discipline.md
@@ -29,7 +29,7 @@ The schema walker resolves JSON `$ref`s, so nested fields under `spec.acceptance
 
 The AC-less spec card (`specter explain spec-coverage`) replaces v1.0's two-column COVERED/UNCOVERED list. It now shows tier, coverage percentage, and the test files covering each AC — so "where is AC-19 tested?" is one command away instead of a grep.
 
-**Why it matters:** these are the surfaces an AI assistant will hit on demand instead of the team pre-loading spec content into the context window. Pair with `init --ai <tool>` (below), which writes an instruction file telling the AI to *call* `specter explain` rather than guess.
+These are the surfaces an AI assistant should hit on demand instead of relying on pre-loaded spec content in its context window. Pair with `init --ai <tool>` (below), which writes an instruction file telling the AI to *call* `specter explain` rather than guess.
 
 ---
 
@@ -51,7 +51,7 @@ Each diagnostic names the offending file, line, and reference. Cascade rule: whe
 
 `specter sync --strict` (and `settings.strict: true`) routes the check through automatically, so CI catches broken annotations before merge.
 
-**Why it matters:** the v0.10.1 docs patch could only warn about this class of bug (annotation drift between tests and specs). v0.11 enforces it.
+The v0.10.1 docs patch could only warn about this class of bug (annotation drift between tests and specs). v0.11 enforces it at CI time.
 
 ---
 
@@ -70,7 +70,7 @@ The hook delegates to a hidden `specter pre-push-check` subcommand that reads gi
 
 Bypass with the standard `git push --no-verify`. New branches without an `origin/HEAD` merge-base are skipped (no "before" to compare against; the next push catches up).
 
-**Why it matters:** the discipline being enforced is "every code change traces to a test annotation that traces to a spec." Reviewers used to ask for that in PR comments. Now the hook asks first, locally, before the push leaves the developer's machine.
+The discipline being enforced is "every code change traces to a test annotation that traces to a spec." Reviewers used to flag this in PR comments; the hook now blocks it locally before the push.
 
 ---
 
@@ -95,11 +95,11 @@ The instruction body teaches the AI four things, in order:
 3. **Run `make dogfood-strict` (or your project's equivalent) before declaring work done.**
 4. **Ask Specter for spec content on demand** via `specter explain <spec-id>`, `specter explain schema`, `specter explain annotation` — not from a pre-loaded snapshot in the instruction file.
 
-The body intentionally does **not** dump spec content. A 249-spec workspace would produce a 10000-line `CLAUDE.md`, churn on every spec edit, and consume the AI's context budget. The instruction file is a project guide, not a manual.
+The body intentionally does **not** dump spec content. A 249-spec workspace would produce a 10000-line `CLAUDE.md` that churns on every spec edit. The instruction file is a project guide, not a manual.
 
 `--ai claude` checks for an existing `AGENTS.md` and writes `@AGENTS.md` import directive instead of inlining the body, avoiding template duplication when the same project ships both.
 
-**Why it matters:** an AI that has read the spec writes different code than one that hasn't. The instruction file is the cheapest way to make that read happen without writing prompt-engineering glue per tool.
+An AI that has read the spec writes different code than one that hasn't. The instruction file is the cheapest way to make that read happen.
 
 ---
 
@@ -120,7 +120,7 @@ settings:
 
 Override per invocation with `--strictness <level>`. The CLI flag and the manifest field are validated against the same enum; typos at either layer error with the three valid values listed.
 
-**Why it matters:** "strict" was conflated with "tier threshold." A team can reasonably want 100% coverage with loose strictness (mid-migration) or 50% coverage with zero-tolerance (mature Tier 1 specs). The three levels separate those intentions.
+"strict" was conflated with "tier threshold." A team can reasonably want 100% coverage with loose strictness (mid-migration) or 50% coverage with zero-tolerance (mature Tier 1 specs). The three levels separate those intentions.
 
 ---
 
@@ -245,4 +245,4 @@ The loop closes a little further each release:
 - **v0.11** — order of operations is mechanical, and the configuration is honest. You're here.
 - **v0.12** — Python ergonomics, AI hooks for hard enforcement (PreToolUse / PostToolUse compact), VS Code strictness surface.
 
-Each piece is narrow and does one thing. Together they make spec-driven development something a tool can verify across the full loop instead of something a team promises.
+v0.10 closed the eval phase. v0.11 closes the order-of-operations phase. The remaining gaps are ergonomic, not structural — what's left for v0.12 is making each language and tool feel native, not reaching past one more conceptual hole.


### PR DESCRIPTION
## Summary

Three documents drafted for v0.11 release prep, plus the v0.11.0 CHANGELOG security section:

- \`CHANGELOG.md\`: v0.11.0 entry covering all five features, four GH-issue closures (#75, #76, #78, #79 cheap fix), seven security hardening items (folded into v0.11.0 per recent decision), spec version table, migration guidance.
- \`docs/explainer/v0.11-ai-loop-discipline.md\`: full walkthrough explainer matching the v0.10 explainer's tone and structure.
- \`V0_12_PYTHON_FOLLOWUP_PLAN.md\`: concrete plan for the deferred Python work (GH #77, #80, #79 better fix as pytest-specter plugin) — per-item spec delta, file touches, test list, effort estimate.

## Review

Drafts went through 2-agent review (technical accuracy + editorial). Six fixes applied based on findings:
- Tagged GH #78 explicitly under \`### Fixed\`
- Rewrote one marketing-flavor sentence in CHANGELOG header
- Trimmed \`--ai\` body description and merged duplicate typo-error mention
- "AI assistant will hit on demand" → "should hit" (over-claim correction)
- Five formulaic "**Why it matters:**" closer labels removed across explainer
- Closer at L248 rewritten so it doesn't paraphrase v0.10's L214

## Merge order note

Should merge AFTER PRs #73, #74, #81, #82, #83, #84, plus the security PRs (\`hotfix/vscode-security\`, \`fix/go-version-bump\`). The release notes describe features in those PRs; merging this first would mention features that aren't in \`release/v0.11\` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)