### PR TITLE
fix: v0.11.1 hotfix — GH #94 (approval_gate report demotion) + GH #95 (multi-@spec false positive)

### DIFF
--- a/specter/cmd/specter/coverage_strictness_test.go
+++ b/specter/cmd/specter/coverage_strictness_test.go
@@ -114,9 +114,70 @@ func TestCoverageStrictness_ZeroTolerance_FailsOnApprovalGate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, code := runCLI(t, dir, "coverage", "--strict")
+		out, code := runCLI(t, dir, "coverage", "--strict")
 		if code != 3 {
 			t.Errorf("expected exit code 3 for approval_gate violation under zero-tolerance, got %d", code)
+		}
+		// GH #94 regression: under zero-tolerance, the report MUST demote the
+		// approval-gate-violating AC. v0.11.0 fired exit 3 but left the report
+		// showing the AC as covered (PASS). v0.11.1 demotes in the report too.
+		if !strings.Contains(out, "0%") {
+			t.Errorf("expected report to show 0%% coverage after approval_gate demotion, got:\n%s", out)
+		}
+		if !strings.Contains(out, "uncovered: AC-01") {
+			t.Errorf("expected report to list AC-01 as uncovered after demotion, got:\n%s", out)
+		}
+		if strings.Contains(out, "100%") {
+			t.Errorf("did not expect 100%% coverage in report after demotion (v0.11.0 bug); got:\n%s", out)
+		}
+	})
+}
+
+// GH #94 — under threshold mode, approval_gate violations stay metadata.
+// The report must show the AC as PASS (no demotion). Regression guard for
+// the v0.11.1 fix to ensure it doesn't accidentally demote in threshold mode.
+func TestCoverageStrictness_ThresholdMode_DoesNotDemoteApprovalGate(t *testing.T) {
+	t.Run("spec-coverage/AC-29 threshold mode does not demote approval_gate violations", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifestWithStrictness(t, dir, "threshold")
+
+		specBody := `spec:
+  id: gated-spec
+  version: "1.0.0"
+  status: approved
+  tier: 3
+  context: { system: x, feature: x }
+  objective: { summary: x }
+  constraints:
+    - id: C-01
+      description: "MUST do thing"
+      type: technical
+      enforcement: error
+  acceptance_criteria:
+    - id: AC-01
+      description: "Thing happens"
+      approval_gate: true
+      references_constraints: ["C-01"]
+      priority: high
+`
+		if err := os.WriteFile(filepath.Join(dir, "gated.spec.yaml"), []byte(specBody), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testFile := "// @spec gated-spec\n// @ac AC-01\nfunc TestGated(t *testing.T) {}\n"
+		if err := os.WriteFile(filepath.Join(dir, "gated_test.go"), []byte(testFile), 0644); err != nil {
+			t.Fatal(err)
+		}
+		results := `{"results": [{"spec_id": "gated-spec", "ac_id": "AC-01", "status": "passed", "test_name": "TestGated"}]}`
+		if err := os.WriteFile(filepath.Join(dir, ".specter-results.json"), []byte(results), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		out, code := runCLI(t, dir, "coverage", "--strict")
+		if code != 0 {
+			t.Errorf("expected exit 0 under threshold mode (approval_gate is metadata), got %d", code)
+		}
+		if !strings.Contains(out, "100%") || !strings.Contains(out, "PASS") {
+			t.Errorf("expected 100%% PASS under threshold (no demotion), got:\n%s", out)
 		}
 	})
 }

--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -819,6 +819,20 @@ func coverageCmd() *cobra.Command {
 				report.Entries[i].SpecFile = specFileByID[report.Entries[i].SpecID]
 			}
 
+			// GH #94 — under zero-tolerance, demote ACs that violate the
+			// approval_gate contract (approval_gate: true with unset
+			// approval_date) so the report reflects the same enforcement
+			// signal the exit code carries. v0.11.0 fired the exit code but
+			// left the report unchanged; the user-visible PASS/FAIL cell
+			// stayed identical between threshold and zero-tolerance.
+			//
+			// Demotion shape: move the AC from CoveredACs to UncoveredACs,
+			// recompute CoveragePct + PassesThreshold per entry, recompute
+			// Summary.Passing / Summary.Failing.
+			if effectiveStrictness == "zero-tolerance" {
+				demoteApprovalGateViolations(report, specs)
+			}
+
 			// C-10: --json emits the report in every state, including when
 			// parse failed. Downstream consumers (VS Code extension) branch on
 			// ParseErrors vs Entries to decide what to render. Exit code, not
@@ -1589,6 +1603,77 @@ func runInitAI(tool string) error {
 		fmt.Println("Detected existing AGENTS.md — CLAUDE.md uses @AGENTS.md import to avoid duplicating the template.")
 	}
 	return nil
+}
+
+// demoteApprovalGateViolations is the v0.11.1 fix for GH #94. Under
+// strictness=zero-tolerance, an AC with approval_gate: true and unset
+// approval_date is a demotion — it must show up in the report as
+// uncovered, not just trigger the exit-3 code path. Walks the report
+// in place: moves violating ACs from CoveredACs to UncoveredACs,
+// recomputes per-entry CoveragePct + PassesThreshold, and recomputes
+// Summary.Passing / Summary.Failing.
+//
+// v0.11.0 emitted the exit code but left the report identical to
+// threshold mode — operator-visible report stayed PASS while the run
+// exited 3. This function aligns the report with the exit signal.
+func demoteApprovalGateViolations(report *coverage.CoverageReport, specs []schema.SpecAST) {
+	// Build (specID → set of AC IDs to demote) from the spec AST.
+	violations := make(map[string]map[string]bool)
+	for i := range specs {
+		s := &specs[i]
+		var demoted map[string]bool
+		for _, ac := range s.AcceptanceCriteria {
+			if ac.ApprovalGate && ac.ApprovalDate == "" {
+				if demoted == nil {
+					demoted = make(map[string]bool)
+				}
+				demoted[ac.ID] = true
+			}
+		}
+		if demoted != nil {
+			violations[s.ID] = demoted
+		}
+	}
+	if len(violations) == 0 {
+		return
+	}
+
+	// Walk report entries and demote.
+	report.Summary.Passing = 0
+	report.Summary.Failing = 0
+	for i := range report.Entries {
+		e := &report.Entries[i]
+		demoted := violations[e.SpecID]
+		if demoted == nil {
+			if e.PassesThreshold {
+				report.Summary.Passing++
+			} else {
+				report.Summary.Failing++
+			}
+			continue
+		}
+		var keptCovered []string
+		for _, acID := range e.CoveredACs {
+			if demoted[acID] {
+				e.UncoveredACs = append(e.UncoveredACs, acID)
+				continue
+			}
+			keptCovered = append(keptCovered, acID)
+		}
+		e.CoveredACs = keptCovered
+		if e.TotalACs > 0 {
+			e.CoveragePct = float64(len(e.CoveredACs)) * 100 / float64(e.TotalACs)
+		} else {
+			e.CoveragePct = 0
+		}
+		// PassesThreshold uses the per-tier threshold the entry was built with.
+		e.PassesThreshold = int(e.CoveragePct) >= e.Threshold
+		if e.PassesThreshold {
+			report.Summary.Passing++
+		} else {
+			report.Summary.Failing++
+		}
+	}
 }
 
 // extractFencedBody pulls the in-fence body out of a freshly-rendered template,

--- a/specter/internal/checker/test_annotations.go
+++ b/specter/internal/checker/test_annotations.go
@@ -75,7 +75,13 @@ func CheckTestAnnotations(testFiles map[string]string, specs []schema.SpecAST) [
 
 func scanFileAnnotations(path, content string, validACs map[string]map[string]bool) []CheckDiagnostic {
 	var diags []CheckDiagnostic
-	currentSpec := ""
+
+	// declaredSpecs accumulates every `@spec <id>` header seen in the file.
+	// Multi-`@spec` files are legitimate (cross-cutting tests that bridge
+	// two specs); each `@ac` line is validated against the *union* of
+	// declared specs, not just the most recent one (closes GH #95).
+	var declaredSpecs []string
+	specSeen := map[string]bool{}
 
 	// Multi-line string state. Annotations appearing inside a backtick template
 	// literal (TS/JS/Go raw string) or a Python triple-quoted string are
@@ -102,14 +108,18 @@ func scanFileAnnotations(path, content string, validACs map[string]map[string]bo
 		}
 
 		if m := tacSpecRefRE.FindStringSubmatch(line); len(m) > 1 {
-			currentSpec = m[1]
-			if _, known := validACs[currentSpec]; !known {
+			specID := m[1]
+			if !specSeen[specID] {
+				specSeen[specID] = true
+				declaredSpecs = append(declaredSpecs, specID)
+			}
+			if _, known := validACs[specID]; !known {
 				diags = append(diags, CheckDiagnostic{
 					Kind:     "unknown_spec_ref",
 					Severity: "error",
-					SpecID:   currentSpec,
+					SpecID:   specID,
 					Message: fmt.Sprintf("test %s:%d references @spec %q but no spec with that id exists in the workspace",
-						path, lineNum, currentSpec),
+						path, lineNum, specID),
 				})
 			}
 			continue
@@ -128,29 +138,60 @@ func scanFileAnnotations(path, content string, validACs map[string]map[string]bo
 		for _, tok := range tokens {
 			switch {
 			case tacStrictAcRE.MatchString(tok):
-				if currentSpec == "" {
-					// @ac without preceding @spec — out of scope for v0.11.
+				if len(declaredSpecs) == 0 {
+					// @ac without any preceding @spec — out of scope for v0.11.
 					continue
 				}
-				valid, ok := validACs[currentSpec]
-				if !ok {
-					// Parent spec already flagged as unknown_spec_ref.
+				// Collect the subset of declared specs that exist in the
+				// workspace. If none exist, cascade-suppress (parent specs
+				// already flagged as unknown_spec_ref).
+				var knownDeclared []string
+				for _, sid := range declaredSpecs {
+					if _, ok := validACs[sid]; ok {
+						knownDeclared = append(knownDeclared, sid)
+					}
+				}
+				if len(knownDeclared) == 0 {
 					continue
 				}
-				if !valid[tok] {
+				// Valid if the AC exists in ANY known declared spec
+				// (multi-@spec files bridge specs; an AC need only be
+				// declared by one of them).
+				inAny := false
+				for _, sid := range knownDeclared {
+					if validACs[sid][tok] {
+						inAny = true
+						break
+					}
+				}
+				if !inAny {
+					// Name the declared specs in the error so the operator
+					// can see which specs were checked.
+					specsNamed := strings.Join(knownDeclared, ", ")
+					reportSpec := knownDeclared[0]
+					if len(knownDeclared) > 1 {
+						reportSpec = "(" + specsNamed + ")"
+					}
 					diags = append(diags, CheckDiagnostic{
 						Kind:     "unknown_ac_ref",
 						Severity: "error",
-						SpecID:   currentSpec,
-						Message: fmt.Sprintf("test %s:%d references @ac %s but spec %q does not declare that AC",
-							path, lineNum, tok, currentSpec),
+						SpecID:   knownDeclared[0],
+						Message: fmt.Sprintf("test %s:%d references @ac %s but no declared spec %s declares that AC",
+							path, lineNum, tok, reportSpec),
 					})
 				}
 			case tacLooseAcRE.MatchString(tok):
+				// Use the most-recently-declared spec for context (just the
+				// label on the diagnostic; the malformed-ID check itself is
+				// independent of any spec).
+				lastSpec := ""
+				if len(declaredSpecs) > 0 {
+					lastSpec = declaredSpecs[len(declaredSpecs)-1]
+				}
 				diags = append(diags, CheckDiagnostic{
 					Kind:     "malformed_ac_id",
 					Severity: "error",
-					SpecID:   currentSpec,
+					SpecID:   lastSpec,
 					Message: fmt.Sprintf("test %s:%d has malformed AC id %q (expected ^AC-\\d{2,}$, e.g. AC-01)",
 						path, lineNum, tok),
 				})

--- a/specter/internal/checker/test_annotations_test.go
+++ b/specter/internal/checker/test_annotations_test.go
@@ -101,6 +101,88 @@ func TestCheckTestAnnotations_MalformedAcId(t *testing.T) {
 	})
 }
 
+// GH #95 — multi-@spec test files: an @ac is valid if it exists in ANY
+// declared @spec, not just the most recently declared one. Cross-cutting
+// tests legitimately bridge two specs.
+func TestCheckTestAnnotations_MultipleSpecs_UnionValidation(t *testing.T) {
+	t.Run("spec-check/multi-@spec validates against union of declared specs", func(t *testing.T) {
+		specs := []schema.SpecAST{
+			makeSpecWithACs("spec-foo", "AC-01", "AC-02"),
+			makeSpecWithACs("spec-bar", "AC-10", "AC-11"),
+		}
+		// Test file declares both specs at the top, then references ACs from each.
+		// AC-01 is in spec-foo; AC-10 is in spec-bar. Both should validate.
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec spec-foo\n// @spec spec-bar\n// @ac AC-01\n// @ac AC-10\nfunc TestFoo(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		if len(diags) != 0 {
+			t.Errorf("expected zero diagnostics for valid multi-spec references, got %d: %+v", len(diags), diags)
+		}
+	})
+
+	t.Run("spec-check/multi-@spec emits unknown_ac_ref only when AC is in no declared spec", func(t *testing.T) {
+		specs := []schema.SpecAST{
+			makeSpecWithACs("spec-foo", "AC-01"),
+			makeSpecWithACs("spec-bar", "AC-10"),
+		}
+		// AC-99 doesn't exist in either declared spec — should flag.
+		// AC-01 is in spec-foo (one of the declared specs) — should not flag.
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec spec-foo\n// @spec spec-bar\n// @ac AC-01\n// @ac AC-99\nfunc TestFoo(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		// Exactly one unknown_ac_ref for AC-99.
+		var ac99Diag int
+		for _, d := range diags {
+			if d.Kind == "unknown_ac_ref" && strings.Contains(d.Message, "AC-99") {
+				ac99Diag++
+			}
+		}
+		if ac99Diag != 1 {
+			t.Errorf("expected exactly 1 unknown_ac_ref for AC-99, got %d; all diags: %+v", ac99Diag, diags)
+		}
+		// No false positive for AC-01.
+		for _, d := range diags {
+			if d.Kind == "unknown_ac_ref" && strings.Contains(d.Message, "AC-01") {
+				t.Errorf("false positive: AC-01 exists in spec-foo (declared in same file), should not flag. Diag: %+v", d)
+			}
+		}
+	})
+
+	t.Run("spec-check/multi-@spec — one declared spec unknown does not suppress checks against the other", func(t *testing.T) {
+		specs := []schema.SpecAST{
+			makeSpecWithACs("real-spec", "AC-01"),
+		}
+		// File declares both real-spec and bogus-spec; bogus-spec is unknown
+		// but real-spec exists. AC-01 should still validate (it's in real-spec).
+		testFiles := map[string]string{
+			"foo_test.go": "// @spec real-spec\n// @spec bogus-spec\n// @ac AC-01\nfunc TestFoo(t *testing.T) {}\n",
+		}
+		diags := CheckTestAnnotations(testFiles, specs)
+
+		// Expect one unknown_spec_ref for bogus-spec.
+		var unknownSpec int
+		var unknownAc int
+		for _, d := range diags {
+			switch d.Kind {
+			case "unknown_spec_ref":
+				unknownSpec++
+			case "unknown_ac_ref":
+				unknownAc++
+			}
+		}
+		if unknownSpec != 1 {
+			t.Errorf("expected 1 unknown_spec_ref (for bogus-spec), got %d", unknownSpec)
+		}
+		if unknownAc != 0 {
+			t.Errorf("expected 0 unknown_ac_ref (AC-01 exists in real-spec), got %d; all diags: %+v", unknownAc, diags)
+		}
+	})
+}
+
 // Regression guard: annotations inside backtick template strings (TS/JS) and
 // triple-quoted Python strings are payload, not real annotations — must NOT
 // flag. Common pattern: tests for an annotation parser embed example text.


### PR DESCRIPTION
## Summary

Two bugs reported against v0.11.0; both fixed in this hotfix. Per `CONTRIBUTING.md` branch discipline, hotfixes branch off `main`, PR to `main`, merge, tag immediately.

## GH #95 — `check --test` false positive on multi-@spec test files

`scanFileAnnotations` in `internal/checker/test_annotations.go` tracked `currentSpec` as latest-wins, so a test file declaring two `@spec` headers at the top got the second header as the parent context for following `@ac` lines. An `@ac` legitimately in the FIRST declared spec was flagged `unknown_ac_ref`.

**Fix.** Track every declared `@spec` as a list. For each `@ac`, filter to the subset of declared specs that exist in the workspace, then accept the AC if it exists in ANY of those (union, not latest). Cascade rule preserved: if zero declared specs are known, suppress `@ac` checks.

**Tests.** Three new in `test_annotations_test.go`: union validation, isolated `unknown_ac_ref` when AC is in no declared spec, mixed-known/unknown declared specs.

## GH #94 — `strictness=zero-tolerance` + `approval_gate` report demotion

v0.11.0 fired exit code 3 when an AC carried `approval_gate: true` with unset `approval_date` under zero-tolerance, but the report cell continued to show the AC as PASS. The reporter expected the report to also reflect the demotion (otherwise threshold and zero-tolerance modes produce identical text reports — only the exit code differs).

**Fix.** New `demoteApprovalGateViolations` helper runs after `BuildCoverageReportStrict` when `strictness=zero-tolerance`. Walks report entries, moves violating ACs from `CoveredACs` to `UncoveredACs`, recomputes per-entry `CoveragePct` + `PassesThreshold`, recomputes `Summary.Passing` / `Summary.Failing`.

**Tests.** Updated `TestCoverageStrictness_ZeroTolerance_FailsOnApprovalGate` to assert the report shows 0% + `uncovered: AC-01` after demotion. New `TestCoverageStrictness_ThresholdMode_DoesNotDemoteApprovalGate` regression-guards threshold mode (no demotion; approval_gate remains metadata there per spec).

## Behavior change

For projects on `strictness: zero-tolerance` only:

- A spec with `approval_gate: true` AC and unset `approval_date` will now show as **NONE / uncovered** in the report (was PASS in v0.11.0).
- Exit code 3 unchanged.
- Threshold mode unchanged.

The CHANGELOG entry under v0.11.1 will note this; conceptually it's the v0.11.0 behavior catching up to what the spec contract intended.

## Verification

- `make check` ✓
- `make dogfood-strict` ✓ (15/15 specs at 100%)
- End-to-end smoke test on a fixture confirms both modes behave as expected:
  - threshold: 100% PASS exit 0
  - zero-tolerance: 0% NONE exit 3 with `error: ... 1 AC(s) carry approval_gate=true with unset approval_date`

## v0.11.1 release plan

1. Merge this PR to main
2. Open `bump/v0.11.1` (VERSION + package.json + CHANGELOG entry)
3. Tag `v0.11.1`
4. `release.yml` publishes binaries via goreleaser
5. VSIX rebuild + Marketplace publish per `RELEASING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)