### PR TITLE
fix(resolver): report all cycles including shared-edge overlaps (spec-resolve C-03)

### DIFF
--- a/specter/internal/resolver/resolve.go
+++ b/specter/internal/resolver/resolve.go
@@ -7,6 +7,8 @@ package resolver
 
 import (
 	"fmt"
+	"slices"
+	"sort"
 
 	"github.com/Hanalyx/specter/internal/schema"
 	"github.com/Masterminds/semver/v3"
@@ -174,71 +176,207 @@ func ResolveSpecs(inputs []SpecInput) *SpecGraph {
 	return graph
 }
 
-// findCycles uses DFS to find all cycles in the graph.
+// maxCycles caps simple-cycle enumeration (C-03). Dense strongly connected
+// components can contain exponentially many simple cycles; spec graphs are
+// small in practice, but the cap bounds pathological inputs. The cap is
+// deterministic because enumeration order is deterministic.
+const maxCycles = 1000
+
+// findCycles enumerates ALL simple cycles in the graph (C-03), including
+// overlapping cycles that share an edge or a node, and disjoint cycles
+// (AC-15). It decomposes the graph into strongly connected components
+// (Tarjan) and enumerates simple cycles per SCC (Johnson's algorithm).
+//
+// Output is deterministic regardless of map iteration order: vertices are
+// processed in lexicographic order, so each cycle starts at its
+// lexicographically smallest node, and the resulting list is sorted
+// lexicographically. Each returned cycle lists its nodes once, without
+// repeating the start node; the caller closes the loop.
 func findCycles(nodes map[string]*SpecNode, adjacency map[string][]string) [][]string {
-	const (
-		white = 0 // unvisited
-		grey  = 1 // in current path
-		black = 2 // fully processed
-	)
+	// Index nodes in sorted order so vertex i < vertex j implies
+	// ids[i] < ids[j] lexicographically.
+	ids := make([]string, 0, len(nodes))
+	for id := range nodes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	index := make(map[string]int, len(ids))
+	for i, id := range ids {
+		index[id] = i
+	}
 
-	color := make(map[string]int)
-	parent := make(map[string]string)
+	n := len(ids)
+	adj := make([][]int, n)
 	var cycles [][]string
-	cycleNodes := make(map[string]bool) // track which nodes are already in a reported cycle
-
-	var dfs func(node string)
-	dfs = func(node string) {
-		color[node] = grey
-		for _, neighbor := range adjacency[node] {
-			if _, exists := nodes[neighbor]; !exists {
-				continue // skip dangling refs
+	for i, id := range ids {
+		seen := make(map[int]bool)
+		for _, neighbor := range adjacency[id] {
+			j, exists := index[neighbor]
+			if !exists || seen[j] {
+				continue // dangling ref or duplicate edge
 			}
-			if color[neighbor] == grey {
-				// Found a cycle — reconstruct path
-				cycle := []string{neighbor}
-				curr := node
-				for curr != neighbor {
-					cycle = append([]string{curr}, cycle...)
-					curr = parent[curr]
-				}
-				// Only add if we haven't reported this cycle already
-				key := cycleKey(cycle)
-				if !cycleNodes[key] {
-					cycleNodes[key] = true
+			seen[j] = true
+			if j == i {
+				// Self-loop: a one-node cycle. Johnson's algorithm
+				// below enumerates cycles of length >= 2 only.
+				cycles = append(cycles, []string{id})
+				continue
+			}
+			adj[i] = append(adj[i], j)
+		}
+		sort.Ints(adj[i])
+	}
+
+	// Johnson's algorithm state.
+	blocked := make([]bool, n)
+	blockedBy := make([]map[int]bool, n)
+	stack := make([]int, 0, n)
+
+	var unblock func(v int)
+	unblock = func(v int) {
+		blocked[v] = false
+		for w := range blockedBy[v] {
+			delete(blockedBy[v], w)
+			if blocked[w] {
+				unblock(w)
+			}
+		}
+	}
+
+	var circuit func(v, start int, scc map[int]bool) bool
+	circuit = func(v, start int, scc map[int]bool) bool {
+		found := false
+		stack = append(stack, v)
+		blocked[v] = true
+		for _, w := range adj[v] {
+			if !scc[w] {
+				continue
+			}
+			if w == start {
+				if len(cycles) < maxCycles {
+					cycle := make([]string, len(stack))
+					for i, u := range stack {
+						cycle[i] = ids[u]
+					}
 					cycles = append(cycles, cycle)
 				}
-			} else if color[neighbor] == white {
-				parent[neighbor] = node
-				dfs(neighbor)
+				found = true
+			} else if !blocked[w] {
+				if circuit(w, start, scc) {
+					found = true
+				}
 			}
 		}
-		color[node] = black
-	}
-
-	for id := range nodes {
-		if color[id] == white {
-			dfs(id)
+		if found {
+			unblock(v)
+		} else {
+			for _, w := range adj[v] {
+				if scc[w] {
+					blockedBy[w][v] = true
+				}
+			}
 		}
+		stack = stack[:len(stack)-1]
+		return found
 	}
 
+	for s := 0; s < n && len(cycles) < maxCycles; {
+		// Find the non-trivial SCC containing the smallest vertex in
+		// the subgraph induced by vertices >= s.
+		least := -1
+		var leastSCC map[int]bool
+		for _, scc := range tarjanSCC(adj, s, n) {
+			if len(scc) < 2 {
+				continue
+			}
+			m := scc[0]
+			for _, v := range scc[1:] {
+				if v < m {
+					m = v
+				}
+			}
+			if least == -1 || m < least {
+				least = m
+				leastSCC = make(map[int]bool, len(scc))
+				for _, v := range scc {
+					leastSCC[v] = true
+				}
+			}
+		}
+		if least == -1 {
+			break
+		}
+		s = least
+		for v := range leastSCC {
+			blocked[v] = false
+			blockedBy[v] = make(map[int]bool)
+		}
+		circuit(s, s, leastSCC)
+		s++
+	}
+
+	// Canonical order: cycles already start at their smallest node (the
+	// Johnson start vertex is the minimum of its SCC's remaining
+	// subgraph); sort the list for stable diagnostics.
+	slices.SortFunc(cycles, slices.Compare)
 	return cycles
 }
 
-func cycleKey(cycle []string) string {
-	// Normalize cycle to start with the smallest element
-	min := 0
-	for i, v := range cycle {
-		if v < cycle[min] {
-			min = i
+// tarjanSCC returns the strongly connected components of the subgraph
+// induced by vertices in [minV, n), ignoring edges to vertices below minV.
+func tarjanSCC(adj [][]int, minV, n int) [][]int {
+	const unvisited = -1
+	order := make([]int, n)
+	low := make([]int, n)
+	onStack := make([]bool, n)
+	for i := range order {
+		order[i] = unvisited
+	}
+	var stack []int
+	counter := 0
+	var sccs [][]int
+
+	var strongConnect func(v int)
+	strongConnect = func(v int) {
+		order[v] = counter
+		low[v] = counter
+		counter++
+		stack = append(stack, v)
+		onStack[v] = true
+		for _, w := range adj[v] {
+			if w < minV {
+				continue
+			}
+			if order[w] == unvisited {
+				strongConnect(w)
+				if low[w] < low[v] {
+					low[v] = low[w]
+				}
+			} else if onStack[w] && order[w] < low[v] {
+				low[v] = order[w]
+			}
+		}
+		if low[v] == order[v] {
+			var scc []int
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[w] = false
+				scc = append(scc, w)
+				if w == v {
+					break
+				}
+			}
+			sccs = append(sccs, scc)
 		}
 	}
-	rotated := append(cycle[min:], cycle[:min]...)
-	result := ""
-	for _, v := range rotated {
-		result += v + ","
+
+	for v := minV; v < n; v++ {
+		if order[v] == unvisited {
+			strongConnect(v)
+		}
 	}
-	return result
+	return sccs
 }
 
 // topologicalSort returns nodes in dependency order (dependencies first).

--- a/specter/internal/resolver/resolve_test.go
+++ b/specter/internal/resolver/resolve_test.go
@@ -2,6 +2,8 @@
 package resolver
 
 import (
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Hanalyx/specter/internal/schema"
@@ -228,6 +230,99 @@ func TestDanglingReferenceIncludesSuggestion(t *testing.T) {
 		}
 		if dr.SuggestedFixPath == "" {
 			t.Error("expected SuggestedFixPath to be set")
+		}
+	})
+}
+
+// circularPaths collects every circular_dependency diagnostic's cycle path
+// rendered as "a -> b -> a", in diagnostic order.
+func circularPaths(g *SpecGraph) []string {
+	var paths []string
+	for _, d := range g.Diagnostics {
+		if d.Kind == "circular_dependency" {
+			paths = append(paths, strings.Join(d.CyclePath, " -> "))
+		}
+	}
+	return paths
+}
+
+// thetaGraphInputs builds the AC-15 theta graph: a -> x -> b -> a and
+// a -> y -> b -> a, sharing edge b -> a.
+func thetaGraphInputs() []SpecInput {
+	return []SpecInput{
+		{Spec: makeSpec("a", withDeps(dep("x"), dep("y"))), File: "a.spec.yaml"},
+		{Spec: makeSpec("x", withDeps(dep("b"))), File: "x.spec.yaml"},
+		{Spec: makeSpec("y", withDeps(dep("b"))), File: "y.spec.yaml"},
+		{Spec: makeSpec("b", withDeps(dep("a"))), File: "b.spec.yaml"},
+	}
+}
+
+// @ac AC-15
+func TestThetaGraphReportsBothSharedEdgeCycles(t *testing.T) {
+	t.Run("spec-resolve/AC-15 theta graph reports both shared-edge cycles", func(t *testing.T) {
+		g := ResolveSpecs(thetaGraphInputs())
+
+		want := []string{"a -> x -> b -> a", "a -> y -> b -> a"}
+		got := circularPaths(g)
+		if !slices.Equal(got, want) {
+			t.Errorf("expected exactly cycles %v, got %v", want, got)
+		}
+		if len(g.TopologicalOrder) != 0 {
+			t.Error("expected empty topo order when cycles exist")
+		}
+	})
+}
+
+// @ac AC-15
+func TestSharedNodeCyclesBothReported(t *testing.T) {
+	t.Run("spec-resolve/AC-15 two cycles sharing a node are both reported", func(t *testing.T) {
+		// a <-> b and b <-> c share node b.
+		g := ResolveSpecs([]SpecInput{
+			{Spec: makeSpec("a", withDeps(dep("b"))), File: "a.spec.yaml"},
+			{Spec: makeSpec("b", withDeps(dep("a"), dep("c"))), File: "b.spec.yaml"},
+			{Spec: makeSpec("c", withDeps(dep("b"))), File: "c.spec.yaml"},
+		})
+
+		want := []string{"a -> b -> a", "b -> c -> b"}
+		got := circularPaths(g)
+		if !slices.Equal(got, want) {
+			t.Errorf("expected exactly cycles %v, got %v", want, got)
+		}
+	})
+}
+
+// @ac AC-15
+func TestDisjointCyclesBothReported(t *testing.T) {
+	t.Run("spec-resolve/AC-15 two disjoint cycles are both reported", func(t *testing.T) {
+		// a <-> b and c <-> d share nothing.
+		g := ResolveSpecs([]SpecInput{
+			{Spec: makeSpec("a", withDeps(dep("b"))), File: "a.spec.yaml"},
+			{Spec: makeSpec("b", withDeps(dep("a"))), File: "b.spec.yaml"},
+			{Spec: makeSpec("c", withDeps(dep("d"))), File: "c.spec.yaml"},
+			{Spec: makeSpec("d", withDeps(dep("c"))), File: "d.spec.yaml"},
+		})
+
+		want := []string{"a -> b -> a", "c -> d -> c"}
+		got := circularPaths(g)
+		if !slices.Equal(got, want) {
+			t.Errorf("expected exactly cycles %v, got %v", want, got)
+		}
+	})
+}
+
+// @ac AC-15
+func TestCycleReportingIsDeterministic(t *testing.T) {
+	t.Run("spec-resolve/AC-15 cycle reporting is deterministic across runs", func(t *testing.T) {
+		// Map iteration order varies per run; the diagnostic set must not.
+		first := circularPaths(ResolveSpecs(thetaGraphInputs()))
+		if len(first) != 2 {
+			t.Fatalf("expected 2 cycles in theta graph, got %v", first)
+		}
+		for i := 0; i < 50; i++ {
+			got := circularPaths(ResolveSpecs(thetaGraphInputs()))
+			if !slices.Equal(got, first) {
+				t.Fatalf("iteration %d: cycle set %v differs from first run %v", i, got, first)
+			}
 		}
 	})
 }

--- a/specter/specs/spec-resolve.spec.yaml
+++ b/specter/specs/spec-resolve.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-resolve
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 1
 
@@ -57,7 +57,7 @@ spec:
       enforcement: warning
 
     - id: C-03
-      description: "MUST detect ALL circular dependencies, not just the first one found"
+      description: "MUST detect ALL circular dependencies, not just the first one found — including overlapping cycles that share an edge or a node, and disjoint cycles. Reporting MUST be deterministic regardless of input order or map iteration order: each cycle path is rotated to start at its lexicographically smallest spec ID, and the set of cycles is sorted lexicographically. Simple-cycle enumeration is capped at 1000 cycles per resolve (dense SCCs can contain exponentially many simple cycles); the cap is deterministic because enumeration order is deterministic."
       type: technical
       enforcement: error
 
@@ -283,7 +283,24 @@ spec:
       references_constraints: ["C-13"]
       priority: high
 
+    - id: AC-15
+      description: "Two cycles sharing an edge (theta graph: a->x->b->a and a->y->b->a share edge b->a) are BOTH reported as separate circular_dependency diagnostics, deterministically — independent of map iteration order. Cycle paths are canonical: each path starts (and ends) at the lexicographically smallest spec ID in its cycle, and the set of cycles is sorted lexicographically. The same guarantee applies to cycles sharing a node and to disjoint cycles."
+      inputs:
+        specs: ["a.spec.yaml (depends on x, y)", "x.spec.yaml (depends on b)", "y.spec.yaml (depends on b)", "b.spec.yaml (depends on a)"]
+      expected_output:
+        type: "Diagnostic[]"
+        kind: "circular_dependency"
+        cycle_paths: [["a", "x", "b", "a"], ["a", "y", "b", "a"]]
+        deterministic_across_runs: true
+      references_constraints: ["C-03", "C-04"]
+      priority: critical
+
   changelog:
+    - version: "1.3.0"
+      date: "2026-06-11"
+      author: "specter-team"
+      type: minor
+      description: "Strengthen C-03 and add AC-15 — overlapping cycles. The previous white/grey/black DFS silently skipped edges into fully-processed (black) nodes, so two cycles sharing an edge (theta graph) dropped one cycle depending on map iteration order. C-03 now requires ALL simple cycles including edge-sharing, node-sharing, and disjoint overlaps, with deterministic canonical output (cycles rotated to start at lexicographically smallest spec ID, sorted lexicographically) and a documented enumeration cap of 1000 simple cycles per resolve."
     - version: "1.2.0"
       date: "2026-05-15"
       author: "specter-team"


### PR DESCRIPTION
## Summary

Fixes finding 5 of the 2026-06-11 six-finding review: the resolver's white/grey/black DFS silently skipped edges into fully-processed (black) nodes, so two cycles sharing an **edge** (theta graph: `a→x→b→a` and `a→y→b→a`) dropped one cycle in ~60% of runs depending on map iteration order — despite C-03 requiring ALL circular dependencies. (Cycles sharing only a node, and disjoint cycles, were unaffected.) No false PASS was possible — at least one cycle always reported and the topological order emptied — so the cost was whack-a-mole UX: fix the reported cycle, re-run, a previously hidden one appears.

## Commits (SDD three-commit cycle)

1. **docs(specs)** — spec-resolve 1.2.0 → 1.3.0: C-03 strengthened (shared-edge/shared-node/disjoint cycles, deterministic canonical output, documented 1000-cycle enumeration cap); new AC-15 (priority critical).
2. **test(resolver)** — four tests asserting *exact* cycle sets (theta, shared-node, disjoint) and determinism across 50 runs. Verified failing against the old DFS (theta graph returned 1 cycle instead of 2).
3. **fix(resolver)** — `findCycles` rewritten: Tarjan SCC decomposition + Johnson's simple-cycle enumeration. Vertices indexed in sorted order so every cycle starts at its lexicographically smallest spec ID; the cycle list is sorted for stable diagnostics. Diagnostic kind, `CyclePath` closed-loop shape, and message format unchanged. Pure function, no I/O.

## Notes

- Enumeration is capped at 1000 simple cycles per resolve (dense SCCs are exponential); the cap is deterministic and documented in C-03.
- Existing cycle tests previously asserted only "at least one diagnostic"; the new tests pin exact sets.

## Verification

`gofmt`, `go vet ./...`, `go test ./...` (all packages), and `make dogfood` (spec-resolve 15/15 ACs, 100%) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)