### PR TITLE
fix(sync): apply MaxTestFileBytes cap to discovered test files

### DIFF
--- a/specter/cmd/specter/main.go
+++ b/specter/cmd/specter/main.go
@@ -1242,7 +1242,26 @@ func syncCmd() *cobra.Command {
 			}
 			var testContents []specsync.FileContent
 			for _, f := range testFiles {
-				data, _ := os.ReadFile(f)
+				// spec-sync C-10: same per-file size cap as `check --test`
+				// (spec-check C-12). Sync buffers every test file for the
+				// check and coverage phases; an unbounded read is the same
+				// OOM surface the v0.13 H5 fix closed for check, coverage,
+				// and explain. os.Stat first so an oversized file is never
+				// buffered. Skip is per-file (not fatal); emit a stderr
+				// warning naming the file.
+				if info, statErr := os.Stat(f); statErr == nil && info.Size() > checker.MaxTestFileBytes {
+					fmt.Fprintf(os.Stderr,
+						"warn: test file %s exceeds %d byte limit (got %d bytes); skipping\n",
+						f, checker.MaxTestFileBytes, info.Size())
+					continue
+				}
+				data, err := os.ReadFile(f)
+				if err != nil {
+					// spec-sync C-10: unreadable test file — warn and skip
+					// rather than silently appending empty content.
+					fmt.Fprintf(os.Stderr, "warn: could not read test file %s: %v; skipping\n", f, err)
+					continue
+				}
 				testContents = append(testContents, specsync.FileContent{Path: f, Content: string(data)})
 			}
 
@@ -1289,7 +1308,7 @@ func syncCmd() *cobra.Command {
 				CheckTestAnnotations: strict || m.Settings.Strict, // spec-check C-09/AC-12: sync --strict (or settings.strict) routes through
 			})
 
-			// spec-sync C-09: zero-tolerance violations exit with the same
+			// spec-sync C-10: zero-tolerance violations exit with the same
 			// distinct codes `coverage` uses (2 = non-passed annotated AC,
 			// 3 = approval_gate violation), in text and --json modes alike.
 			// Called after output is emitted so machine consumers see the

--- a/specter/cmd/specter/sync_test.go
+++ b/specter/cmd/specter/sync_test.go
@@ -1,0 +1,108 @@
+// sync_test.go -- CLI integration tests for `specter sync` test-file handling.
+//
+// @spec spec-sync
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// spec-sync C-10 / AC-14 — parity fix for the v0.13 H5 hardening.
+//
+// A test file larger than MaxTestFileBytes (4 MiB) discovered by
+// `sync` MUST be skipped — the file is NOT read into memory, a stderr
+// warning names the file, and the run continues with remaining files.
+// The skip alone MUST NOT fail the pipeline. Closes the gap left by
+// commit 8b76961, which stat-guarded check, coverage, and explain but
+// never touched sync's read loop: a large test artifact could OOM the
+// primary CI command.
+//
+// @ac AC-14
+func TestSync_OversizedTestFileSkipped(t *testing.T) {
+	t.Run("spec-sync/AC-14 sync skips test file larger than MaxTestFileBytes", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSpec(t, dir, "x.spec.yaml", minimalValidSpec("x-spec", 3, "AC-01"))
+
+		// 4 MiB + 1 byte — one past the cap. Content is arbitrary
+		// non-Go bytes; the stat guard must fire before any read.
+		const cap = 4 << 20
+		body := bytes.Repeat([]byte("x"), cap+1)
+		oversized := filepath.Join(dir, "huge_test.go")
+		if err := os.WriteFile(oversized, body, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// A small, valid test file annotating x-spec/AC-01. This file
+		// MUST still be scanned (skip applies per-file, not whole run),
+		// so the coverage phase passes from this file alone.
+		small := "package foo\n\nimport \"testing\"\n\n// @spec x-spec\n// @ac AC-01\nfunc TestSmall(t *testing.T) {\n}\n"
+		if err := os.WriteFile(filepath.Join(dir, "small_test.go"), []byte(small), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// --strictness annotation: coverage counts source annotations,
+		// no .specter-results.json required (spec-sync C-08/AC-11).
+		out, code := runCLI(t, dir, "sync", "--strictness", "annotation")
+
+		// The skip itself must not fail the pipeline: the spec parses,
+		// resolve/check pass, and coverage is satisfied by the small
+		// file's annotation (tier 3 threshold 50%, actual 100%).
+		if code != 0 {
+			t.Errorf("oversized test file skip should not drive non-zero exit (got %d); output:\n%s", code, out)
+		}
+
+		// Warning must name the offending file and contain the skip
+		// reason. Per AC-14 the message contains `exceeds` and
+		// `skipping` — the same operator vocabulary as `check --test`
+		// and `coverage` (spec-check C-12).
+		if !strings.Contains(out, "huge_test.go") {
+			t.Errorf("expected warning to name the oversized file `huge_test.go`, got:\n%s", out)
+		}
+		if !strings.Contains(out, "exceeds") || !strings.Contains(out, "skipping") {
+			t.Errorf("expected warning to contain `exceeds` and `skipping`, got:\n%s", out)
+		}
+
+		// Coverage MUST still be computed from the remaining in-cap
+		// files: the coverage phase passes via small_test.go's
+		// annotation, and the pipeline reports overall success.
+		if !strings.Contains(out, "PASS coverage") {
+			t.Errorf("expected coverage phase to pass from remaining files, got:\n%s", out)
+		}
+		if !strings.Contains(out, "All checks passed.") {
+			t.Errorf("expected pipeline success despite the skip, got:\n%s", out)
+		}
+	})
+
+	t.Run("spec-sync/AC-14 file at exactly the cap is scanned", func(t *testing.T) {
+		// Boundary condition: len == cap (4 MiB) must scan. The guard
+		// is `size > MaxTestFileBytes`, matching check --test exactly.
+		dir := t.TempDir()
+		writeSpec(t, dir, "x.spec.yaml", minimalValidSpec("x-spec", 3, "AC-01"))
+
+		header := "package foo\n\nimport \"testing\"\n\n// @spec x-spec\n// @ac AC-01\nfunc TestBoundary(t *testing.T) {\n}\n// padding:\n"
+		const cap = 4 << 20
+		padding := bytes.Repeat([]byte("/"), cap-len(header))
+		body := append([]byte(header), padding...)
+		if err := os.WriteFile(filepath.Join(dir, "boundary_test.go"), body, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		out, code := runCLI(t, dir, "sync", "--strictness", "annotation")
+
+		if code != 0 {
+			t.Errorf("file at exactly the cap should be scanned and sync should pass (got %d); output:\n%s", code, out)
+		}
+		if strings.Contains(out, "skipping") {
+			t.Errorf("file at exactly the cap must NOT be skipped, got:\n%s", out)
+		}
+		// The boundary file's annotation is the only coverage source;
+		// a passing coverage phase proves the file was actually read.
+		if !strings.Contains(out, "PASS coverage") {
+			t.Errorf("expected coverage phase to pass via boundary_test.go's annotation, got:\n%s", out)
+		}
+	})
+}

--- a/specter/specs/spec-sync.spec.yaml
+++ b/specter/specs/spec-sync.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-sync
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -81,6 +81,11 @@ spec:
     - id: C-09
       description: "Under an effective strictness of `zero-tolerance`, sync's coverage phase MUST enforce the same two zero-tolerance gates `coverage` enforces (spec-coverage C-25/C-26), in the same order: (a) any annotated AC with a results-file status other than `passed` fails the coverage phase and the process exits with code 2, even when every spec meets its tier coverage threshold; (b) any AC carrying `approval_gate: true` with an unset `approval_date` is demoted in the coverage report (spec-coverage GH #94 semantics — the report and the exit signal agree) and, when no code-2 violation is present, the process exits with code 3. Both gates apply identically under `--json` (mirroring spec-coverage C-29's text/JSON exit parity). C-03's contract is unchanged — exit 0 still means all phases passed; codes 2 and 3 refine the failure exit so CI can distinguish violation classes exactly as it can with `coverage`. Rationale: pre-1.4.0, sync routed zero-tolerance through the strict report path but gated only on tier thresholds (Summary.Failing), so a Tier 3 spec with one passing and one failing annotated AC passed sync at 50% while `coverage --strictness zero-tolerance` exited 2 on the same workspace — a false-green in the primary CI command, contradicting C-06 and AC-09."
       type: business
+      enforcement: error
+
+    - id: C-10
+      description: "Sync's test-file discovery MUST apply the same per-file size cap as `check --test` (spec-check C-12, `checker.MaxTestFileBytes`, 4 MiB). Each discovered test file is stat-guarded BEFORE it is read — an oversized file is never buffered into memory. A file over the cap is skipped per-file with a stderr warning naming the file, the limit, and the actual size; the skip MUST NOT fail the run. A test file that cannot be read (I/O error) is likewise skipped with a stderr warning, not fatal. Spec files are exempt: neither `check` nor `coverage` caps spec-file reads, and sync matches that parity."
+      type: technical
       enforcement: error
 
   depends_on:
@@ -221,7 +226,25 @@ spec:
       references_constraints: ["C-07", "C-09"]
       priority: critical
 
+    - id: AC-14
+      description: "A discovered test file larger than `checker.MaxTestFileBytes` (4 MiB) is skipped by `sync` with a stderr warning that names the file and contains `exceeds` and `skipping`; the file is never read into memory. The run does not fail because of the skip: sync exits 0 and the coverage phase counts annotations from the remaining (in-cap) test files."
+      inputs:
+        workspace: "valid spec with AC-01, one test file > 4 MiB, one small test file annotating AC-01"
+        command: "specter sync --strictness annotation"
+      expected_output:
+        exit_code: 0
+        warning_names_oversized_file: true
+        warning_contains: ["exceeds", "skipping"]
+        coverage_counts_remaining_files: true
+      references_constraints: ["C-10"]
+      priority: high
+
   changelog:
+    - version: "1.5.0"
+      date: "2026-06-11"
+      author: "specter-team"
+      type: minor
+      description: "Add C-10/AC-14: sync's test-file discovery applies the same per-file size cap as `check --test` (spec-check C-12, checker.MaxTestFileBytes, 4 MiB) — stat-guard before read, skip oversized files per-file with a stderr warning, never fail the run on the skip. Also: unreadable test files warn and skip instead of being silently ignored. Closes the gap left by the v0.13 hardening commit (8b76961), which guarded check, coverage, and explain but never touched sync's read loop — a large test artifact could OOM the primary CI command. Spec files remain uncapped, matching check/coverage parity."
     - version: "1.4.0"
       date: "2026-06-11"
       author: "specter-team"


### PR DESCRIPTION
## Summary

Fixes finding 6 of the 2026-06-11 six-finding review: the `sync` command read every discovered test file with an unguarded `os.ReadFile` (error silently ignored), bypassing the 4 MiB `MaxTestFileBytes` cap that `check --test`, `coverage`, and `explain` all apply. A single large test artifact could OOM the primary CI command. Git history shows the v0.13 H5 hardening commit (8b76961) *claimed* the sync site in its message but its diff never touched it — the cap was missed, not regressed.

## Commits (SDD three-commit cycle)

1. **spec** — spec-sync 1.4.0 → 1.5.0: new C-10 + AC-14 (stat-guard before read; oversized files skip with a stderr warning, never fail the run; unreadable files warn + skip; spec files exempt, matching check/coverage parity).
2. **test** — oversized file (4 MiB + 1) skipped with warning while sync exits 0 using the remaining files; boundary file at exactly 4 MiB is scanned. Verified failing before the fix.
3. **fix** — identical guard pattern to the coverage site at `cmd/specter/main.go`. The read error is no longer discarded (warn + skip — intentionally stricter than the siblings' silent `continue`).

## Stacking

⚠️ **Based on #140** (`fix/strictness-parity`) — the spec additions were renumbered C-09/AC-12 → **C-10/AC-14** because #140 claims those IDs in spec-sync 1.4.0. Merge after #140; GitHub will retarget this PR to `main` when the base branch is deleted.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, and `make dogfood` green on the stacked branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)