### PR TITLE
chore: bump go directive to 1.25.9

### DIFF
--- a/specter/go.mod
+++ b/specter/go.mod
@@ -1,6 +1,6 @@
 module github.com/Hanalyx/specter
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Bumps `go 1.25.8` → `go 1.25.9` in `go.mod`. Picks up five stdlib advisories.

This is the go.mod-only split from PR #86. The companion workflow cleanup (removing the `go1.25.9 install` dance from `pre-release-test.yml`, now redundant once go.mod tracks 1.25.9) is in #86 and needs to be merged via web UI (the gh CLI's OAuth scope refuses workflow file edits).

Closes #86 once both this and the workflow cleanup land.