### PR TITLE
fix(ci): release.yml trigger fails to fire on tag pushes (M7 landmine)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,21 @@
 name: Release
 
 on:
+  # M7: chained on the upstream Pre-Release Test Suite. Tag pushes set
+  # head_branch to the tag name (e.g., v0.12.0), so we do NOT filter
+  # branches at the trigger level — the `if:` condition below enforces
+  # the tag-only invariant via startsWith(head_branch, 'v').
   workflow_run:
     workflows: ["Pre-Release Test Suite"]
     types: [completed]
-    branches: [main]
+  # Manual fallback so the operator can re-run for an existing tag
+  # (e.g., when fixing a release-infra bug post-tag) without re-tagging.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g., v0.12.0). Defaults to the workflow ref."
+        required: false
+        type: string
 
 # `contents: write` lets goreleaser create the GitHub Release.
 # `id-token: write` lets cosign fetch a sigstore OIDC token for keyless
@@ -26,19 +37,24 @@ concurrency:
 
 jobs:
   release:
-    # Only run when the upstream Pre-Release Test Suite (Tier 1+2+3) was
-    # triggered by a tag push AND finished successfully. Otherwise a Tier 3
-    # regression-matrix failure could publish artifacts before validation
-    # completes.
+    # workflow_run path: only run when the upstream Pre-Release Test Suite
+    # (Tier 1+2+3) was triggered by a tag push AND finished successfully.
+    # Otherwise a Tier 3 regression-matrix failure could publish artifacts
+    # before validation completes.
+    # workflow_dispatch path: always run (operator opt-in for re-releases).
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     name: Build and Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run carries the upstream commit SHA;
+          # workflow_dispatch with a tag input checks that ref out;
+          # workflow_dispatch with no input falls back to github.ref.
+          ref: ${{ github.event.workflow_run.head_sha || inputs.tag || github.ref }}
           fetch-depth: 0
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5


### PR DESCRIPTION
## Summary

The `workflow_run` trigger for `release.yml` had `branches: [main]`, but tag pushes set `head_branch` to the tag name (e.g., `v0.12.0`). The filter excluded tag-triggered upstream runs, so M7 never fired. v0.12.0 was tagged successfully, the Pre-Release Test Suite went green — but no artifacts were published.

## Root cause

Same shape as the `cyclonedx-json={{ .Document }}` SBOM bug (closed in `6debbbd`): release-infrastructure that wasn't end-to-end tested before the merge gate. Both bugs make the agent re-review's recommendation #2 ("release-time pre-flight gate") even more justified — neither would have shipped if a `goreleaser release --snapshot` smoke job ran in CI.

## Changes

- **Remove `branches: [main]`** from `workflow_run`. The existing `if: startsWith(head_branch, 'v')` condition already enforces the tag-only invariant.
- **Add `workflow_dispatch`** with optional `tag` input. Lets the operator manually fire `release.yml` for an existing tag without re-tagging (recovery path for v0.12.0).

## Recovery for v0.12.0

After this PR merges:

```
gh workflow run release.yml --ref main -f tag=v0.12.0
```

Goreleaser then builds and publishes artifacts to the existing v0.12.0 GitHub Release (currently empty / not-yet-created).

## Test plan

- [x] Diff is two-block YAML edit; reviewed inline.
- [ ] CI green on this PR (the workflow file itself only fires on tags + workflow_dispatch, so this PR's CI runs the standard CI workflow only).
- [ ] After merge: manual dispatch produces the v0.12.0 release artifacts (binaries, checksums + sigs, SBOMs).

## Follow-up

A `goreleaser release --snapshot --skip=publish --clean` pre-flight smoke job in CI is the right backstop. Captured in `BACKLOG.md` "Release-time pre-flight gate" — promote to v0.12.1 cycle scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)