### PR TITLE
chore: forward-merge PR #82 content into release/v0.11

### DIFF
--- a/specter/V0_11_PLAN.md
+++ b/specter/V0_11_PLAN.md
@@ -153,7 +153,11 @@ All tests use Convention A subtest wrapping.
 
 ---
 
-## Feature 5 — `settings.strictness`
+## Feature 5 + Wave C bundle — settings hardening (Feature 5 + GH issues #75, #76, #78)
+
+Wave C scope expanded after a `gh issue list` review surfaced three open bugs/enhancements on the same `settings:` surface as `settings.strictness`. Bundling avoids shipping a new `strictness:` key into a settings block where typos are silently accepted (#76) and where empty test discovery silently reports 0% (#75).
+
+This branch is **stacked on `feat/init-bundle`** (PR #81) so spec-manifest starts at v1.7.0 with C-22/C-23/AC-27..AC-36 already present.
 
 ### Spec (commit 1)
 
@@ -161,33 +165,54 @@ Two specs bump in one commit:
 
 **`spec-manifest` 1.7.0 → 1.8.0:**
 - C-24: `settings.strictness` field with enum `{annotation, threshold, zero-tolerance}`, default `threshold`.
-- AC-37: parse accepts all three enum values; default applied when unset.
-- AC-38: parse rejects invalid enum with clear error message.
+- C-25: `settings.tests_glob` (string or list) — default test-discovery pattern (closes #78).
+- C-26: `ParseManifest` rejects unknown keys in any block under `settings:` with a "did you mean?" suggestion (closes #76).
+- AC-37: parse accepts all three strictness enum values; default `threshold` applied when unset.
+- AC-38: parse rejects invalid strictness enum with clear error message.
+- AC-39: `settings.tests_glob` accepts a string or a list; both flow through to discovery.
+- AC-40: typo'd settings key (e.g., `tests_glob:` -> `test_glob:`) errors with did-you-mean suggestion.
 
 **`spec-coverage` 1.10.0 → 1.11.0:**
 - C-24: `strictness=annotation` rejects `--strict` CLI flag with clear error.
 - C-25: `strictness=zero-tolerance` exits non-zero when any annotated AC has `status != passed`, regardless of tier threshold.
 - C-26: `strictness=zero-tolerance` exits non-zero when any AC has `approval_gate: true` and `approval_date` unset.
+- C-27: `coverage --strict` warns (and under zero-tolerance, errors) when test discovery returns zero files containing `@spec`/`@ac` annotations (closes #75).
 - AC-27: `--strictness <level>` CLI flag overrides `specter.yaml` per-invocation.
 - AC-28: `--strict` is preserved as a shortcut for `--strictness threshold` (backwards compatible).
 - AC-29: exit-code contract — 0 for pass, 2 for strictness violation, 3 for approval-gate violation under zero-tolerance.
+- AC-30: empty test-discovery emits a clear warning above the coverage table; under zero-tolerance, exits non-zero.
 
 ### Tests (commit 2)
 
-- `internal/parser/strictness_test.go`: AC-37, AC-38.
-- `internal/coverage/strictness_test.go`: AC-27 through AC-29, plus one test per `strictness` level verifying demotion semantics.
-- `cmd/specter/coverage_strictness_test.go`: CLI-level — `--strictness zero-tolerance` on a fixture with one failing test exits code 2; same fixture under `threshold` exits 0 if tier threshold met.
+Pure tests in `internal/manifest/`:
+- `settings_strictness_test.go`: AC-37, AC-38 (parse strictness enum).
+- `settings_tests_glob_test.go`: AC-39 (string + list forms).
+- `settings_unknown_key_test.go`: AC-40 (did-you-mean for typos).
+
+CLI tests:
+- `cmd/specter/coverage_strictness_test.go`: AC-27..29 — `--strictness zero-tolerance` on a fixture with one failing test exits 2; threshold exits 0; approval_gate=true && approval_date=null exits 3.
+- `cmd/specter/coverage_empty_discovery_test.go`: AC-30 — empty workspace warns; zero-tolerance fails.
 
 ### Implementation (commit 3)
 
-- `internal/parser/spec-schema.json`: add `settings.strictness` enum. JSON-schema validation catches AC-38.
-- `internal/coverage/coverage.go`: `BuildCoverageReportStrict` gains a `Strictness` field; exit-code contract lives in `cmd/specter/main.go`.
-- `cmd/specter/main.go`: add `--strictness` flag; wire `--strict` as its shortcut.
-- `docs/CLI_REFERENCE.md`: new section on strictness levels. `docs/SPEC_SCHEMA_REFERENCE.md`: add `settings.strictness` field row.
+- `internal/manifest/types.go`: add `Strictness string` and `TestsGlob StringOrList` fields to `Settings`.
+- `internal/manifest/manifest.go`: switch `yaml.Unmarshal` to `yaml.NewDecoder(...).KnownFields(true)`; add `Strictness` enum validation; render did-you-mean for unknown keys via Levenshtein.
+- `internal/coverage/coverage.go`: `BuildCoverageReportStrict` gains a `Strictness` field; new exit-code contract.
+- `cmd/specter/main.go`: add `--strictness <level>` flag; wire `--strict` as its shortcut. `coverage` and `sync` consult `m.Settings.TestsGlob` when `--tests` is unset. Empty-discovery warning printed above the table.
+- `docs/CLI_REFERENCE.md`: new strictness section + `--strictness` flag. `docs/SPEC_SCHEMA_REFERENCE.md`: add `settings.strictness` and `settings.tests_glob` rows.
 
 ### Eval
 
-`make dogfood-strict` green under default (`threshold`). Set `settings.strictness: zero-tolerance` in `specter.yaml` and re-run — confirm the gate still passes (all 15 specs at 100% avg coverage means zero failing tests). Create a deliberate failing-test fixture and confirm zero-tolerance exits 2 where threshold would exit 0. Two review agents (per root `CLAUDE.md` Docs Review Policy) verify `SPEC_SCHEMA_REFERENCE.md` and `CLI_REFERENCE.md` deltas match the embedded schema and code behavior.
+`make dogfood-strict` green under default (`threshold`). Setting `settings.strictness: zero-tolerance` keeps it green (15/15 specs, no failing tests). Deliberate failing-test fixture: zero-tolerance exits 2 where threshold exits 0. Typo'd `tests_glob:` errors with did-you-mean. Empty workspace under `--strict` warns clearly. Two review agents verify `SPEC_SCHEMA_REFERENCE.md` and `CLI_REFERENCE.md` deltas match the embedded schema and code behavior.
+
+### Closes
+
+- Feature 5 (`settings.strictness`)
+- GH #75 (silent 0% on empty test discovery)
+- GH #76 (silent acceptance of unknown settings keys)
+- GH #78 (`settings.tests_glob`)
+
+Cluster 2 (GH #77, #79, #80 — Python adoption / Convention B for pytest) is intentionally out of scope; tracked as the next wave after Wave C lands.
 
 ---
 

--- a/specter/cmd/specter/coverage_strictness_test.go
+++ b/specter/cmd/specter/coverage_strictness_test.go
@@ -72,6 +72,55 @@ func TestCoverageStrictness_ZeroTolerance_FailsOnNonPassedAC(t *testing.T) {
 	})
 }
 
+// @ac AC-29
+func TestCoverageStrictness_ZeroTolerance_FailsOnApprovalGate(t *testing.T) {
+	t.Run("spec-coverage/AC-29 zero-tolerance fails on approval_gate=true with unset approval_date (exit 3)", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifestWithStrictness(t, dir, "zero-tolerance")
+
+		// Spec carries approval_gate=true on AC-01 with no approval_date.
+		// Build it inline because minimalValidSpec doesn't emit gate metadata.
+		specBody := `spec:
+  id: gated-spec
+  version: "1.0.0"
+  status: approved
+  tier: 3
+  context: { system: x, feature: x }
+  objective: { summary: x }
+  constraints:
+    - id: C-01
+      description: "MUST do thing"
+      type: technical
+      enforcement: error
+  acceptance_criteria:
+    - id: AC-01
+      description: "Thing happens"
+      approval_gate: true
+      references_constraints: ["C-01"]
+      priority: high
+`
+		if err := os.WriteFile(filepath.Join(dir, "gated.spec.yaml"), []byte(specBody), 0644); err != nil {
+			t.Fatal(err)
+		}
+		// Annotate the AC so the empty-discovery gate doesn't fire.
+		testFile := "// @spec gated-spec\n// @ac AC-01\nfunc TestGated(t *testing.T) {}\n"
+		if err := os.WriteFile(filepath.Join(dir, "gated_test.go"), []byte(testFile), 0644); err != nil {
+			t.Fatal(err)
+		}
+		// Results: AC-01 passed (so the strictness check at exit 2 is satisfied).
+		// Approval-gate violation should still trigger exit 3.
+		results := `{"results": [{"spec_id": "gated-spec", "ac_id": "AC-01", "status": "passed", "test_name": "TestGated"}]}`
+		if err := os.WriteFile(filepath.Join(dir, ".specter-results.json"), []byte(results), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, code := runCLI(t, dir, "coverage", "--strict")
+		if code != 3 {
+			t.Errorf("expected exit code 3 for approval_gate violation under zero-tolerance, got %d", code)
+		}
+	})
+}
+
 // @ac AC-30
 func TestCoverageStrictness_EmptyTestDiscovery_WarnsThenFailsUnderZeroTolerance(t *testing.T) {
 	t.Run("spec-coverage/AC-30 empty test discovery warns under threshold, errors under zero-tolerance", func(t *testing.T) {

--- a/specter/cmd/specter/coverage_strictness_test.go
+++ b/specter/cmd/specter/coverage_strictness_test.go
@@ -1,0 +1,99 @@
+// coverage_strictness_test.go -- CLI-level tests for the v0.11
+// settings.strictness gate (Wave C).
+//
+// @spec spec-coverage
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeManifest creates a minimal specter.yaml at the given path with the
+// settings.strictness value set.
+func writeManifestWithStrictness(t *testing.T, dir, strictness string) {
+	t.Helper()
+	body := "system:\n  name: test\nsettings:\n  specs_dir: .\n"
+	if strictness != "" {
+		body += "  strictness: " + strictness + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, "specter.yaml"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// @ac AC-27
+func TestCoverageStrictness_CLIFlagOverridesManifest(t *testing.T) {
+	t.Run("spec-coverage/AC-27 --strictness flag overrides manifest setting", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifestWithStrictness(t, dir, "threshold")
+		writeSpec(t, dir, "my-spec.spec.yaml", minimalValidSpec("my-spec", 2, "AC-01"))
+
+		// --strictness annotation rejects --strict (per C-24).
+		out, code := runCLI(t, dir, "coverage", "--strict", "--strictness", "annotation")
+		if code == 0 {
+			t.Errorf("expected nonzero exit when --strict combined with annotation strictness, got 0; output:\n%s", out)
+		}
+		if !strings.Contains(strings.ToLower(out), "strictness") {
+			t.Errorf("expected 'strictness' in error message, got:\n%s", out)
+		}
+	})
+}
+
+// @ac AC-28
+func TestCoverageStrictness_ZeroTolerance_FailsOnNonPassedAC(t *testing.T) {
+	t.Run("spec-coverage/AC-28 zero-tolerance fails on non-passed annotated AC even when tier threshold met", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifestWithStrictness(t, dir, "zero-tolerance")
+
+		// One Tier 2 spec with two ACs. Both annotated. Results say AC-01 failed.
+		// Coverage % = 100% (both annotated). Tier 2 threshold = 80%, so under
+		// `threshold` mode this would pass. Under zero-tolerance, the failed AC
+		// triggers a non-zero exit.
+		writeSpec(t, dir, "my-spec.spec.yaml", minimalValidSpec("my-spec", 2, "AC-01", "AC-02"))
+		testFile := "// @spec my-spec\n// @ac AC-01\n// @ac AC-02\nfunc TestFoo(t *testing.T) {}\n"
+		if err := os.WriteFile(filepath.Join(dir, "foo_test.go"), []byte(testFile), 0644); err != nil {
+			t.Fatal(err)
+		}
+		results := `{"results": [
+			{"spec_id": "my-spec", "ac_id": "AC-01", "status": "failed", "test_name": "TestFoo"},
+			{"spec_id": "my-spec", "ac_id": "AC-02", "status": "passed", "test_name": "TestFoo"}
+		]}`
+		if err := os.WriteFile(filepath.Join(dir, ".specter-results.json"), []byte(results), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		out, code := runCLI(t, dir, "coverage", "--strict")
+		if code == 0 {
+			t.Fatalf("expected nonzero exit under zero-tolerance with one failed AC, got 0; output:\n%s", out)
+		}
+	})
+}
+
+// @ac AC-30
+func TestCoverageStrictness_EmptyTestDiscovery_WarnsThenFailsUnderZeroTolerance(t *testing.T) {
+	t.Run("spec-coverage/AC-30 empty test discovery warns under threshold, errors under zero-tolerance", func(t *testing.T) {
+		// Threshold mode: warn but don't fail (current behavior preserved).
+		dirT := t.TempDir()
+		writeManifestWithStrictness(t, dirT, "threshold")
+		writeSpec(t, dirT, "my-spec.spec.yaml", minimalValidSpec("my-spec", 3, "AC-01"))
+		// No test files at all.
+		out, _ := runCLI(t, dirT, "coverage", "--strict")
+		if !strings.Contains(strings.ToLower(out), "no test files") &&
+			!strings.Contains(strings.ToLower(out), "no @spec") &&
+			!strings.Contains(strings.ToLower(out), "tests_glob") {
+			t.Errorf("expected warning about empty test discovery under threshold, got:\n%s", out)
+		}
+
+		// Zero-tolerance mode: same setup must exit non-zero.
+		dirZ := t.TempDir()
+		writeManifestWithStrictness(t, dirZ, "zero-tolerance")
+		writeSpec(t, dirZ, "my-spec.spec.yaml", minimalValidSpec("my-spec", 3, "AC-01"))
+		_, codeZ := runCLI(t, dirZ, "coverage", "--strict")
+		if codeZ == 0 {
+			t.Errorf("expected nonzero exit under zero-tolerance with empty test discovery, got 0")
+		}
+	})
+}

--- a/specter/cmd/specter/glob.go
+++ b/specter/cmd/specter/glob.go
@@ -1,0 +1,106 @@
+// Glob matching for test discovery (settings.tests_glob, --tests).
+//
+// filepath.Glob doesn't support `**` (recursive directory match). The
+// natural form users write — `tests/**/*.py`, `internal/**/*_test.go` —
+// silently fell through to walking the entire repo before this helper.
+//
+// globMatchWalk walks `.` once, applying matchGlob to each file's relative
+// path. Returns the sorted list of matching files. Skips standard noise
+// dirs (.git, node_modules, dist, .venv).
+//
+// matchGlob handles three wildcard forms:
+//   - `*` matches any sequence within ONE path component (excluding `/`).
+//   - `**` matches any number of path components (including zero).
+//   - `?` matches exactly one character within a component.
+//
+// Anchored at the start of the path; trailing components must match.
+//
+// @spec spec-coverage
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// globMatchWalk walks `.` and returns paths matching the given glob.
+// Returns paths in sorted order. Empty result is a valid outcome —
+// callers (e.g. coverage --strict) detect it and surface a warning.
+func globMatchWalk(pattern string) []string {
+	var matches []string
+	skipDirs := map[string]bool{
+		".git": true, "node_modules": true, "dist": true,
+		".venv": true, "venv": true, "__pycache__": true,
+	}
+	_ = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Normalize "./foo" to "foo" so the pattern can match without the prefix.
+		rel := strings.TrimPrefix(path, "./")
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if matchGlob(pattern, rel) {
+			matches = append(matches, rel)
+		}
+		return nil
+	})
+	sort.Strings(matches)
+	return matches
+}
+
+// matchGlob reports whether path matches the glob pattern. Supports
+// `*`, `**`, and `?`. Anchored at both ends.
+//
+// Implementation: split both pattern and path on `/`, walk in parallel,
+// recurse on `**` segments to try every possible "consume zero or more
+// path components" choice.
+func matchGlob(pattern, path string) bool {
+	patParts := strings.Split(pattern, "/")
+	pathParts := strings.Split(path, "/")
+	return matchParts(patParts, pathParts)
+}
+
+func matchParts(pat, path []string) bool {
+	for len(pat) > 0 {
+		head := pat[0]
+		if head == "**" {
+			// `**` consumes zero or more path components. Try each tail
+			// position; succeed if any matches the remaining pattern.
+			rest := pat[1:]
+			for i := 0; i <= len(path); i++ {
+				if matchParts(rest, path[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(path) == 0 {
+			return false
+		}
+		if !matchSegment(head, path[0]) {
+			return false
+		}
+		pat = pat[1:]
+		path = path[1:]
+	}
+	return len(path) == 0
+}
+
+// matchSegment matches one pattern segment (no `/`) against one path
+// segment. Supports `*` (any chars) and `?` (one char).
+func matchSegment(pat, segment string) bool {
+	// Use filepath.Match for the well-tested per-segment semantics.
+	// Match returns false on syntax errors; treat as no-match.
+	ok, err := filepath.Match(pat, segment)
+	if err != nil {
+		return false
+	}
+	return ok
+}

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -52,7 +52,7 @@ const maxDescLen = 50
 // nothing. Explains where specter looked and what to try next — users often
 // keep specs in a non-default directory and need the hint.
 func noSpecsMessage() string {
-	m, _ := loadManifest()
+	m, _, _ := loadManifest()
 	searched := m.SpecsDir()
 	if searched == "" || searched == "." {
 		searched = "current directory and subdirectories"
@@ -268,7 +268,7 @@ func discoverSpecs(patterns ...string) []string {
 		return patterns
 	}
 	// Load manifest to honor settings.exclude and specs_dir.
-	m, _ := loadManifest()
+	m, _, _ := loadManifest()
 	excludeNames := make(map[string]bool)
 	for _, e := range m.ExcludePatterns() {
 		excludeNames[e] = true
@@ -300,14 +300,8 @@ func discoverSpecs(patterns ...string) []string {
 }
 
 func discoverTestFiles(glob string) []string {
-	// If an explicit glob is provided, use filepath.Glob to resolve it directly.
 	if glob != "" {
-		matches, err := filepath.Glob(glob)
-		if err == nil && len(matches) > 0 {
-			return matches
-		}
-		// Glob matched nothing or errored — fall through to default walk so the
-		// caller gets a useful result rather than silent empty output.
+		return globMatchWalk(glob)
 	}
 
 	// Default: walk the repo for all recognized test file suffixes.
@@ -571,7 +565,11 @@ func checkCmd() *cobra.Command {
 				return errSilent
 			}
 
-			m, _ := loadManifest()
+			m, _, mErr := loadManifest()
+			if mErr != nil {
+				fmt.Fprintln(os.Stderr, "error:", mErr)
+				return errSilent
+			}
 			opts := &checker.CheckOptions{
 				Strict:      strict || m.Settings.Strict,
 				WarnOnDraft: m.Settings.WarnOnDraft,
@@ -663,19 +661,34 @@ func coverageCmd() *cobra.Command {
 				specFileByID[in.Spec.ID] = in.File
 			}
 
-			m, _ := loadManifest()
-
-			// C-25: when --tests is unset, fall back to settings.tests_glob.
-			// First entry wins for the discoverTestFiles call (it accepts a single
-			// glob); the manifest can carry multiple but we use the first as the
-			// primary discovery hint. discoverTestFiles falls back to walking "."
-			// when its argument is empty.
-			effectiveTestsGlob := testsGlob
-			if effectiveTestsGlob == "" && len(m.Settings.TestsGlob) > 0 {
-				effectiveTestsGlob = m.Settings.TestsGlob[0]
+			m, _, mErr := loadManifest()
+			if mErr != nil {
+				fmt.Fprintln(os.Stderr, "error:", mErr)
+				return errSilent
 			}
 
-			testFiles := discoverTestFiles(effectiveTestsGlob)
+			// C-25: when --tests is unset, fall back to settings.tests_glob.
+			// Manifest may carry multiple globs as a list; iterate and union
+			// the matches (deduped). Empty manifest list + no --tests falls
+			// through to discoverTestFiles("") which walks "." for known
+			// test-file extensions.
+			var testFiles []string
+			switch {
+			case testsGlob != "":
+				testFiles = discoverTestFiles(testsGlob)
+			case len(m.Settings.TestsGlob) > 0:
+				seen := map[string]bool{}
+				for _, g := range m.Settings.TestsGlob {
+					for _, f := range discoverTestFiles(g) {
+						if !seen[f] {
+							seen[f] = true
+							testFiles = append(testFiles, f)
+						}
+					}
+				}
+			default:
+				testFiles = discoverTestFiles("")
+			}
 			var allAnnotations []coverage.AnnotationMatch
 			for _, f := range testFiles {
 				data, err := os.ReadFile(f)
@@ -683,6 +696,17 @@ func coverageCmd() *cobra.Command {
 					continue
 				}
 				allAnnotations = append(allAnnotations, coverage.ExtractAnnotations(string(data), f)...)
+			}
+
+			// Validate the CLI flag against the same enum as settings.strictness.
+			// Reject typos at the flag layer rather than silently falling
+			// through (the same class GH #76 closes for the manifest).
+			if strictnessFlag != "" {
+				validStrictness := map[string]bool{"annotation": true, "threshold": true, "zero-tolerance": true}
+				if !validStrictness[strictnessFlag] {
+					fmt.Fprintf(os.Stderr, "error: --strictness %q is not a valid value (allowed: annotation, threshold, zero-tolerance)\n", strictnessFlag)
+					return errSilent
+				}
 			}
 
 			// Resolve effective strictness: CLI flag overrides manifest setting.
@@ -923,7 +947,11 @@ func syncCmd() *cobra.Command {
 				testContents = append(testContents, specsync.FileContent{Path: f, Content: string(data)})
 			}
 
-			m, _ := loadManifest()
+			m, _, mErr := loadManifest()
+			if mErr != nil {
+				fmt.Fprintln(os.Stderr, "error:", mErr)
+				return errSilent
+			}
 			checkOpts := &checker.CheckOptions{
 				Strict:      strict || m.Settings.Strict,
 				WarnOnDraft: m.Settings.WarnOnDraft,
@@ -1246,21 +1274,26 @@ func findManifest() (manifestPath string, projectRoot string) {
 	return "", ""
 }
 
-func loadManifest() (*manifest.Manifest, string) {
+// loadManifest finds and parses the nearest specter.yaml. Always returns a
+// non-nil Manifest — Defaults() if no file exists or parse fails — so library
+// helpers (noSpecsMessage, discoverSpecs) can safely deref. Returns a non-nil
+// error when a manifest IS present but fails to parse; RunE handlers must
+// check the error and fail-fast (per GH #76 — silent fallback to Defaults()
+// on parse error swallowed every typo'd settings key).
+func loadManifest() (*manifest.Manifest, string, error) {
 	path, root := findManifest()
 	if path == "" {
-		return manifest.Defaults(), ""
+		return manifest.Defaults(), "", nil
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return manifest.Defaults(), ""
+		return manifest.Defaults(), "", fmt.Errorf("read %s: %w", path, err)
 	}
 	m, err := manifest.ParseManifest(string(data))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: invalid specter.yaml: %v (using defaults)\n", err)
-		return manifest.Defaults(), ""
+		return manifest.Defaults(), "", fmt.Errorf("invalid %s: %w", path, err)
 	}
-	return m, root
+	return m, root, nil
 }
 
 func initCmd() *cobra.Command {
@@ -1769,7 +1802,11 @@ func doctorCmd() *cobra.Command {
 
 			// --- Check 5: Coverage meets tier thresholds (C-05, AC-06) ---
 			if len(specFiles) > 0 {
-				m, _ := loadManifest()
+				m, _, mErr := loadManifest()
+				if mErr != nil {
+					fmt.Fprintln(os.Stderr, "error:", mErr)
+					return errSilent
+				}
 				_, specs, hasParseErrors := parseAllSpecs(specFiles)
 				if hasParseErrors {
 					printCheck("coverage", "WARN", "Skipping coverage check — specs have parse errors")
@@ -2048,7 +2085,11 @@ func watchCmd() *cobra.Command {
 		Short: "Re-run sync pipeline on file changes",
 		Long:  "Watches .spec.yaml and test files for changes and re-runs the full sync pipeline. Press Ctrl+C to stop.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m, _ := loadManifest()
+			m, _, mErr := loadManifest()
+			if mErr != nil {
+				fmt.Fprintln(os.Stderr, "error:", mErr)
+				return errSilent
+			}
 
 			specsDir := m.SpecsDir()
 			fmt.Printf("specter watch\n\n")

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -640,6 +640,7 @@ func coverageCmd() *cobra.Command {
 	var failingOnly bool
 	var strict bool
 	var scope string
+	var strictnessFlag string
 	cmd := &cobra.Command{
 		Use:   "coverage",
 		Short: "Generate spec-to-test traceability matrix",
@@ -662,7 +663,19 @@ func coverageCmd() *cobra.Command {
 				specFileByID[in.Spec.ID] = in.File
 			}
 
-			testFiles := discoverTestFiles(testsGlob)
+			m, _ := loadManifest()
+
+			// C-25: when --tests is unset, fall back to settings.tests_glob.
+			// First entry wins for the discoverTestFiles call (it accepts a single
+			// glob); the manifest can carry multiple but we use the first as the
+			// primary discovery hint. discoverTestFiles falls back to walking "."
+			// when its argument is empty.
+			effectiveTestsGlob := testsGlob
+			if effectiveTestsGlob == "" && len(m.Settings.TestsGlob) > 0 {
+				effectiveTestsGlob = m.Settings.TestsGlob[0]
+			}
+
+			testFiles := discoverTestFiles(effectiveTestsGlob)
 			var allAnnotations []coverage.AnnotationMatch
 			for _, f := range testFiles {
 				data, err := os.ReadFile(f)
@@ -672,7 +685,34 @@ func coverageCmd() *cobra.Command {
 				allAnnotations = append(allAnnotations, coverage.ExtractAnnotations(string(data), f)...)
 			}
 
-			m, _ := loadManifest()
+			// Resolve effective strictness: CLI flag overrides manifest setting.
+			effectiveStrictness := m.Settings.Strictness
+			if strictnessFlag != "" {
+				effectiveStrictness = strictnessFlag
+			}
+			if effectiveStrictness == "" {
+				effectiveStrictness = "threshold"
+			}
+
+			// C-24: --strict combined with strictness=annotation is incoherent
+			// (annotation mode is for new adopters; strict requires runner-visible
+			// annotations). Fail-fast with a clear message.
+			if strict && effectiveStrictness == "annotation" {
+				fmt.Fprintln(os.Stderr, "error: --strict requires settings.strictness >= threshold; current strictness is annotation")
+				fmt.Fprintln(os.Stderr, "       set settings.strictness to 'threshold' or 'zero-tolerance' in specter.yaml, or pass --strictness <level>")
+				return errSilent
+			}
+
+			// C-27: empty test discovery under --strict surfaces a warning.
+			// Under zero-tolerance, the warning becomes a hard error.
+			if strict && len(allAnnotations) == 0 {
+				fmt.Fprintln(os.Stderr, "warn: no test files contained @spec/@ac annotations — coverage will report 0% for every spec")
+				fmt.Fprintln(os.Stderr, "      set settings.tests_glob in specter.yaml or pass --tests <glob>")
+				if effectiveStrictness == "zero-tolerance" {
+					fmt.Fprintln(os.Stderr, "error: zero-tolerance strictness requires at least one annotated test file")
+					return errSilent
+				}
+			}
 
 			// AC-25: resolve --scope domain to a set of spec IDs.
 			// Unknown domain → fail-fast listing valid names.
@@ -803,6 +843,39 @@ func coverageCmd() *cobra.Command {
 				fmt.Printf("  run: specter explain %s:%s\n", w.DependsOn, w.UncoveredACs[0])
 			}
 
+			// C-25 / AC-28: zero-tolerance fails on any non-passed annotated AC,
+			// regardless of whether the spec's tier-coverage % met its threshold.
+			// Exit code 2 distinguishes strictness violation from threshold failure.
+			//
+			// C-26 / AC-29: zero-tolerance also fails on approval_gate=true with
+			// unset approval_date. Exit code 3 distinguishes approval-gate violation.
+			if effectiveStrictness == "zero-tolerance" {
+				if results != nil {
+					nonPassed := 0
+					for _, r := range results.Results {
+						if r.Status != "" && r.Status != "passed" {
+							nonPassed++
+						}
+					}
+					if nonPassed > 0 {
+						fmt.Fprintf(os.Stderr, "error: zero-tolerance strictness — %d annotated AC(s) did not pass\n", nonPassed)
+						os.Exit(2)
+					}
+				}
+				gateViolations := 0
+				for _, s := range specs {
+					for _, ac := range s.AcceptanceCriteria {
+						if ac.ApprovalGate && ac.ApprovalDate == "" {
+							gateViolations++
+						}
+					}
+				}
+				if gateViolations > 0 {
+					fmt.Fprintf(os.Stderr, "error: zero-tolerance strictness — %d AC(s) carry approval_gate=true with unset approval_date\n", gateViolations)
+					os.Exit(3)
+				}
+			}
+
 			if report.Summary.Failing > 0 {
 				return errSilent
 			}
@@ -814,6 +887,7 @@ func coverageCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&failingOnly, "failing", false, "Show only specs below 100% coverage in the table (summary header still reflects the full report)")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Require .specter-results.json and treat any non-passed annotated AC as uncovered (all tiers)")
 	cmd.Flags().StringVar(&scope, "scope", "", "Narrow --strict demand to specs in the named domain from specter.yaml (specs outside the domain fall back to v0.9 boolean-passed logic). Requires --strict.")
+	cmd.Flags().StringVar(&strictnessFlag, "strictness", "", "Override settings.strictness in specter.yaml (annotation | threshold | zero-tolerance)")
 	return cmd
 }
 

--- a/specter/internal/manifest/manifest.go
+++ b/specter/internal/manifest/manifest.go
@@ -2,12 +2,41 @@ package manifest
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
+// validTopLevelKeys lists every key allowed at the manifest top level.
+// Updated when adding a new top-level field.
+var validTopLevelKeys = []string{"system", "domains", "settings", "registry"}
+
+// validSettingsKeys lists every key allowed under `settings:`. Updated when
+// adding a new settings field.
+var validSettingsKeys = []string{
+	"specs_dir", "coverage", "exclude", "strict", "warn_on_draft",
+	"tier_overrides", "tests_glob", "strictness",
+}
+
+// validStrictnessValues enumerates the three allowed strictness levels.
+var validStrictnessValues = []string{"annotation", "threshold", "zero-tolerance"}
+
 // ParseManifest parses and validates a specter.yaml content string.
+//
+// C-26: rejects unknown top-level and settings keys with a did-you-mean
+// suggestion when the offending key is within Levenshtein 3 of a valid one.
+// C-24: validates settings.strictness against the enum {annotation,
+// threshold, zero-tolerance} and applies the default ("threshold") when unset.
 func ParseManifest(yamlContent string) (*Manifest, error) {
+	// Step 1: unknown-key rejection. Parse into a generic map first so we
+	// can surface offending keys with did-you-mean before the typed parse
+	// silently drops them.
+	if err := validateManifestKeys(yamlContent); err != nil {
+		return nil, err
+	}
+
+	// Step 2: typed parse.
 	var m Manifest
 	if err := yaml.Unmarshal([]byte(yamlContent), &m); err != nil {
 		return nil, fmt.Errorf("invalid YAML: %w", err)
@@ -31,7 +60,136 @@ func ParseManifest(yamlContent string) (*Manifest, error) {
 		return nil, err
 	}
 
+	// C-24: validate strictness enum + default.
+	if err := validateStrictness(&m.Settings); err != nil {
+		return nil, err
+	}
+
 	return &m, nil
+}
+
+// validateManifestKeys checks for unknown top-level and settings keys.
+func validateManifestKeys(yamlContent string) error {
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal([]byte(yamlContent), &raw); err != nil {
+		// Not our job to surface yaml-syntax errors here; the typed parse
+		// will catch them with a better-shaped error.
+		return nil
+	}
+
+	for key := range raw {
+		if !contains(validTopLevelKeys, key) {
+			return unknownKeyError(key, "", validTopLevelKeys)
+		}
+	}
+
+	settingsRaw, ok := raw["settings"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for key := range settingsRaw {
+		if !contains(validSettingsKeys, key) {
+			return unknownKeyError(key, "settings", validSettingsKeys)
+		}
+	}
+	return nil
+}
+
+// validateStrictness validates m.Settings.Strictness against the enum and
+// applies the default "threshold" when unset.
+func validateStrictness(s *Settings) error {
+	if s.Strictness == "" {
+		s.Strictness = "threshold"
+		return nil
+	}
+	if !contains(validStrictnessValues, s.Strictness) {
+		return fmt.Errorf("settings.strictness: %q is not a valid value (allowed: %s)",
+			s.Strictness, strings.Join(validStrictnessValues, ", "))
+	}
+	return nil
+}
+
+// unknownKeyError builds a did-you-mean error for unknown manifest keys.
+// scope is "" for top-level or e.g. "settings" for nested.
+func unknownKeyError(offending, scope string, valid []string) error {
+	prefix := offending
+	if scope != "" {
+		prefix = scope + "." + offending
+	}
+	suggestion := closestKey(offending, valid)
+	sortedValid := append([]string{}, valid...)
+	sort.Strings(sortedValid)
+	scopeLabel := "manifest"
+	if scope != "" {
+		scopeLabel = scope
+	}
+	if suggestion != "" {
+		return fmt.Errorf("unknown %s key %q — did you mean %q? (valid keys: %s)",
+			scopeLabel, prefix, suggestion, strings.Join(sortedValid, ", "))
+	}
+	return fmt.Errorf("unknown %s key %q (valid keys: %s)",
+		scopeLabel, prefix, strings.Join(sortedValid, ", "))
+}
+
+// closestKey returns the closest valid key to target by Levenshtein distance,
+// or "" if no key is within distance 3.
+func closestKey(target string, candidates []string) string {
+	best := ""
+	bestDist := 4
+	for _, c := range candidates {
+		d := levenshtein(target, c)
+		if d < bestDist {
+			bestDist = d
+			best = c
+		}
+	}
+	return best
+}
+
+// levenshtein computes edit distance between a and b.
+func levenshtein(a, b string) int {
+	if a == "" {
+		return len(b)
+	}
+	if b == "" {
+		return len(a)
+	}
+	ra, rb := []rune(a), []rune(b)
+	mLen, n := len(ra), len(rb)
+	prev := make([]int, n+1)
+	curr := make([]int, n+1)
+	for j := 0; j <= n; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= mLen; i++ {
+		curr[0] = i
+		for j := 1; j <= n; j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			a, b, c := curr[j-1]+1, prev[j]+1, prev[j-1]+cost
+			minVal := a
+			if b < minVal {
+				minVal = b
+			}
+			if c < minVal {
+				minVal = c
+			}
+			curr[j] = minVal
+		}
+		prev, curr = curr, prev
+	}
+	return prev[n]
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // Defaults returns a Manifest with sensible defaults for use when no specter.yaml exists.

--- a/specter/internal/manifest/manifest.go
+++ b/specter/internal/manifest/manifest.go
@@ -199,7 +199,8 @@ func Defaults() *Manifest {
 			Name: "",
 		},
 		Settings: Settings{
-			SpecsDir: "specs",
+			SpecsDir:   "specs",
+			Strictness: "threshold",
 			Coverage: CoverageConfig{
 				Tier1: 100,
 				Tier2: 80,

--- a/specter/internal/manifest/settings_strictness_test.go
+++ b/specter/internal/manifest/settings_strictness_test.go
@@ -1,0 +1,63 @@
+// Pure-function tests for settings.strictness parsing (C-24, AC-37, AC-38).
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// @ac AC-37
+func TestParseManifest_Strictness_AcceptsAllThreeValues(t *testing.T) {
+	t.Run("spec-manifest/AC-37 settings.strictness accepts annotation/threshold/zero-tolerance", func(t *testing.T) {
+		cases := map[string]string{
+			"annotation":     "system: { name: x }\nsettings:\n  strictness: annotation\n",
+			"threshold":      "system: { name: x }\nsettings:\n  strictness: threshold\n",
+			"zero-tolerance": "system: { name: x }\nsettings:\n  strictness: zero-tolerance\n",
+		}
+		for want, yamlBody := range cases {
+			m, err := ParseManifest(yamlBody)
+			if err != nil {
+				t.Errorf("ParseManifest(%q): %v", want, err)
+				continue
+			}
+			if m.Settings.Strictness != want {
+				t.Errorf("ParseManifest(%q): Settings.Strictness = %q, want %q", want, m.Settings.Strictness, want)
+			}
+		}
+	})
+}
+
+// @ac AC-37
+func TestParseManifest_Strictness_DefaultsToThreshold(t *testing.T) {
+	t.Run("spec-manifest/AC-37 unset strictness defaults to threshold", func(t *testing.T) {
+		m, err := ParseManifest("system: { name: x }\nsettings:\n  specs_dir: specs\n")
+		if err != nil {
+			t.Fatalf("ParseManifest: %v", err)
+		}
+		if m.Settings.Strictness != "threshold" {
+			t.Errorf("expected default Strictness = \"threshold\", got %q", m.Settings.Strictness)
+		}
+	})
+}
+
+// @ac AC-38
+func TestParseManifest_Strictness_RejectsInvalidValue(t *testing.T) {
+	t.Run("spec-manifest/AC-38 invalid strictness errors with clear message", func(t *testing.T) {
+		_, err := ParseManifest("system: { name: x }\nsettings:\n  strictness: bogus\n")
+		if err == nil {
+			t.Fatal("expected error for invalid strictness, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "strictness") {
+			t.Errorf("expected 'strictness' in error, got: %s", msg)
+		}
+		// Error must list the valid values.
+		for _, valid := range []string{"annotation", "threshold", "zero-tolerance"} {
+			if !strings.Contains(msg, valid) {
+				t.Errorf("expected error to list valid value %q, got: %s", valid, msg)
+			}
+		}
+	})
+}

--- a/specter/internal/manifest/settings_tests_glob_test.go
+++ b/specter/internal/manifest/settings_tests_glob_test.go
@@ -1,0 +1,51 @@
+// Pure-function tests for settings.tests_glob parsing (C-25, AC-39).
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"reflect"
+	"testing"
+)
+
+// @ac AC-39
+func TestParseManifest_TestsGlob_StringForm(t *testing.T) {
+	t.Run("spec-manifest/AC-39 tests_glob string form normalizes to single-element slice", func(t *testing.T) {
+		m, err := ParseManifest("system: { name: x }\nsettings:\n  tests_glob: tests/**/*.py\n")
+		if err != nil {
+			t.Fatalf("ParseManifest: %v", err)
+		}
+		want := []string{"tests/**/*.py"}
+		if !reflect.DeepEqual(m.Settings.TestsGlob, want) {
+			t.Errorf("TestsGlob = %v, want %v", m.Settings.TestsGlob, want)
+		}
+	})
+}
+
+// @ac AC-39
+func TestParseManifest_TestsGlob_ListForm(t *testing.T) {
+	t.Run("spec-manifest/AC-39 tests_glob list form preserves all entries", func(t *testing.T) {
+		body := "system: { name: x }\nsettings:\n  tests_glob:\n    - tests/**/*.py\n    - integration/**/*.py\n"
+		m, err := ParseManifest(body)
+		if err != nil {
+			t.Fatalf("ParseManifest: %v", err)
+		}
+		want := []string{"tests/**/*.py", "integration/**/*.py"}
+		if !reflect.DeepEqual(m.Settings.TestsGlob, want) {
+			t.Errorf("TestsGlob = %v, want %v", m.Settings.TestsGlob, want)
+		}
+	})
+}
+
+// @ac AC-39
+func TestParseManifest_TestsGlob_UnsetIsEmpty(t *testing.T) {
+	t.Run("spec-manifest/AC-39 unset tests_glob is empty (not nil panic)", func(t *testing.T) {
+		m, err := ParseManifest("system: { name: x }\n")
+		if err != nil {
+			t.Fatalf("ParseManifest: %v", err)
+		}
+		if len(m.Settings.TestsGlob) != 0 {
+			t.Errorf("expected empty TestsGlob, got %v", m.Settings.TestsGlob)
+		}
+	})
+}

--- a/specter/internal/manifest/settings_tests_glob_test.go
+++ b/specter/internal/manifest/settings_tests_glob_test.go
@@ -16,7 +16,7 @@ func TestParseManifest_TestsGlob_StringForm(t *testing.T) {
 			t.Fatalf("ParseManifest: %v", err)
 		}
 		want := []string{"tests/**/*.py"}
-		if !reflect.DeepEqual(m.Settings.TestsGlob, want) {
+		if !reflect.DeepEqual([]string(m.Settings.TestsGlob), want) {
 			t.Errorf("TestsGlob = %v, want %v", m.Settings.TestsGlob, want)
 		}
 	})
@@ -31,7 +31,7 @@ func TestParseManifest_TestsGlob_ListForm(t *testing.T) {
 			t.Fatalf("ParseManifest: %v", err)
 		}
 		want := []string{"tests/**/*.py", "integration/**/*.py"}
-		if !reflect.DeepEqual(m.Settings.TestsGlob, want) {
+		if !reflect.DeepEqual([]string(m.Settings.TestsGlob), want) {
 			t.Errorf("TestsGlob = %v, want %v", m.Settings.TestsGlob, want)
 		}
 	})

--- a/specter/internal/manifest/settings_unknown_key_test.go
+++ b/specter/internal/manifest/settings_unknown_key_test.go
@@ -1,0 +1,94 @@
+// Pure-function tests for unknown-key rejection in the settings block (C-26, AC-40).
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// @ac AC-40
+func TestParseManifest_UnknownSettingsKey_ErrorsWithDidYouMean(t *testing.T) {
+	t.Run("spec-manifest/AC-40 typo'd settings key errors with did-you-mean suggestion", func(t *testing.T) {
+		// `test_glob` is a one-character distance from the real `tests_glob`.
+		body := "system: { name: x }\nsettings:\n  test_glob: tests/**/*.py\n"
+		_, err := ParseManifest(body)
+		if err == nil {
+			t.Fatal("expected error for unknown settings key, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "test_glob") {
+			t.Errorf("expected error to name the offending key 'test_glob', got: %s", msg)
+		}
+		if !strings.Contains(strings.ToLower(msg), "did you mean") {
+			t.Errorf("expected 'did you mean' suggestion, got: %s", msg)
+		}
+		if !strings.Contains(msg, "tests_glob") {
+			t.Errorf("expected suggestion to name 'tests_glob', got: %s", msg)
+		}
+	})
+}
+
+// @ac AC-40
+func TestParseManifest_UnknownSettingsKey_FarFromValid_NoSuggestion(t *testing.T) {
+	t.Run("spec-manifest/AC-40 wildly typo'd key errors but omits did-you-mean", func(t *testing.T) {
+		// 'xyz_random_thing' is far from any valid settings key (Levenshtein >> 3).
+		body := "system: { name: x }\nsettings:\n  xyz_random_thing: 123\n"
+		_, err := ParseManifest(body)
+		if err == nil {
+			t.Fatal("expected error for unknown settings key, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "xyz_random_thing") {
+			t.Errorf("expected error to name the offending key, got: %s", msg)
+		}
+		// No close match → no did-you-mean.
+		if strings.Contains(strings.ToLower(msg), "did you mean") {
+			t.Errorf("expected no did-you-mean for far-distance typo, got: %s", msg)
+		}
+	})
+}
+
+// @ac AC-40
+func TestParseManifest_UnknownTopLevelKey_ErrorsCleanly(t *testing.T) {
+	t.Run("spec-manifest/AC-40 unknown top-level manifest key also errors", func(t *testing.T) {
+		// Top-level (sibling of system/domains/settings/registry) — same rule.
+		body := "system: { name: x }\nbogus_top_level: yes\n"
+		_, err := ParseManifest(body)
+		if err == nil {
+			t.Fatal("expected error for unknown top-level key, got nil")
+		}
+		if !strings.Contains(err.Error(), "bogus_top_level") {
+			t.Errorf("expected error to name 'bogus_top_level', got: %v", err)
+		}
+	})
+}
+
+// Regression guard: every existing valid settings key must still parse.
+func TestParseManifest_AllValidSettingsKeys_StillParse(t *testing.T) {
+	t.Run("spec-manifest/regression all valid settings keys parse cleanly", func(t *testing.T) {
+		body := `
+system:
+  name: regression-system
+settings:
+  specs_dir: specs
+  coverage:
+    tier1: 100
+    tier2: 80
+    tier3: 50
+  exclude:
+    - .git
+  strict: false
+  warn_on_draft: true
+  tier_overrides:
+    spec-foo: 1
+  tests_glob: tests/**/*.py
+  strictness: zero-tolerance
+`
+		_, err := ParseManifest(body)
+		if err != nil {
+			t.Errorf("expected clean parse for all valid keys, got error: %v", err)
+		}
+	})
+}

--- a/specter/internal/manifest/string_or_list.go
+++ b/specter/internal/manifest/string_or_list.go
@@ -1,0 +1,71 @@
+// StringOrList is a YAML field that accepts either a single string or a list
+// of strings. Used by `settings.tests_glob` (C-25) so users can write either:
+//
+//	tests_glob: "tests/**/*.py"
+//
+// or
+//
+//	tests_glob:
+//	  - "tests/**/*.py"
+//	  - "integration/**/*.py"
+//
+// Both forms normalize into a []string at parse time.
+//
+// @spec spec-manifest
+package manifest
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// StringOrList is a slice of strings that can unmarshal from either a YAML
+// scalar (single string) or a YAML sequence (list of strings).
+type StringOrList []string
+
+// UnmarshalYAML implements yaml.Unmarshaler. Accepts scalar or sequence;
+// rejects mappings and other shapes with a clear error.
+func (s *StringOrList) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var single string
+		if err := value.Decode(&single); err != nil {
+			return err
+		}
+		*s = StringOrList{single}
+		return nil
+	case yaml.SequenceNode:
+		var list []string
+		if err := value.Decode(&list); err != nil {
+			return err
+		}
+		*s = StringOrList(list)
+		return nil
+	default:
+		return fmt.Errorf("expected string or list, got %s at line %d", nodeKindName(value.Kind), value.Line)
+	}
+}
+
+// MarshalYAML emits the slice as a list. Single-element slices stay as a
+// list rather than collapsing back to a scalar — round-trip preservation
+// of the original shape isn't worth the complexity for this field.
+func (s StringOrList) MarshalYAML() (interface{}, error) {
+	return []string(s), nil
+}
+
+func nodeKindName(k yaml.Kind) string {
+	switch k {
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.AliasNode:
+		return "alias"
+	}
+	return "unknown"
+}

--- a/specter/internal/manifest/types.go
+++ b/specter/internal/manifest/types.go
@@ -39,6 +39,8 @@ type Settings struct {
 	Strict        bool           `yaml:"strict,omitempty" json:"strict,omitempty"`                 // C-11: treat warnings as errors
 	WarnOnDraft   bool           `yaml:"warn_on_draft,omitempty" json:"warn_on_draft,omitempty"`   // C-12: warn on draft specs
 	TierOverrides map[string]int `yaml:"tier_overrides,omitempty" json:"tier_overrides,omitempty"` // C-14: per-spec tier overrides
+	TestsGlob     StringOrList   `yaml:"tests_glob,omitempty" json:"tests_glob,omitempty"`         // C-25: default test-discovery glob (string or list)
+	Strictness    string         `yaml:"strictness,omitempty" json:"strictness,omitempty"`         // C-24: annotation | threshold (default) | zero-tolerance
 }
 
 // CoverageConfig defines per-tier coverage thresholds.

--- a/specter/specs/spec-coverage.spec.yaml
+++ b/specter/specs/spec-coverage.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-coverage
-  version: "1.10.0"
+  version: "1.11.0"
   status: approved
   tier: 2
 
@@ -150,6 +150,26 @@ spec:
 
     - id: C-23
       description: "`specter coverage --scope <domain>` narrows `--strict`'s demand set to ACs of specs listed under the named domain in `specter.yaml`. Semantics: (a) ACs in the scoped domain behave per C-19 (must have status=passed entry, else demoted); (b) ACs outside the scoped domain use the pre-strict boolean-passed logic — annotation presence alone counts as coverage regardless of whether a passing entry exists in results; (c) the report includes ALL specs (not filtered), so the operator sees the full workspace, not a shrunken view. `--scope` without `--strict` is an error. `--scope` combines with `--tests <glob>` as AND (both filters apply). Rationale: staged adoption — a 250-spec workspace cannot migrate every test to runner-visible annotations in one wave; `--scope` lets CI enforce `--strict` on one domain per wave while the rest of the workspace continues with v0.9 semantics."
+      type: business
+      enforcement: error
+
+    - id: C-24
+      description: "When `settings.strictness == \"annotation\"` in `specter.yaml`, `specter coverage --strict` MUST exit non-zero with a clear error rejecting the flag combination: `--strict requires settings.strictness >= threshold; current strictness is annotation`. Rationale: `annotation` mode is for new adopters mid-migration; combining it with the strict flag is incoherent and almost always a misconfiguration."
+      type: business
+      enforcement: error
+
+    - id: C-25
+      description: "When `settings.strictness == \"zero-tolerance\"` (or `--strictness zero-tolerance`), `specter coverage` MUST exit non-zero whenever any annotated AC has a results-file status other than `passed`, regardless of tier coverage threshold. Under `threshold` (default), the same workspace may still pass if total demoted-coverage clears the tier threshold. Zero-tolerance is the strictest gate — one failing annotated test fails the entire run."
+      type: business
+      enforcement: error
+
+    - id: C-26
+      description: "Under `settings.strictness == \"zero-tolerance\"`, `specter coverage` MUST also exit non-zero when any AC carries `approval_gate: true` and an unset `approval_date`. The exit code is distinct from C-25's strictness violation (3 vs 2) so CI can differentiate. Under `threshold` mode `approval_gate` remains metadata-only (matches today's behavior — see spec-explain SPEC_SCHEMA_REFERENCE)."
+      type: business
+      enforcement: error
+
+    - id: C-27
+      description: "`specter coverage --strict` MUST emit a stderr warning before computing coverage when test discovery (after applying `--tests <glob>` or the manifest's `settings.tests_glob`, then falling back to `filepath.Walk(\".\")`) yields zero files containing `@spec` or `@ac` annotations. The warning names the likely cause (`no test files contained @spec/@ac annotations — coverage will report 0% for every spec`) and points at the configuration fix (`set settings.tests_glob in specter.yaml or pass --tests <glob>`). Under `strictness == zero-tolerance`, the warning is upgraded to a hard error (non-zero exit). Closes the silent-0% UX hole reported in GH #75."
       type: business
       enforcement: error
 
@@ -405,7 +425,56 @@ spec:
       references_constraints: ["C-23"]
       priority: medium
 
+    - id: AC-27
+      description: "`specter coverage --strictness <level>` overrides the manifest's `settings.strictness` per-invocation. `--strict` remains a backwards-compatible shortcut for `--strictness threshold`. `--strict --strictness annotation` is an error (incoherent: shortcut and explicit level disagree)."
+      inputs:
+        manifest_strictness: "threshold"
+        cli_flag: "--strictness zero-tolerance"
+      expected_output:
+        effective_strictness: "zero-tolerance"
+      references_constraints: ["C-24", "C-25"]
+      priority: critical
+
+    - id: AC-28
+      description: "Workspace where `settings.strictness == zero-tolerance` and one annotated AC has `status: failed` in `.specter-results.json`: `specter coverage` exits with code 2 even when the spec's tier-coverage % otherwise meets its threshold."
+      inputs:
+        manifest: "settings.strictness: zero-tolerance"
+        results: "AC-01 status=failed; AC-02..AC-10 status=passed (tier 2 spec at 90% > 80% threshold)"
+      expected_output:
+        exit_code: 2
+        threshold_alone_would_have_passed: true
+      references_constraints: ["C-25"]
+      priority: critical
+
+    - id: AC-29
+      description: "Workspace where `settings.strictness == zero-tolerance` and one AC carries `approval_gate: true` with `approval_date` unset: `specter coverage` exits with code 3 (distinct from C-25's code 2). Under `threshold`, the same workspace exits 0 — `approval_gate` remains metadata."
+      inputs:
+        manifest: "settings.strictness: zero-tolerance"
+        spec_ac: "approval_gate: true, approval_date: <unset>"
+      expected_output:
+        zero_tolerance_exit_code: 3
+        threshold_exit_code: 0
+      references_constraints: ["C-26"]
+      priority: high
+
+    - id: AC-30
+      description: "`specter coverage --strict` on a workspace where test discovery yields zero files containing `@spec` / `@ac` annotations emits a stderr warning (`no test files contained @spec/@ac annotations`) ABOVE the coverage table, naming the likely fix (`set settings.tests_glob or pass --tests <glob>`). Under `strictness == zero-tolerance`, the warning is upgraded to an error and exit is non-zero. Under `threshold`, exit code is unchanged from today (the run completes; the warning surfaces the cause)."
+      inputs:
+        scenario_threshold: "no annotated test files; settings.strictness: threshold"
+        scenario_zero_tolerance: "no annotated test files; settings.strictness: zero-tolerance"
+      expected_output:
+        threshold_warning_emitted: true
+        threshold_exit: "unchanged"
+        zero_tolerance_exit_code: "non-zero"
+      references_constraints: ["C-27"]
+      priority: critical
+
   changelog:
+    - version: "1.11.0"
+      date: "2026-04-25"
+      author: "specter-team"
+      type: minor
+      description: "v0.11 settings hardening (paired with spec-manifest 1.8.0). Add C-24/AC-27..28 and C-25/AC-28 for the three-level strictness gate (annotation rejects --strict; zero-tolerance fails on any non-passed annotated AC regardless of tier threshold). Add C-26/AC-29 for zero-tolerance approval_gate enforcement (exit code 3, distinct from strictness exit code 2). Add C-27/AC-30 for empty-test-discovery warning under --strict, upgraded to a hard error under zero-tolerance — closes GH #75 (silent 0% UX hole). Replaces the BUG-3 part 2 entry that used to live in BACKLOG."
     - version: "1.10.0"
       date: "2026-04-23"
       author: "specter-team"

--- a/specter/specs/spec-manifest.spec.yaml
+++ b/specter/specs/spec-manifest.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-manifest
-  version: "1.7.0"
+  version: "1.8.0"
   status: draft
   tier: 2
 
@@ -161,6 +161,21 @@ spec:
 
     - id: C-23
       description: "`specter init --ai <tool>` MUST write a per-tool AI instruction file with a `<!-- specter:begin v1 --> ... <!-- specter:end -->` fenced region containing the v0.11 instruction template (preflight, Convention A, validation gate, on-demand explain references). The fenced region's tool-target path is: `claude` → `CLAUDE.md`, `codex` → `AGENTS.md`, `cursor` → `.cursor/rules/specter.md`, `copilot` → `.github/copilot-instructions.md` (body capped at 4KB), `gemini` → `GEMINI.md`. Re-runs MUST replace only the fenced region; out-of-fence content is preserved byte-for-byte. `--ai claude` checks for an existing `AGENTS.md` and writes `@AGENTS.md` import directive instead of inlining the body when one exists."
+      type: technical
+      enforcement: error
+
+    - id: C-24
+      description: "MUST parse `settings.strictness` (string enum: `annotation` | `threshold` | `zero-tolerance`) with default `threshold`. The level governs `coverage --strict` semantics in spec-coverage; spec-manifest's role is parse-only — accept the three values, default when unset, reject any other string with a clear error naming the valid options."
+      type: technical
+      enforcement: error
+
+    - id: C-25
+      description: "MUST parse `settings.tests_glob` as either a string (single glob) or a list of strings (multiple globs) into a normalized `[]string`. Used by `coverage` and `sync` as the default test-discovery pattern when `--tests` is unset. Closes the silent-0% UX hole where users running `coverage --strict` on a Python/Node project with no `--tests` flag see all ACs reported as uncovered because `filepath.Walk(\".\")` misses their `tests/**/*.py` layout."
+      type: technical
+      enforcement: error
+
+    - id: C-26
+      description: "ParseManifest MUST reject any unknown key under the `settings:` block (and at the top level of the manifest) with a clear error naming the offending key, the closest valid key by Levenshtein distance ≤ 3 (`did you mean: <key>?`), and the full list of valid keys at that level. Rationale: today `settings.tests_glob:` (a plausible-but-misspelled-or-not-yet-existing key) parses cleanly and is silently ignored, leading users to believe their manifest is configured when in fact the key did nothing. The same silent-acceptance footgun threatens any new settings key (e.g., the v0.11 `strictness` field) — making the rejection a parse-level invariant closes the class."
       type: technical
       enforcement: error
 
@@ -534,6 +549,51 @@ spec:
       references_constraints: ["C-23"]
       priority: high
 
+    - id: AC-37
+      description: "ParseManifest accepts `settings.strictness: annotation`, `settings.strictness: threshold`, and `settings.strictness: zero-tolerance` cleanly. When unset, the parsed Manifest carries `Settings.Strictness == \"threshold\"` (default applied)."
+      inputs:
+        manifest_strictness_annotation: "settings.strictness: annotation"
+        manifest_strictness_zero_tolerance: "settings.strictness: zero-tolerance"
+        manifest_unset: "settings: { specs_dir: specs }"
+      expected_output:
+        annotation_parses: true
+        zero_tolerance_parses: true
+        unset_default: "threshold"
+      references_constraints: ["C-24"]
+      priority: critical
+
+    - id: AC-38
+      description: "ParseManifest rejects `settings.strictness: bogus` with a clear error naming the field and the three valid values. No partial parse; the function returns an error and a nil Manifest."
+      inputs:
+        manifest: "settings.strictness: bogus"
+      expected_output:
+        error_contains: "settings.strictness"
+        error_lists_valid_values: ["annotation", "threshold", "zero-tolerance"]
+      references_constraints: ["C-24"]
+      priority: critical
+
+    - id: AC-39
+      description: "ParseManifest accepts `settings.tests_glob` as either a single string (`tests_glob: \"tests/**/*.py\"`) or a list (`tests_glob: [\"tests/**/*.py\", \"integration/**/*.py\"]`). Both forms normalize into `Settings.TestsGlob []string`."
+      inputs:
+        manifest_string_form: "settings.tests_glob: tests/**/*.py"
+        manifest_list_form: "settings.tests_glob: [tests/**/*.py, integration/**/*.py]"
+      expected_output:
+        string_form_normalized_length: 1
+        list_form_normalized_length: 2
+      references_constraints: ["C-25"]
+      priority: critical
+
+    - id: AC-40
+      description: "ParseManifest with a typo'd settings key (e.g., `test_glob:` instead of `tests_glob:`) returns an error naming the offending key, the closest valid key (`did you mean: tests_glob?`), and exits parse-time. Empty workspace under `coverage --strict` no longer silently reports 0% — the manifest fails to parse first."
+      inputs:
+        manifest: "settings.test_glob: tests/**/*.py"
+      expected_output:
+        error_contains: "test_glob"
+        error_did_you_mean: "tests_glob"
+        exit_code: "non-zero"
+      references_constraints: ["C-26"]
+      priority: critical
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.0.0"
@@ -543,6 +603,11 @@ spec:
       relationship: requires
 
   changelog:
+    - version: "1.8.0"
+      date: "2026-04-25"
+      author: "specter-team"
+      type: minor
+      description: "v0.11 settings hardening. Add C-24/AC-37..38 for `settings.strictness` (Feature 5: three-level enum gating coverage --strict semantics). Add C-25/AC-39 for `settings.tests_glob` (closes GH #78: default test-discovery pattern, removes the silent-0% UX hole when --tests is unset). Add C-26/AC-40 for unknown-key rejection in settings (closes GH #76: typo'd keys now error with did-you-mean). Together these close a class of silent-failure footguns where users guess plausible setting names and get no signal."
     - version: "1.7.0"
       date: "2026-04-25"
       author: "specter-team"


### PR DESCRIPTION
Recovers from a base-change that didn't take effect on PR #82. The settings-hardening content (Wave C) landed on feat/init-bundle but not release/v0.11. This PR forward-merges it. No new code beyond what reviewed in #82.