### PR TITLE
fix(sync): non-misleading missing-results message (names mode, offers --strictness annotation)

### DIFF
--- a/specter/docs/explainer/v0.13-sync-strict-coverage.md
+++ b/specter/docs/explainer/v0.13-sync-strict-coverage.md
@@ -16,12 +16,14 @@ Specter Sync
   PASS parse: 111 spec(s) parsed successfully
   PASS resolve: 111 specs, 43 dependencies resolved
   PASS check: 0 warning(s), 0 info
-  FAIL coverage: --strict requires .specter-results.json — run 'specter ingest' first
+  FAIL coverage: strictness "threshold" requires .specter-results.json — run 'specter ingest' first, or use --strictness annotation for structural coverage
 
 Pipeline failed at coverage phase.
 ```
 
-Exit code is `1`. Run `specter ingest` (directly, or through whatever test-results target your project uses) so that `.specter-results.json` exists, and the same `specter sync` passes again.
+Exit code is `1`. Run `specter ingest` (directly, or through whatever test-results target your project uses) so that `.specter-results.json` exists, and the same `specter sync` passes again — or, if you want `sync` to stay runnable on a clean tree, add `--strictness annotation` (see [What you should do](#what-you-should-do)).
+
+> Older v0.13 patches phrased this message as `--strict requires .specter-results.json — run 'specter ingest' first`. The cause and the fixes are identical; only the wording was refined to name the active strictness mode and the `--strictness annotation` alternative.
 
 This is not a crash and not data loss. It is `sync` enforcing a guarantee it could not enforce before v0.13. The rest of this page explains why, what surprised you, and how to get the behavior you want.
 
@@ -63,11 +65,13 @@ The `strictness` setting was introduced in v0.11, but through v0.12 the `coverag
 
 That split was a gap, not a feature. `sync` is documented as the one-shot CI gate (`parse → resolve → check → coverage`). If you set `strictness: threshold` expecting your coverage to be outcome-gated, `sync` silently gave you a weaker check than `coverage` did. A pipeline could be green in `sync` while `coverage --strict` was red on the same tree.
 
-v0.13 closed the gap. `sync`'s coverage phase now routes through the same strict logic as `coverage`. Under `threshold` or `zero-tolerance` (which, again, includes the default), a missing `.specter-results.json` is a hard failure with the exact same message `coverage --strict` has always emitted:
+v0.13 closed the gap. `sync`'s coverage phase now routes through the same strict logic as `coverage`. Under `threshold` or `zero-tolerance` (which, again, includes the default), a missing `.specter-results.json` is a hard failure:
 
 ```
---strict requires .specter-results.json — run 'specter ingest' first
+strictness "threshold" requires .specter-results.json — run 'specter ingest' first, or use --strictness annotation for structural coverage
 ```
+
+The message names the strictness mode that drove the failure (here, the default `threshold`) rather than a `--strict` flag you never passed, and it points at both fixes. `coverage --strict` keeps its own wording (`--strict requires .specter-results.json …`), because there you did pass `--strict`.
 
 Under `annotation` mode, a missing results file is **not** an error; the structural path runs as before.
 
@@ -82,6 +86,8 @@ The change is correct, but it has a real and uncomfortable consequence: **`sync`
 Before v0.13, the first command in the dev loop could be `specter sync`, run before you had executed any tests. Now, under the default `threshold`, that same `sync` fails because no test run has produced `.specter-results.json` yet. The natural "did my specs and graph hold together?" check now depends on a file that only exists after you run your tests and ingest the results.
 
 This also produces a **local-vs-CI split** during a partial upgrade. If your CI is pinned to v0.12.x, the CI `sync` job still uses the old structural path and stays green, while a contributor who upgraded to v0.13.x locally sees `sync` fail on the same clean tree. The behavior didn't diverge because anyone changed your config; it diverged because the two machines run different Specter versions interpreting the same `strictness: threshold` differently.
+
+The fix for the split is to stop straddling versions: **pin the same Specter version in CI and in your contributor setup**, then make every bare `specter sync` invocation (in your `Makefile` and CI) one of the options below — ingest-first or `--strictness annotation`. Bumping the pin from v0.12.x to v0.13.x is safe *after* those invocations are updated, not before.
 
 > Note: `.specter-results.json` is normally git-ignored, so a fresh checkout never has one. That is by design, but it is exactly why `sync` under a strict default fails on first run.
 
@@ -118,6 +124,8 @@ specter coverage --strict
 
 This is the pattern Specter itself uses on its own repository: its CI runs `specter sync --strictness annotation` for the structural gate and a separate `coverage --strict` step for the outcome gate. You get both guarantees without either step blocking the other. `--strictness annotation` affects only that one invocation and leaves your `specter.yaml` default untouched.
 
+The cost of this split is one extra command: your dev `sync` no longer gives one-shot outcome coverage. `sync` answers "do my specs hold together?" and the separate strict step answers "did the annotated tests pass?" — two runs instead of one. For most loops that is a fair trade for a `sync` that works on a clean tree; if you would rather keep a single command, use Option 1.
+
 ### Option 3: Change the default in `specter.yaml`
 
 You can set the project default back to structural everywhere:
@@ -153,6 +161,6 @@ If your CI is still pinned to v0.12.x and you are deciding whether to move the p
 | `specter sync`, any strict mode, results file present | Passes/fails on real test outcomes |
 | `specter sync`, `strictness: annotation`, no results file | Passes (structural coverage) |
 
-The error message `--strict requires .specter-results.json — run 'specter ingest' first` always means the same thing: a strict mode is active and the results file is missing. The fix is always one of: produce the file (`ingest`), or opt that invocation into `--strictness annotation`.
+The error message `strictness "<mode>" requires .specter-results.json — run 'specter ingest' first, or use --strictness annotation for structural coverage` always means the same thing: a strict mode is active and the results file is missing. The fix is always one of: produce the file (`ingest`), or opt that invocation into `--strictness annotation`. (Older v0.13 patches phrased it as `--strict requires .specter-results.json …`.)
 
 For the underlying outcome-coverage machinery, see [CI-gated coverage](v0.10-ci-gated-coverage.md). For the full flag and setting reference, see [`CLI_REFERENCE.md`](../CLI_REFERENCE.md).

--- a/specter/internal/sync/sync.go
+++ b/specter/internal/sync/sync.go
@@ -6,6 +6,7 @@
 package sync
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Hanalyx/specter/internal/checker"
@@ -202,8 +203,9 @@ func RunSync(input SyncInput) *SyncResult {
 	}
 
 	// spec-sync C-06/C-07: route the coverage phase through
-	// BuildCoverageReportStrict under any strict mode. Annotation
-	// mode (and the default) preserves the legacy
+	// BuildCoverageReportStrict under any strict mode (threshold or
+	// zero-tolerance — which includes the manifest default threshold,
+	// per spec-manifest C-24). Annotation mode preserves the legacy
 	// BuildCoverageReportWithResults path.
 	effectiveStrictness := input.Strictness
 	if effectiveStrictness == "" && input.CheckOpts != nil && input.CheckOpts.Strict {
@@ -214,15 +216,24 @@ func RunSync(input SyncInput) *SyncResult {
 
 	var coverageReport *coverage.CoverageReport
 	if useStrictPath {
-		// C-08: missing .specter-results.json under strict mode fails
-		// with ErrMissingResults — the same error message coverage
-		// --strict emits. Surface it as a coverage phase failure.
 		report, strictErr := coverage.BuildCoverageReportStrict(specs, allAnnotations, thresholds, input.Results, true, nil)
 		if strictErr != nil {
+			// C-08: missing .specter-results.json under strict mode
+			// fails the coverage phase. Surface a sync-specific message
+			// that names the active strictness mode and offers both
+			// remedies. Unlike `coverage --strict`, sync's strict mode
+			// usually comes from the manifest default rather than an
+			// explicit flag, so the message MUST NOT attribute the
+			// requirement to `--strict` (coverage.ErrMissingResults's
+			// wording, correct only where the operator passed --strict).
+			msg := strictErr.Error()
+			if errors.Is(strictErr, coverage.ErrMissingResults) {
+				msg = fmt.Sprintf("strictness %q requires .specter-results.json — run 'specter ingest' first, or use --strictness annotation for structural coverage", effectiveStrictness)
+			}
 			result.Phases = append(result.Phases, PhaseResult{
 				Phase:   "coverage",
 				Passed:  false,
-				Message: strictErr.Error(),
+				Message: msg,
 			})
 			result.StoppedAt = "coverage"
 			return result

--- a/specter/internal/sync/sync_test.go
+++ b/specter/internal/sync/sync_test.go
@@ -330,14 +330,15 @@ func TestSyncStrictness_CoverageMatchesStrictPath(t *testing.T) {
 	})
 }
 
-// AC-10: missing .specter-results.json under strict mode fails with
-// the SAME error message as coverage --strict (ErrMissingResults).
-// The test asserts the coverage phase fails and the message mentions
-// `specter ingest`.
+// AC-10: missing .specter-results.json under strict mode fails the
+// coverage phase with a message that names the active strictness mode,
+// references `specter ingest`, and offers `--strictness annotation` as
+// the alternative remedy — and does NOT attribute the requirement to a
+// `--strict` flag the sync operator never passed.
 //
 // @ac AC-10
 func TestSyncStrictness_MissingResultsUnderStrict(t *testing.T) {
-	t.Run("spec-sync/AC-10 sync --strictness zero-tolerance with missing results fails with ingest hint", func(t *testing.T) {
+	t.Run("spec-sync/AC-10 sync --strictness zero-tolerance with missing results fails with mode-named, non-misleading hint", func(t *testing.T) {
 		result := RunSync(SyncInput{
 			SpecFiles:  []FileContent{{Path: "a.yaml", Content: validSpecYAML("a", 2, "")}},
 			TestFiles:  []FileContent{{Path: "a.test.ts", Content: testFileContent("a", "AC-01")}},
@@ -361,10 +362,22 @@ func TestSyncStrictness_MissingResultsUnderStrict(t *testing.T) {
 		if coveragePhase.Passed {
 			t.Error("expected coverage phase to fail under strict mode with missing Results")
 		}
-		// AC-10 requires the message reference specter ingest. The
-		// exact wording comes from coverage.ErrMissingResults.
-		if !strings.Contains(coveragePhase.Message, "specter ingest") {
-			t.Errorf("expected coverage phase message to mention `specter ingest`, got: %q", coveragePhase.Message)
+		msg := coveragePhase.Message
+		// (a) names the active strictness mode.
+		if !strings.Contains(msg, "zero-tolerance") {
+			t.Errorf("expected message to name the active strictness mode %q, got: %q", "zero-tolerance", msg)
+		}
+		// (b) references specter ingest as one remedy.
+		if !strings.Contains(msg, "specter ingest") {
+			t.Errorf("expected message to mention `specter ingest`, got: %q", msg)
+		}
+		// (c) offers --strictness annotation as the alternative remedy.
+		if !strings.Contains(msg, "--strictness annotation") {
+			t.Errorf("expected message to offer `--strictness annotation`, got: %q", msg)
+		}
+		// MUST NOT misattribute the requirement to a --strict flag.
+		if strings.Contains(msg, "--strict requires") {
+			t.Errorf("message must not attribute the requirement to `--strict` in sync, got: %q", msg)
 		}
 	})
 }

--- a/specter/specs/spec-sync.spec.yaml
+++ b/specter/specs/spec-sync.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-sync
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -31,7 +31,7 @@ spec:
         - "Summary report of all phases"
         - "Strictness routing: `sync --strictness <level>` matches `coverage --strictness <level>` semantics for the coverage phase; `sync --strict` is an alias for `--strictness zero-tolerance` retained for backward compatibility"
         - "Sync's coverage phase delegates to the strict coverage path (`BuildCoverageReportStrict`), not the weaker `BuildCoverageReportWithResults`; ACs whose annotated tests did not pass (per `.specter-results.json`) demote, matching `coverage --strict` exactly"
-        - "Missing `.specter-results.json` under strict modes (`threshold` or `zero-tolerance`) fails with the same error message as `coverage --strict`"
+        - "Missing `.specter-results.json` under strict modes (`threshold` or `zero-tolerance`) fails the coverage phase with a message naming the active strictness mode and the two remedies — run `specter ingest`, or use `--strictness annotation` for structural coverage — without attributing the requirement to a `--strict` flag the operator may not have passed"
       excludes:
         - "Git diff analysis (future: only check changed specs)"
         - "PR comment generation"
@@ -64,7 +64,7 @@ spec:
       enforcement: error
 
     - id: C-06
-      description: "MUST support `--strictness <level>` flag accepting `annotation` | `threshold` | `zero-tolerance`. Semantics match `coverage --strictness` exactly: `annotation` counts source-comment @ac as covered (no test-result enforcement); `threshold` requires annotated ACs to have passing test results AND tier thresholds met; `zero-tolerance` requires every annotated AC's test to pass regardless of tier. The legacy `--strict` boolean flag remains as an alias for `--strictness zero-tolerance` for backward compatibility. When neither flag is provided, the strictness comes from `settings.strictness` in the manifest (default: `annotation`). When both `--strict` and `--strictness` are passed, `--strictness` wins."
+      description: "MUST support `--strictness <level>` flag accepting `annotation` | `threshold` | `zero-tolerance`. Semantics match `coverage --strictness` exactly: `annotation` counts source-comment @ac as covered (no test-result enforcement); `threshold` requires annotated ACs to have passing test results AND tier thresholds met; `zero-tolerance` requires every annotated AC's test to pass regardless of tier. The legacy `--strict` boolean flag remains as an alias for `--strictness zero-tolerance` for backward compatibility. When neither flag is provided, the strictness comes from `settings.strictness` in the manifest (default: `threshold`, per spec-manifest C-24). When both `--strict` and `--strictness` are passed, `--strictness` wins."
       type: technical
       enforcement: error
 
@@ -74,7 +74,7 @@ spec:
       enforcement: error
 
     - id: C-08
-      description: "Under any strict mode, if `.specter-results.json` is missing, `sync`'s coverage phase MUST fail with the SAME error message as `coverage --strict` emits in the same condition. The message MUST direct the operator to run `specter ingest` first. Under `annotation` mode (or when no strict flag is set), missing results is NOT an error — the manifest-level annotation-counting path proceeds."
+      description: "Under any strict mode, if `.specter-results.json` is missing, `sync`'s coverage phase MUST fail with a message that (a) names the active strictness mode (`threshold` or `zero-tolerance`) and (b) directs the operator to EITHER run `specter ingest` first OR use `--strictness annotation` for structural coverage. The message MUST NOT attribute the requirement to a `--strict` flag: in `sync` the strictness usually comes from the manifest default rather than an explicit flag, so the `coverage --strict` wording (`--strict requires .specter-results.json`) — correct for `coverage --strict`, where the operator did pass `--strict` — misdirects the fix here. Under `annotation` mode (or when no strict flag is set), missing results is NOT an error — the manifest-level annotation-counting path proceeds."
       type: technical
       enforcement: error
 
@@ -165,14 +165,16 @@ spec:
       priority: critical
 
     - id: AC-10
-      description: "Under `--strictness threshold` or `--strictness zero-tolerance`, when `.specter-results.json` is missing, sync's coverage phase fails with the SAME error message as `coverage --strict` emits. The message references `specter ingest` as the remediation."
+      description: "Under `--strictness threshold` or `--strictness zero-tolerance`, when `.specter-results.json` is missing, sync's coverage phase fails with a message that (a) names the active strictness mode, (b) references `specter ingest` as one remedy, and (c) offers `--strictness annotation` as the alternative remedy. The message MUST NOT claim `--strict` was required, since the strictness may come from the manifest default."
       inputs:
         workspace: "valid specs, annotated tests, NO .specter-results.json file"
-        commands_compared: ["specter coverage --strict", "specter sync --strict"]
+        command: "specter sync --strictness zero-tolerance"
       expected_output:
         exit_code_nonzero: true
-        error_message_identical: true
+        message_names_strictness_mode: true
         message_mentions_specter_ingest: true
+        message_offers_strictness_annotation: true
+        message_does_not_reference_strict_flag: true
       references_constraints: ["C-08"]
       priority: critical
 
@@ -187,6 +189,11 @@ spec:
       priority: high
 
   changelog:
+    - version: "1.3.0"
+      date: "2026-06-10"
+      author: "specter-team"
+      type: minor
+      description: "Amend C-08/AC-10: sync's missing-.specter-results.json message now names the active strictness mode and offers `--strictness annotation` as an alternative remedy, instead of reusing coverage's `--strict requires ...` wording verbatim. The old message attributed the requirement to a `--strict` flag the operator never passed — under sync the strictness usually comes from the manifest default `threshold` — which misdirected the fix. Also corrects C-06's stale parenthetical: the manifest default is `threshold` (per spec-manifest C-24), not `annotation`. Driven by external adopter (Kensa) feedback on the v0.13 sync strict-coverage explainer. Behavior of `coverage --strict` is unchanged."
     - version: "1.2.0"
       date: "2026-05-15"
       author: "specter-team"


### PR DESCRIPTION
## What

When `specter sync`'s coverage phase fails on a missing `.specter-results.json` under a strict mode, it now emits:

```
strictness "threshold" requires .specter-results.json — run 'specter ingest' first, or use --strictness annotation for structural coverage
```

instead of reusing `coverage`'s `--strict requires .specter-results.json …` wording.

## Why

External adopter (Kensa) feedback on the v0.13 sync strict-coverage explainer: the old message names a `--strict` flag the sync operator usually never passed — under `sync` the strict mode comes from the manifest **default** (`threshold`), not an explicit flag. So the message pointed at the wrong lever. This change names the actual driver (the strictness mode) and gives both remedies (`ingest`, or `--strictness annotation`).

Decision recorded with the maintainer: **fix the message (this PR); keep the `threshold` default** (document-only, already shipped in the explainer).

## SDD cycle (three commits + doc)

1. `fix(sync)` — amend spec **C-08 / AC-10** (message contract) and correct **C-06**'s stale "(default: `annotation`)" → `threshold` per spec-manifest C-24. spec-sync **1.2.0 → 1.3.0**.
2. `test(sync)` — strengthen the AC-10 test to assert the message names the mode, mentions `specter ingest`, offers `--strictness annotation`, and does **not** contain `--strict requires`. (Fails against pre-impl code.)
3. `fix(sync)` — implementation: rewrite the message only when `errors.Is(err, coverage.ErrMissingResults)`, so **`coverage --strict`'s wording is untouched**.
4. `docs(explainer)` — update the explainer message in three places, stop claiming the two messages are identical, and fold in the rest of Kensa's review (pin-consistency remedy for the CI/local split; Option 2 workflow cost).

## Scope guard

- `coverage --strict` behavior and message: **unchanged** (verified `errors.Is`-gated).
- Default strictness: **unchanged** (`threshold`).

## Verification

- `go build ./...`, `go test ./...` (14 pkgs, 0 fail), `go vet`, `gofmt`, and `make dogfood` all green. (`make check`'s lint step fails locally on a golangci-lint v1/v2 mismatch — environment, not this change; CI runs the correct version.)
- Per the Docs Review Policy, two independent agents verified the doc + the spec/test/impl consistency against the branch code. No discrepancies.

## Release note

Behavior change to a user-facing message → needs a `CHANGELOG.md` entry and a version at the next release cut (no active `release/*` branch right now). Patch-worthy DX fix; could also fold into v0.14. Not bumped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)