### PR TITLE
fix(release): cosign --new-bundle-format=false (third release-time landmine)

### DIFF
--- a/specter/.goreleaser.yml
+++ b/specter/.goreleaser.yml
@@ -41,6 +41,13 @@ checksum:
 #   cosign verify-blob --certificate-identity-regexp 'https://github.com/Hanalyx/specter/.github/workflows/release.yml' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
 #     --certificate checksums.txt.pem --signature checksums.txt.sig checksums.txt
+#
+# `--new-bundle-format=false` keeps the legacy two-file output
+# (.sig + .pem) that matches the verification example above. Recent
+# cosign versions default to bundle-format=true, which deprecates
+# `--output-signature`/`--output-certificate` and requires `--bundle
+# <path>`. Until verification tooling and docs migrate to bundle
+# format, opt out explicitly.
 signs:
   - cmd: cosign
     signature: "${artifact}.sig"
@@ -48,6 +55,7 @@ signs:
     args:
       - "sign-blob"
       - "--yes"
+      - "--new-bundle-format=false"
       - "--output-signature=${signature}"
       - "--output-certificate=${certificate}"
       - "${artifact}"


### PR DESCRIPTION
## Summary

The v0.12.0 release dispatch (after #116 fixed the trigger) succeeded through build → archive → packaging → SBOM, then failed at cosign signing:

\`\`\`
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
\`\`\`

Recent cosign versions default to \`--new-bundle-format=true\`, which deprecates \`--output-signature\`/\`--output-certificate\` (we pass both — now ignored) and requires \`--bundle <path>\` (we don't pass that — cosign tries to open \`""\` and errors).

## Fix

Add \`--new-bundle-format=false\` to keep the legacy two-file output (\`.sig\` + \`.pem\`). Matches the verification example in the config comment and the downstream docs.

## Three release-infra landmines this cycle

This is the third release-infra bug in v0.12 — same root cause every time: code that wasn't end-to-end tested before merging:

1. \`cyclonedx-json={{ .Document }}\` is not a goreleaser template field — would crash with \`missingkey=error\` (fixed in \`6debbbd\` before tag push)
2. \`release.yml\` had \`branches: [main]\` filter that excluded tag-triggered upstream runs — M7 never fired (fixed in #116)
3. cosign \`--new-bundle-format\` default flipped to true; deprecated args silently ignored, required arg never passed — current PR

All three would have been caught by \`goreleaser release --snapshot --skip=publish --clean\` in CI. Pre-flight gate is now **P1**, not P3 — promoting in BACKLOG.

## Recovery for v0.12.0

\`\`\`
gh workflow run release.yml --ref main -f tag=v0.12.0
\`\`\`

After this PR merges, the existing v0.12.0 tag will re-trigger goreleaser via \`workflow_dispatch\` and produce all artifacts.

## Test plan

- [x] Diff is one-line YAML addition; reviewed inline.
- [ ] CI green on this PR (only the standard CI workflow runs — release.yml itself only fires on tags + workflow_dispatch).
- [ ] After merge: re-run release dispatch produces all v0.12.0 artifacts (signed checksums, CycloneDX SBOMs, multi-platform binaries, deb/rpm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)