### PR TITLE
ci: remove redundant go1.25.9 install workaround

### DIFF
--- a/.github/workflows/pre-release-test.yml
+++ b/.github/workflows/pre-release-test.yml
@@ -58,13 +58,9 @@ jobs:
         run: go test -race ./...
 
       - name: Vulnerability scan
-        # govulncheck@latest requires go1.25+. Install go1.25.9 for this step
-        # only — the rest of the workflow uses the version from go.mod (1.22.2).
         run: |
-          go install golang.org/dl/go1.25.9@latest
-          ~/go/bin/go1.25.9 download
-          ~/go/bin/go1.25.9 install golang.org/x/vuln/cmd/govulncheck@latest
-          ~/go/bin/go1.25.9 run golang.org/x/vuln/cmd/govulncheck@latest ./...
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
 
       - name: Build
         run: go build -o bin/specter ./cmd/specter/


### PR DESCRIPTION
Cleanup. `go.mod` tracks 1.25.9 as of v0.11.0 (#89). `actions/setup-go` now pulls 1.25.9 natively and `govulncheck@latest` runs without the manual download dance.

Replaces the closed PR #86 (rebased to target main; the go.mod half landed via #89).