### PR TITLE
docs(explainer): v0.13 sync strict-coverage results-file requirement

### DIFF
--- a/specter/docs/explainer/v0.13-sync-strict-coverage.md
+++ b/specter/docs/explainer/v0.13-sync-strict-coverage.md
@@ -1,0 +1,158 @@
+# Why `specter sync` now needs a results file (v0.13)
+
+**Target audience:** teams upgrading from v0.12.x to v0.13.x whose `specter sync` suddenly fails on a clean checkout.
+**What changed:** in v0.13, `sync`'s coverage phase honors your `strictness` setting, and the default setting (`threshold`) requires `.specter-results.json`.
+**What to do:** pick one of the three fixes in [What you should do](#what-you-should-do). The recommended one is a one-flag change.
+
+---
+
+## The symptom
+
+You upgrade Specter from a v0.12.x release to v0.13.x. A `specter sync` that used to pass on a fresh checkout now stops at the coverage phase:
+
+```
+Specter Sync
+
+  PASS parse: 111 spec(s) parsed successfully
+  PASS resolve: 111 specs, 43 dependencies resolved
+  PASS check: 0 warning(s), 0 info
+  FAIL coverage: --strict requires .specter-results.json — run 'specter ingest' first
+
+Pipeline failed at coverage phase.
+```
+
+Exit code is `1`. Run `specter ingest` (directly, or through whatever test-results target your project uses) so that `.specter-results.json` exists, and the same `specter sync` passes again.
+
+This is not a crash and not data loss. It is `sync` enforcing a guarantee it could not enforce before v0.13. The rest of this page explains why, what surprised you, and how to get the behavior you want.
+
+---
+
+## Background: two ways to measure coverage
+
+Specter can decide whether an acceptance criterion (AC) is "covered" in two ways.
+
+- **Structural (annotation) coverage**: an AC is covered when a test carries its `// @ac AC-NN` annotation. Specter counts annotations. It does **not** ask whether the test passed. This needs no test results, so it runs on a clean checkout.
+- **Outcome (strict) coverage**: an AC is covered only when its annotated test actually **passed** in the last run. A failing, skipped, or errored test demotes the AC to uncovered. This requires a results file, `.specter-results.json`, produced by `specter ingest` from your test runner's output.
+
+Outcome coverage is the stronger guarantee. It is the reason `specter ingest` and `coverage --strict` exist (see [CI-gated coverage](v0.10-ci-gated-coverage.md)). Structural coverage only tells you "someone wrote a test for AC-07." Outcome coverage tells you "the test for AC-07 ran and passed."
+
+Which one applies is controlled by one setting: `strictness`.
+
+---
+
+## The `strictness` setting
+
+`strictness` lives in `specter.yaml` under `settings`, and can be overridden per command with `--strictness`. It has three values:
+
+| Value | Coverage mode | Needs `.specter-results.json`? |
+|---|---|---|
+| `annotation` | structural: counts annotations | No |
+| `threshold` | outcome: failing/skipped tests demote, per-tier thresholds apply | **Yes** |
+| `zero-tolerance` | outcome: strictest; any gap fails | **Yes** |
+
+**The default, when `strictness` is unset, is `threshold`.** That single fact is the source of the surprise. You do not have to write `strictness: threshold` anywhere to get the new behavior; leaving it out gives you `threshold` too.
+
+---
+
+## What actually changed between v0.12 and v0.13
+
+The `strictness` setting was introduced in v0.11, but through v0.12 the `coverage` command honored it while the `sync` command quietly ignored it. `sync`'s coverage phase always used the structural path, regardless of your `strictness` value. So on v0.12:
+
+- `specter coverage --strict` enforced outcome coverage and demanded a results file.
+- `specter sync` did **not**; it counted annotations and passed on a clean tree.
+
+That split was a gap, not a feature. `sync` is documented as the one-shot CI gate (`parse → resolve → check → coverage`). If you set `strictness: threshold` expecting your coverage to be outcome-gated, `sync` silently gave you a weaker check than `coverage` did. A pipeline could be green in `sync` while `coverage --strict` was red on the same tree.
+
+v0.13 closed the gap. `sync`'s coverage phase now routes through the same strict logic as `coverage`. Under `threshold` or `zero-tolerance` (which, again, includes the default), a missing `.specter-results.json` is a hard failure with the exact same message `coverage --strict` has always emitted:
+
+```
+--strict requires .specter-results.json — run 'specter ingest' first
+```
+
+Under `annotation` mode, a missing results file is **not** an error; the structural path runs as before.
+
+The intent: `sync` and `coverage` should mean the same thing. If your `strictness` says outcome coverage, every command that reports coverage should enforce outcome coverage, including `sync`. Letting `sync` silently fall back to annotation-counting would let a team ship a broken pipeline believing they were protected. That is the same reasoning behind `coverage --strict` refusing to run without results.
+
+---
+
+## The side effect that bit you
+
+The change is correct, but it has a real and uncomfortable consequence: **`sync` is no longer runnable on a clean checkout under the default settings.**
+
+Before v0.13, the first command in the dev loop could be `specter sync`, run before you had executed any tests. Now, under the default `threshold`, that same `sync` fails because no test run has produced `.specter-results.json` yet. The natural "did my specs and graph hold together?" check now depends on a file that only exists after you run your tests and ingest the results.
+
+This also produces a **local-vs-CI split** during a partial upgrade. If your CI is pinned to v0.12.x, the CI `sync` job still uses the old structural path and stays green, while a contributor who upgraded to v0.13.x locally sees `sync` fail on the same clean tree. The behavior didn't diverge because anyone changed your config; it diverged because the two machines run different Specter versions interpreting the same `strictness: threshold` differently.
+
+> Note: `.specter-results.json` is normally git-ignored, so a fresh checkout never has one. That is by design, but it is exactly why `sync` under a strict default fails on first run.
+
+---
+
+## What you should do
+
+Three options. They are not equivalent: the first keeps your outcome-coverage guarantee, the others trade it away or move it. Pick based on what you want `sync` to mean.
+
+### Option 1: Keep strict, produce the results file first (recommended for CI gates)
+
+If you want `sync` to keep enforcing outcome coverage, give it the results file. Run your tests, ingest them, then sync:
+
+```bash
+go test -json ./... > go-results.json
+specter ingest --go-test go-results.json   # writes .specter-results.json
+specter sync                                # coverage phase now has its inputs
+```
+
+Most projects already have a make target or CI step that does the ingest. Run it before `sync`. This keeps the strongest guarantee: a failing or skipped annotated test will correctly fail your pipeline.
+
+### Option 2: Split the fast structural gate from the strict gate (recommended for the dev loop)
+
+If you want `sync` to be the quick "do my specs hold together?" check that runs on a clean tree, **and** you still want outcome enforcement, run two separate steps. Make `sync` structural with an explicit override, and put the strict check in its own step that ingests first:
+
+```bash
+# Fast gate: runs on a clean checkout, no results file needed
+specter sync --strictness annotation
+
+# Strict gate: separate step, after tests have run and been ingested
+specter ingest --go-test go-results.json
+specter coverage --strict
+```
+
+This is the pattern Specter itself uses on its own repository: its CI runs `specter sync --strictness annotation` for the structural gate and a separate `coverage --strict` step for the outcome gate. You get both guarantees without either step blocking the other. `--strictness annotation` affects only that one invocation and leaves your `specter.yaml` default untouched.
+
+### Option 3: Change the default in `specter.yaml`
+
+You can set the project default back to structural everywhere:
+
+```yaml
+# specter.yaml
+settings:
+  strictness: annotation
+```
+
+This makes `sync` and `coverage` both run structurally with no flags. **Understand the cost:** you are turning off outcome coverage for the whole project. Failing and skipped annotated tests will count as covered again, the exact gap `coverage --strict` was built to close. Choose this only if you genuinely do not want outcome-gated coverage. If you want it anywhere, prefer Option 2.
+
+---
+
+## Choosing between them
+
+- You want `sync` to be your single CI gate and you already ingest test results → **Option 1.**
+- You want a fast `sync` on a clean tree *and* a real outcome check → **Option 2.** This is the most common right answer.
+- You do not want outcome coverage at all → **Option 3.**
+
+If your CI is still pinned to v0.12.x and you are deciding whether to move the pin to v0.13.x: the pin is safe to move once your `sync` step is one of the above. The pin failing on v0.13.x is not a regression to wait out; it is the new contract telling you the step needs a results file or an explicit `--strictness annotation`.
+
+---
+
+## Quick reference
+
+| Situation | Result under v0.13 |
+|---|---|
+| `specter sync`, no `specter.yaml` strictness, no results file | **Fails** at coverage (default is `threshold`) |
+| `specter sync`, `strictness: threshold`, no results file | **Fails** at coverage |
+| `specter sync`, `strictness: zero-tolerance`, no results file | **Fails** at coverage |
+| `specter sync --strictness annotation`, no results file | Passes (structural coverage) |
+| `specter sync`, any strict mode, results file present | Passes/fails on real test outcomes |
+| `specter sync`, `strictness: annotation`, no results file | Passes (structural coverage) |
+
+The error message `--strict requires .specter-results.json — run 'specter ingest' first` always means the same thing: a strict mode is active and the results file is missing. The fix is always one of: produce the file (`ingest`), or opt that invocation into `--strictness annotation`.
+
+For the underlying outcome-coverage machinery, see [CI-gated coverage](v0.10-ci-gated-coverage.md). For the full flag and setting reference, see [`CLI_REFERENCE.md`](../CLI_REFERENCE.md).


### PR DESCRIPTION
## What

Adds `specter/docs/explainer/v0.13-sync-strict-coverage.md`, a developer-facing explainer for the v0.13 change where `specter sync` hard-fails at the coverage phase without `.specter-results.json` on a clean checkout.

## Why

A bug report (from an external adopter on v0.13.2) framed this as a regression. Investigation showed it is **intentional, spec-mandated behavior** shipped in v0.13.0: `sync`'s coverage phase now honors `strictness`, and the default (`threshold`) requires a results file. The explainer documents the intent, the side effect, and what developers should do.

## Contents

- **Intent** — v0.13 closes the v0.12 gap where `sync` silently ignored `strictness` while `coverage --strict` enforced it.
- **Side effect** — `sync` is no longer runnable on a clean tree under defaults; local-vs-CI divergence during a partial upgrade.
- **Three remedies** — ingest before sync; split a fast `sync --strictness annotation` gate from a separate `coverage --strict` step (the pattern Specter's own CI uses); or set `settings.strictness: annotation`.
- A situation→outcome quick-reference table.

## Verification

Per the repo Docs Review Policy, two independent review agents verified every technical claim against `internal/sync`, `internal/coverage`, `internal/manifest`, `cmd/specter`, and `.github/workflows/ci.yml`. No discrepancies.

## Release impact

None. Docs-only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)