### PR TITLE
fix(vscode): per-folder coverage reports + on-save whole-report refresh

### DIFF
--- a/specter/specs/spec-vscode.spec.yaml
+++ b/specter/specs/spec-vscode.spec.yaml
@@ -1,6 +1,6 @@
 spec:
   id: spec-vscode
-  version: "1.6.0"
+  version: "1.7.0"
   status: draft
   tier: 2
 
@@ -322,7 +322,7 @@ spec:
       priority: medium
 
     - id: AC-22
-      description: "Multi-root workspace: each workspace folder has its own SpecterClient, DiagnosticCollection, and manifest. Diagnostics from folder A do not appear in folder B."
+      description: "Multi-root workspace: each workspace folder has its own SpecterClient, DiagnosticCollection, manifest, and coverage report (see AC-54). Diagnostics from folder A do not appear in folder B."
       references_constraints: ["C-06"]
       priority: high
 
@@ -377,7 +377,7 @@ spec:
       priority: high
 
     - id: AC-33
-      description: "Clicking a spec node or a test-file leaf in the Coverage sidebar opens the corresponding file in an editor tab. The spec node uses the path from CoverageReport entries[*].specFile (new in coverage v1.5.0); the test-file leaf uses entry.testFiles[i]. Relative paths emitted by the CLI are resolved against the workspace folder root before being passed to vscode.Uri.file. Previously, test-file leaves rendered as undefined/null (runtime shape mismatch) or passed a relative path straight to Uri.file, which produced a non-existent '/watch_test.go' URI and the 'file not found' editor error."
+      description: "Clicking a spec node or a test-file leaf in the Coverage sidebar opens the corresponding file in an editor tab. The spec node uses the path from CoverageReport entries[*].specFile (new in coverage v1.5.0); the test-file leaf uses entry.testFiles[i]. Relative paths emitted by the CLI are resolved against the OWNING workspace folder — the folder whose coverage run produced the report, specifically the directory of that folder's specter.yaml manifest, which is the CLI's working directory — once, at report-ingestion time, so stored reports carry absolute paths. In a single-folder workspace this is indistinguishable from resolving against the first workspace folder (the pre-1.7.0 behavior); in a multi-root workspace, resolving against the first folder produces URIs inside the wrong folder and is prohibited. Previously, test-file leaves rendered as undefined/null (runtime shape mismatch) or passed a relative path straight to Uri.file, which produced a non-existent '/watch_test.go' URI and the 'file not found' editor error."
       references_constraints: ["C-10"]
       priority: high
 
@@ -539,6 +539,29 @@ spec:
       references_constraints: ["C-29"]
       priority: critical
 
+    - id: AC-54
+      description: "Multi-root workspace: coverage reports are isolated per workspace folder. Folder B's coverage run does not overwrite folder A's report — each folder's report is stored under the same per-folder key as its SpecterClient and DiagnosticCollection. Paths inside a folder's report (entries[*].specFile, entries[*].testFiles[*], parseErrors[*].file) are resolved into the owning folder at ingestion time, so folder B's coverage parse-error diagnostics carry URIs inside folder B — never folder A. Aggregate views (status bar, Coverage sidebar, Insights) render the merged entries and parse errors of all stored reports. Removing a workspace folder removes its report from the store. With a single workspace folder, the merged view is identical to that folder's report — single-root behavior is unchanged."
+      inputs:
+        folder_a: "/ws/alpha (manifest at /ws/alpha/specter.yaml, spec spec-a, parse error in specs/broken.spec.yaml)"
+        folder_b: "/ws/beta (manifest at /ws/beta/specter.yaml, spec spec-b)"
+      expected_output:
+        folder_a_report_survives_folder_b_run: true
+        folder_a_parse_error_uri: "/ws/alpha/specs/broken.spec.yaml"
+        merged_view_contains: ["spec-a", "spec-b"]
+      references_constraints: ["C-05", "C-06"]
+      priority: high
+
+    - id: AC-55
+      description: "Saving a .spec.yaml file re-runs `specter coverage --json` for the saved file's workspace folder and replaces that folder's stored report wholesale — through the same ingestion path the initial activation load uses (path normalization, parse-error diagnostics, status bar and tree refresh). Per-entry splicing is prohibited: the pre-1.7.0 implementation extracted entries[0] of the fresh whole-workspace report and wrote it into the saved spec's slot, corrupting the report (and the status bar and notifications derived from it) whenever the saved spec was not the report's first entry, and pushing duplicate entries when the spec ID matched nothing. Gating the refresh on a `// @spec` slash-comment regex over the saved YAML is likewise prohibited — normal `#`-commented spec files never match that shape, so the refresh only fired (incorrectly) for specs whose prose happened to embed slash-comment examples. The below-threshold notification (AC-18) is evaluated against the fresh report's entry whose specFile matches the saved document's path."
+      inputs:
+        workspace: "specs spec-alpha and spec-zulu; user saves spec-zulu.spec.yaml"
+      expected_output:
+        folder_report_replaced_wholesale: true
+        spec_alpha_entry_overwritten_by_splice: false
+        notification_entry_matched_by: "specFile == saved document path"
+      references_constraints: ["C-04", "C-19"]
+      priority: high
+
   depends_on:
     - spec_id: spec-parse
       version_range: "^1.1.0"
@@ -557,6 +580,28 @@ spec:
       relationship: requires
 
   changelog:
+    - version: "1.7.0"
+      date: "2026-06-11"
+      author: "specter-team"
+      type: minor
+      description: >
+        Multi-root coverage isolation + on-save whole-report refresh.
+        Amend AC-33: CLI-emitted relative paths resolve against the OWNING
+        workspace folder (the manifest's directory — the CLI's cwd) once at
+        report-ingestion time, not against the first workspace folder. The
+        prior wording said "the workspace folder root" without naming which
+        folder in a multi-root workspace; the implementation read it as
+        workspaceFolders[0], sending folder B's paths into folder A. Amend
+        AC-22 to name the per-folder coverage report alongside the
+        per-folder client, collection, and manifest. Add AC-54 (per-folder
+        report isolation: folder B's run does not overwrite folder A's
+        report; parse-error diagnostics resolve into the owning folder;
+        aggregate views merge all folders' reports; removing a folder
+        removes its report; single-root behavior unchanged). Add AC-55
+        (saving a spec replaces the saved file's folder report wholesale
+        via the same ingestion path as the initial load; the entries[0]
+        splice and the slash-comment regex trigger are prohibited; the
+        AC-18 notification evaluates the fresh entry matched by specFile).
     - version: "1.6.0"
       date: "2026-04-28"
       author: "specter-team"

--- a/specter/vscode-extension/src/__tests__/coverageIsolation.test.ts
+++ b/specter/vscode-extension/src/__tests__/coverageIsolation.test.ts
@@ -1,0 +1,312 @@
+// @spec spec-vscode
+//
+// Tests for multi-root coverage-report isolation (AC-54), ingestion-time
+// path normalization against the owning folder (AC-33), and the on-save
+// whole-report refresh contract (AC-55). Mix of pure-function tests over
+// the coverage.ts helpers and static-analysis tests over extension.ts /
+// client.ts source — the same two patterns the rest of this suite uses
+// (no vscode runtime mock exists in this repo; extension.ts invariants
+// are enforced by grep, see commands.test.ts).
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const posix = path.posix;
+
+import {
+  CoverageReportStore,
+  normalizeReportPaths,
+  findEntryBySpecFile,
+} from '../coverage';
+
+import type { CoverageReport, SpecCoverageEntry } from '../types';
+
+const EXT_TS = path.resolve(__dirname, '..', 'extension.ts');
+const CLIENT_TS = path.resolve(__dirname, '..', 'client.ts');
+const readExtSrc = () => fs.readFileSync(EXT_TS, 'utf-8');
+const readClientSrc = () => fs.readFileSync(CLIENT_TS, 'utf-8');
+
+// POSIX path ops so the pure tests are platform-agnostic, mirroring
+// resolveWorkspacePathPure's testing convention.
+const ops = {
+  resolve: (base: string, p: string) => posix.resolve(base, p),
+  isAbsolute: (p: string) => posix.isAbsolute(p),
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeEntry = (
+  specID: string,
+  overrides: Partial<SpecCoverageEntry> = {},
+): SpecCoverageEntry => ({
+  specID,
+  tier: 2,
+  totalACs: 2,
+  coveredACs: ['AC-01'],
+  uncoveredACs: ['AC-02'],
+  coveragePct: 50,
+  threshold: 90,
+  passesThreshold: false,
+  testFiles: [`src/__tests__/${specID}.test.ts`],
+  specFile: `specs/${specID}.spec.yaml`,
+  ...overrides,
+});
+
+const makeReport = (
+  entries: SpecCoverageEntry[],
+  extra: Partial<CoverageReport> = {},
+): CoverageReport => ({
+  entries,
+  summary: {
+    totalSpecs: entries.length,
+    passing: entries.filter(e => e.passesThreshold).length,
+    failing: entries.filter(e => !e.passesThreshold).length,
+    fullyCovered: 0,
+    partiallyCovered: entries.length,
+    uncovered: 0,
+  },
+  ...extra,
+});
+
+// ---------------------------------------------------------------------------
+// AC-33: ingestion-time path normalization against the OWNING folder
+// ---------------------------------------------------------------------------
+
+// @ac AC-33
+describe('[spec-vscode/AC-33] normalizeReportPaths', () => {
+  it('resolves relative specFile, testFiles, and parseErrors[].file against the owning folder root', () => {
+    const report = makeReport([makeEntry('spec-a')], {
+      parseErrors: [{ file: 'specs/broken.spec.yaml', message: 'bad yaml', line: 3 }],
+    });
+
+    const out = normalizeReportPaths(report, '/ws/alpha', ops);
+
+    expect(out.entries[0].specFile).toBe('/ws/alpha/specs/spec-a.spec.yaml');
+    expect(out.entries[0].testFiles).toEqual(['/ws/alpha/src/__tests__/spec-a.test.ts']);
+    expect(out.parseErrors?.[0].file).toBe('/ws/alpha/specs/broken.spec.yaml');
+  });
+
+  it('leaves already-absolute paths untouched', () => {
+    const report = makeReport([
+      makeEntry('spec-a', {
+        specFile: '/elsewhere/specs/spec-a.spec.yaml',
+        testFiles: ['/elsewhere/a.test.ts'],
+      }),
+    ], {
+      parseErrors: [{ file: '/elsewhere/specs/broken.spec.yaml', message: 'bad' }],
+    });
+
+    const out = normalizeReportPaths(report, '/ws/alpha', ops);
+
+    expect(out.entries[0].specFile).toBe('/elsewhere/specs/spec-a.spec.yaml');
+    expect(out.entries[0].testFiles).toEqual(['/elsewhere/a.test.ts']);
+    expect(out.parseErrors?.[0].file).toBe('/elsewhere/specs/broken.spec.yaml');
+  });
+
+  it('does not mutate the input report', () => {
+    const report = makeReport([makeEntry('spec-a')], {
+      parseErrors: [{ file: 'specs/broken.spec.yaml', message: 'bad' }],
+    });
+    const snapshot = JSON.parse(JSON.stringify(report));
+
+    normalizeReportPaths(report, '/ws/alpha', ops);
+
+    expect(report).toEqual(snapshot);
+  });
+
+  it('tolerates missing specFile, null-ish testFiles, and absent parseErrors', () => {
+    const entry = makeEntry('spec-a', { specFile: undefined });
+    // The Go CLI emits null (not []) for empty slices via omitempty.
+    (entry as unknown as { testFiles: null }).testFiles = null;
+    const report = makeReport([entry]);
+
+    const out = normalizeReportPaths(report, '/ws/alpha', ops);
+
+    expect(out.entries[0].specFile).toBeUndefined();
+    expect(out.parseErrors).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-54 / AC-22: per-folder report isolation in the store
+// ---------------------------------------------------------------------------
+
+// @ac AC-54
+// @ac AC-22
+describe('[spec-vscode/AC-54] CoverageReportStore — two-folder isolation', () => {
+  const reportA = () => makeReport([makeEntry('spec-a')], {
+    parseErrors: [{ file: 'specs/broken-a.spec.yaml', message: 'bad yaml in A', line: 2 }],
+  });
+  const reportB = () => makeReport([makeEntry('spec-b')], {
+    parseErrors: [{ file: 'specs/broken-b.spec.yaml', message: 'bad yaml in B', line: 7 }],
+  });
+
+  it("storing folder B's report does not overwrite folder A's", () => {
+    const store = new CoverageReportStore(ops);
+    store.set('/ws/alpha', reportA(), '/ws/alpha');
+    store.set('/ws/beta', reportB(), '/ws/beta');
+
+    expect(store.get('/ws/alpha')?.entries.map(e => e.specID)).toEqual(['spec-a']);
+    expect(store.get('/ws/beta')?.entries.map(e => e.specID)).toEqual(['spec-b']);
+  });
+
+  it("folder B's parse-error path resolves into folder B, not folder A", () => {
+    const store = new CoverageReportStore(ops);
+    store.set('/ws/alpha', reportA(), '/ws/alpha');
+    store.set('/ws/beta', reportB(), '/ws/beta');
+
+    expect(store.get('/ws/alpha')?.parseErrors?.[0].file)
+      .toBe('/ws/alpha/specs/broken-a.spec.yaml');
+    expect(store.get('/ws/beta')?.parseErrors?.[0].file)
+      .toBe('/ws/beta/specs/broken-b.spec.yaml');
+  });
+
+  it('merged() contains both folders entries and parse errors', () => {
+    const store = new CoverageReportStore(ops);
+    store.set('/ws/alpha', reportA(), '/ws/alpha');
+    store.set('/ws/beta', reportB(), '/ws/beta');
+
+    const merged = store.merged();
+    expect(merged?.entries.map(e => e.specID).sort()).toEqual(['spec-a', 'spec-b']);
+    expect(merged?.parseErrors?.map(e => e.file).sort()).toEqual([
+      '/ws/alpha/specs/broken-a.spec.yaml',
+      '/ws/beta/specs/broken-b.spec.yaml',
+    ]);
+    expect(merged?.summary.totalSpecs).toBe(2);
+  });
+
+  it('delete(key) removes that folder from the merged view (folder removal)', () => {
+    const store = new CoverageReportStore(ops);
+    store.set('/ws/alpha', reportA(), '/ws/alpha');
+    store.set('/ws/beta', reportB(), '/ws/beta');
+    store.delete('/ws/alpha');
+
+    expect(store.get('/ws/alpha')).toBeUndefined();
+    expect(store.merged()?.entries.map(e => e.specID)).toEqual(['spec-b']);
+  });
+
+  it('re-storing under the same key replaces only that folder (on-save refresh path)', () => {
+    const store = new CoverageReportStore(ops);
+    store.set('/ws/alpha', reportA(), '/ws/alpha');
+    store.set('/ws/beta', reportB(), '/ws/beta');
+
+    const freshA = makeReport([makeEntry('spec-a', { coveragePct: 100, passesThreshold: true })]);
+    store.set('/ws/alpha', freshA, '/ws/alpha');
+
+    expect(store.get('/ws/alpha')?.entries[0].coveragePct).toBe(100);
+    expect(store.get('/ws/alpha')?.parseErrors).toBeUndefined();
+    expect(store.get('/ws/beta')?.entries.map(e => e.specID)).toEqual(['spec-b']);
+  });
+});
+
+// @ac AC-54
+describe('[spec-vscode/AC-54] CoverageReportStore — single-root regression', () => {
+  it('merged() with one folder IS that folder normalized report (identity, not a copy)', () => {
+    const store = new CoverageReportStore(ops);
+    store.set('/ws/solo', makeReport([makeEntry('spec-a')]), '/ws/solo');
+
+    expect(store.merged()).toBe(store.get('/ws/solo'));
+  });
+
+  it('merged() is null when no report has been stored (sidebar "not run yet" state preserved)', () => {
+    const store = new CoverageReportStore(ops);
+    expect(store.merged()).toBeNull();
+  });
+
+  it('single folder, all-empty report keeps the empty shape (greenfield message state)', () => {
+    const store = new CoverageReportStore(ops);
+    store.set('/ws/solo', makeReport([], { specCandidatesCount: 0 }), '/ws/solo');
+
+    const merged = store.merged();
+    expect(merged?.entries).toEqual([]);
+    expect(merged?.parseErrors).toBeUndefined();
+    expect(merged?.specCandidatesCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-55: on-save refresh — fresh entry located by specFile, never entries[0]
+// ---------------------------------------------------------------------------
+
+// @ac AC-55
+describe('[spec-vscode/AC-55] findEntryBySpecFile', () => {
+  const entries = [
+    makeEntry('spec-alpha', { specFile: '/ws/solo/specs/spec-alpha.spec.yaml' }),
+    makeEntry('spec-zulu', { specFile: '/ws/solo/specs/spec-zulu.spec.yaml' }),
+  ];
+
+  it('returns the entry whose specFile matches the saved document, not entries[0]', () => {
+    const hit = findEntryBySpecFile(entries, '/ws/solo/specs/spec-zulu.spec.yaml');
+    expect(hit?.specID).toBe('spec-zulu');
+  });
+
+  it('matches a relative stored specFile against an absolute query (suffix match)', () => {
+    const rel = [makeEntry('spec-zulu')]; // specFile: specs/spec-zulu.spec.yaml
+    const hit = findEntryBySpecFile(rel, '/ws/solo/specs/spec-zulu.spec.yaml');
+    expect(hit?.specID).toBe('spec-zulu');
+  });
+
+  it('returns undefined when nothing matches (no duplicate-entry pushes)', () => {
+    expect(findEntryBySpecFile(entries, '/ws/solo/specs/spec-nope.spec.yaml')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty entry list', () => {
+    expect(findEntryBySpecFile([], '/ws/solo/specs/spec-zulu.spec.yaml')).toBeUndefined();
+  });
+});
+
+// @ac AC-55
+describe('[spec-vscode/AC-55] on-save handler — static analysis of extension.ts', () => {
+  it('no longer gates the coverage refresh on the // @spec slash-comment regex', () => {
+    expect(readExtSrc()).not.toMatch(/shouldRunCoverageForFile/);
+  });
+
+  it('no longer splices entries[0] of the fresh report into another spec slot', () => {
+    const src = readExtSrc();
+    expect(src).not.toMatch(/entries\?\.\[0\]/);
+    expect(src).not.toMatch(/findIndex\(e\s*=>\s*e\.specID\s*===\s*specID\)/);
+  });
+
+  it('routes the on-save refresh through the same per-folder run the initial load uses', () => {
+    const src = readExtSrc();
+    // The save handler must call runCoverageForFolder and locate the saved
+    // spec's fresh entry by specFile — not by regex-derived spec ID.
+    expect(src).toMatch(/findEntryBySpecFile/);
+    // Initial load + runSync + on-save = at least 3 call sites.
+    const calls = src.match(/runCoverageForFolder\(/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// @ac AC-55
+describe('[spec-vscode/AC-55] client.coverage — static analysis of client.ts', () => {
+  it('the dead specID parameter is gone (CLI has no per-spec filter)', () => {
+    const src = readClientSrc();
+    expect(src).not.toMatch(/coverage\(specID/);
+    expect(src).not.toMatch(/void specID/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-54: extension.ts holds per-folder reports, not one module global
+// ---------------------------------------------------------------------------
+
+// @ac AC-54
+describe('[spec-vscode/AC-54] report state — static analysis of extension.ts', () => {
+  it('replaces the single module-global coverageReport with a per-folder store', () => {
+    const src = readExtSrc();
+    expect(src).not.toMatch(/let coverageReport\b/);
+    expect(src).toMatch(/new CoverageReportStore\(/);
+  });
+
+  it('parse-error diagnostics no longer resolve paths against workspaceFolders[0] inline', () => {
+    const src = readExtSrc();
+    const start = src.indexOf('function pushCoverageParseDiagnostics');
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf('\nfunction ', start + 1);
+    const body = src.slice(start, end === -1 ? undefined : end);
+    expect(body).not.toMatch(/workspaceFolders/);
+  });
+});

--- a/specter/vscode-extension/src/__tests__/diagnostics.test.ts
+++ b/specter/vscode-extension/src/__tests__/diagnostics.test.ts
@@ -3,7 +3,7 @@
 // Tests for diagnostic lifecycle: debounce, atomic replacement, and on-save
 // triggering of the correct specter commands.
 
-import { buildDiagnostics, buildCoverageParseDiagnostics, DiagnosticReplacer, shouldRunCoverageForFile } from '../diagnostics';
+import { buildDiagnostics, buildCoverageParseDiagnostics, DiagnosticReplacer } from '../diagnostics';
 import type { SpecterParseError, SpecterCheckDiagnostic, CoverageParseError } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -133,31 +133,9 @@ describe('[spec-vscode/AC-04] DiagnosticReplacer', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// AC-04: Coverage scoped to affected spec when a test file is saved
-// ---------------------------------------------------------------------------
-
-// @ac AC-04
-describe('[spec-vscode/AC-04] shouldRunCoverageForFile', () => {
-  it('returns the spec IDs found in @spec annotations in a test file', () => {
-    const content = `
-// @spec payment-create-intent
-// @ac AC-01
-function testCreateIntent() {}
-
-// @spec auth-verify-token
-// @ac AC-02
-function testVerifyToken() {}
-    `.trim();
-    const specIDs = shouldRunCoverageForFile(content);
-    expect(specIDs).toContain('payment-create-intent');
-    expect(specIDs).toContain('auth-verify-token');
-  });
-
-  it('returns empty array for files with no @spec annotations', () => {
-    expect(shouldRunCoverageForFile('function testSomething() {}')).toHaveLength(0);
-  });
-});
+// shouldRunCoverageForFile tests removed in v1.7.0 — the helper is gone
+// (spec-vscode AC-55: on-save refreshes the saved file's folder report
+// wholesale; the slash-comment regex trigger is prohibited).
 
 // ---------------------------------------------------------------------------
 // AC-34 (v0.9.0): coverage parse_errors → per-file VS Code diagnostics

--- a/specter/vscode-extension/src/client.ts
+++ b/specter/vscode-extension/src/client.ts
@@ -91,6 +91,15 @@ export class SpecterClient {
 
   constructor(private readonly opts: ClientOptions) {}
 
+  /**
+   * The directory the CLI runs in (the manifest's directory — see run()).
+   * CLI-emitted relative paths are relative to this, so it is the
+   * resolution root for report-path normalization (AC-33, AC-54).
+   */
+  get cliCwd(): string {
+    return path.dirname(this.opts.manifestPath);
+  }
+
   /** Enqueue a task, ensuring it runs after the previous one completes. */
   private enqueue<T>(task: (signal: AbortSignal) => Promise<T>): Promise<T> {
     const controller = new AbortController();
@@ -146,10 +155,10 @@ export class SpecterClient {
    * etc. silently read `undefined` — a latent bug that would have become
    * a crash the moment any code iterated `coveredACs`.
    */
-  coverage(specID?: string): Promise<CoverageResult> {
-    // The CLI has no --spec filter; specID arg is preserved for API
-    // compatibility but currently has no effect. Filter callers-side if needed.
-    void specID;
+  coverage(): Promise<CoverageResult> {
+    // The CLI has no per-spec filter — coverage() always returns the
+    // whole-workspace report. Callers filter the result if they need a
+    // single spec's entry (see findEntryBySpecFile, AC-55).
     // --strictness annotation: the sidebar is a structural coverage view.
     // Since spec-coverage 1.15.0 (C-31) the manifest default `threshold`
     // routes plain `coverage` through the strict path, which hard-fails

--- a/specter/vscode-extension/src/coverage.ts
+++ b/specter/vscode-extension/src/coverage.ts
@@ -92,6 +92,163 @@ export function resolveWorkspacePathPure(
 }
 
 // ---------------------------------------------------------------------------
+// AC-33 / AC-54: ingestion-time path normalization + per-folder report store
+// ---------------------------------------------------------------------------
+
+/**
+ * Injectable path operations so the helpers below stay platform-agnostic
+ * in tests (POSIX semantics) while the production caller passes node's
+ * `path.resolve` / `path.isAbsolute`. Same convention as
+ * resolveWorkspacePathPure.
+ */
+export interface PathOps {
+  resolve: (base: string, p: string) => string;
+  isAbsolute: (p: string) => boolean;
+}
+
+/**
+ * AC-33 (v1.7.0): resolve every CLI-emitted relative path in a coverage
+ * report — entries[*].specFile, entries[*].testFiles[*], and
+ * parseErrors[*].file — against the OWNING folder's root (the manifest's
+ * directory, which is the CLI's cwd), once, at report-ingestion time.
+ * Stored reports therefore carry absolute paths and downstream consumers
+ * (sidebar click-to-open, hover, parse-error diagnostics, Insights) need
+ * no folder context. Absolute paths pass through untouched, so the
+ * first-folder fallback in resolveWorkspacePath becomes a no-op.
+ *
+ * Pure: returns a new report, never mutates the input. Defensive against
+ * the Go CLI's `omitempty` nulls (testFiles/entries may be null at
+ * runtime despite the TypeScript types).
+ */
+export function normalizeReportPaths(
+  report: CoverageReport,
+  folderRoot: string,
+  ops: PathOps,
+): CoverageReport {
+  const abs = (p: string): string =>
+    p && !ops.isAbsolute(p) ? ops.resolve(folderRoot, p) : p;
+
+  return {
+    ...report,
+    entries: (report.entries ?? []).map(e => ({
+      ...e,
+      specFile: e.specFile ? abs(e.specFile) : e.specFile,
+      testFiles: e.testFiles ? e.testFiles.map(abs) : e.testFiles,
+    })),
+    parseErrors: report.parseErrors
+      ? report.parseErrors.map(pe => ({ ...pe, file: abs(pe.file) }))
+      : report.parseErrors,
+  };
+}
+
+/**
+ * AC-54 (v1.7.0): per-workspace-folder coverage reports, keyed the same
+ * way as the per-folder SpecterClient / DiagnosticCollection maps. Fixes
+ * the multi-root bug where a single module-global report meant the last
+ * folder's coverage run silently overwrote every other folder's.
+ *
+ * Reports are normalized via normalizeReportPaths at set() time, so
+ * everything read back from the store carries absolute paths rooted in
+ * the owning folder.
+ */
+export class CoverageReportStore {
+  private readonly reports = new Map<string, CoverageReport>();
+
+  constructor(private readonly ops: PathOps) {}
+
+  /** Normalize against the owning folder root (AC-33), then store (AC-54). */
+  set(key: string, report: CoverageReport, folderRoot: string): void {
+    this.reports.set(key, normalizeReportPaths(report, folderRoot, this.ops));
+  }
+
+  get(key: string): CoverageReport | undefined {
+    return this.reports.get(key);
+  }
+
+  /** Folder removed from the workspace — drop its report (AC-54). */
+  delete(key: string): void {
+    this.reports.delete(key);
+  }
+
+  get size(): number {
+    return this.reports.size;
+  }
+
+  /**
+   * Aggregate view for the status bar, Coverage sidebar, and Insights.
+   * Single-folder workspaces get their stored report back by identity —
+   * byte-for-byte the pre-1.7.0 single-root behavior. Returns null when
+   * nothing is stored (the sidebar's "coverage not run yet" state).
+   * Optional fields (parseErrors, specCandidatesCount,
+   * parseErrorPatterns) stay absent unless at least one folder's report
+   * defined them, preserving the tri-state sidebar logic (AC-28/29/30).
+   */
+  merged(): CoverageReport | null {
+    if (this.reports.size === 0) return null;
+    const all = Array.from(this.reports.values());
+    if (all.length === 1) return all[0];
+
+    const withParseErrors = all.filter(r => r.parseErrors !== undefined);
+    const withCandidates = all.filter(r => r.specCandidatesCount !== undefined);
+    const withPatterns = all.filter(r => r.parseErrorPatterns !== undefined);
+    const sum = (pick: (r: CoverageReport) => number | undefined): number =>
+      all.reduce((s, r) => s + (pick(r) ?? 0), 0);
+
+    return {
+      entries: all.flatMap(r => r.entries ?? []),
+      summary: {
+        totalSpecs: sum(r => r.summary?.totalSpecs),
+        passing: sum(r => r.summary?.passing),
+        failing: sum(r => r.summary?.failing),
+        fullyCovered: sum(r => r.summary?.fullyCovered),
+        partiallyCovered: sum(r => r.summary?.partiallyCovered),
+        uncovered: sum(r => r.summary?.uncovered),
+      },
+      parseErrors: withParseErrors.length > 0
+        ? withParseErrors.flatMap(r => r.parseErrors ?? [])
+        : undefined,
+      specCandidatesCount: withCandidates.length > 0
+        ? withCandidates.reduce((s, r) => s + (r.specCandidatesCount ?? 0), 0)
+        : undefined,
+      parseErrorPatterns: withPatterns.length > 0
+        ? withPatterns.flatMap(r => r.parseErrorPatterns ?? [])
+        : undefined,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AC-55: locate the saved spec's fresh coverage entry by specFile
+// ---------------------------------------------------------------------------
+
+/**
+ * AC-55 (v1.7.0): after an on-save coverage refresh, find the entry for
+ * the saved .spec.yaml by its file path — never by position (the old
+ * entries[0] splice) and never by a regex-derived spec ID. Exact match
+ * first; falls back to trailing-path suffix match in either direction so
+ * a CLI-relative stored path still matches an absolute editor path (same
+ * tolerance as matchFileInIndex). Returns undefined when nothing
+ * matches — the caller must not fabricate or duplicate entries.
+ */
+export function findEntryBySpecFile(
+  entries: ReadonlyArray<SpecCoverageEntry>,
+  absPath: string,
+): SpecCoverageEntry | undefined {
+  const norm = absPath.replace(/\\/g, '/');
+  let suffixHit: SpecCoverageEntry | undefined;
+  for (const e of entries) {
+    const f = e.specFile;
+    if (!f) continue;
+    if (f === absPath) return e;
+    const fNorm = f.replace(/\\/g, '/');
+    if (!suffixHit && (norm.endsWith('/' + fNorm) || fNorm.endsWith('/' + norm))) {
+      suffixHit = e;
+    }
+  }
+  return suffixHit;
+}
+
+// ---------------------------------------------------------------------------
 // AC-32: covering-files lookup for @ac hovers
 // ---------------------------------------------------------------------------
 

--- a/specter/vscode-extension/src/diagnostics.ts
+++ b/specter/vscode-extension/src/diagnostics.ts
@@ -128,22 +128,8 @@ export class DiagnosticReplacer {
   }
 }
 
-// ---------------------------------------------------------------------------
-// AC-04: Extract @spec IDs from a test file to scope coverage runs
-// ---------------------------------------------------------------------------
-
-/**
- * Scans `content` for `// @spec <id>` annotations and returns the unique
- * list of spec IDs found.  Used to scope `specter coverage --spec <id>`
- * to only the specs referenced in the saved test file.
- */
-export function shouldRunCoverageForFile(content: string): string[] {
-  const ids: string[] = [];
-  const pattern = /\/\/\s*@spec\s+(\S+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = pattern.exec(content)) !== null) {
-    const id = m[1];
-    if (!ids.includes(id)) ids.push(id);
-  }
-  return ids;
-}
+// shouldRunCoverageForFile was removed in v1.7.0 (spec-vscode AC-55): it
+// regex-scanned saved YAML for `// @spec` slash comments — a shape normal
+// #-commented spec files never match — to scope a per-spec coverage run
+// the CLI never supported. The on-save hook now refreshes the saved
+// file's folder report wholesale; see extension.ts.

--- a/specter/vscode-extension/src/extension.ts
+++ b/specter/vscode-extension/src/extension.ts
@@ -16,7 +16,7 @@ import {
   downloadChecksums,
   isBinaryFile,
 } from './binaryDiscovery';
-import { buildDiagnostics, buildCoverageParseDiagnostics, DiagnosticReplacer, shouldRunCoverageForFile } from './diagnostics';
+import { buildDiagnostics, buildCoverageParseDiagnostics, DiagnosticReplacer } from './diagnostics';
 import { matchRemovedFieldDiagnostic, isLineSafeToDelete } from './quickFix';
 import {
   buildSpecCompletions,
@@ -37,6 +37,8 @@ import {
   formatSyncCompletion,
   resolveWorkspacePathPure,
   matchFileInIndex,
+  CoverageReportStore,
+  findEntryBySpecFile,
 } from './coverage';
 import { buildConstraintHover, resolveDefinitionTarget } from './navigation';
 import { buildInsightCards, computeInsightsStatus, formatSpecContextForAI, shouldShowWalkthrough } from './insights';
@@ -58,7 +60,18 @@ const clients = new Map<string, SpecterClient>();
 const diagnosticReplacers = new Map<string, DiagnosticReplacer>();
 const diagnosticCollections = new Map<string, vscode.DiagnosticCollection>();
 let specIndex: SpecIndex = { specs: {} };
-let coverageReport: CoverageReport | null = null;
+// AC-54 (v1.7.0): per-folder coverage reports, keyed like `clients`. The
+// pre-1.7.0 single module-global meant the last folder's coverage run
+// silently overwrote every other folder's report in a multi-root
+// workspace. Paths inside each stored report are normalized to absolute
+// against the owning folder's CLI cwd at ingestion time (AC-33), so
+// downstream consumers need no folder context. Aggregate views read
+// coverageReports.merged() — identical to the folder's own report in a
+// single-root workspace.
+const coverageReports = new CoverageReportStore({
+  resolve: (base, p) => path.resolve(base, p),
+  isAbsolute: p => path.isAbsolute(p),
+});
 // Folders where the most recent coverage run failed (parse errors or
 // process-level failure). Consulted by specter.runSync to emit an honest
 // completion message — see AC-31.
@@ -252,6 +265,10 @@ function teardownFolder(folder: vscode.WorkspaceFolder): void {
   diagnosticCollections.get(key)?.dispose();
   diagnosticCollections.delete(key);
   diagnosticReplacers.delete(key);
+  // AC-54: a removed folder's report must not linger in the merged view.
+  coverageReports.delete(key);
+  coverageErrorFolders.delete(key);
+  treeProvider?.refresh();
 }
 
 // ---------------------------------------------------------------------------
@@ -481,13 +498,16 @@ async function maybePromptAddCliToShellPath(
 async function runCoverageForFolder(key: string, client: SpecterClient): Promise<void> {
   try {
     const result = await client.coverage();
-    coverageReport = result as unknown as CoverageReport;
-    updateSpecIndex(coverageReport);
+    // AC-54: store under the folder key; AC-33: normalize CLI-relative
+    // paths against the owning folder's CLI cwd at ingestion time.
+    coverageReports.set(key, result as unknown as CoverageReport, client.cliCwd);
+    const report = coverageReports.get(key)!;
+    updateSpecIndex(report);
 
     // v0.9.0: parse errors flow through the report now, not a rejected
     // promise. Distinguish "CLI ran but parses failed" from the happy path
     // so the sidebar + status bar reflect the real state.
-    const parseErrors = coverageReport.parseErrors ?? [];
+    const parseErrors = report.parseErrors ?? [];
     pushCoverageParseDiagnostics(key, parseErrors);
     if (parseErrors.length > 0) {
       outputChannel?.appendLine(
@@ -500,7 +520,7 @@ async function runCoverageForFolder(key: string, client: SpecterClient): Promise
       setStatusBarError('Specter: parse errors. Click to view details.');
       coverageErrorFolders.add(key);
     } else {
-      updateStatusBar(coverageReport);
+      updateStatusBar(coverageReports.merged());
       coverageErrorFolders.delete(key);
     }
     treeProvider?.refresh();
@@ -534,9 +554,11 @@ function pushCoverageParseDiagnostics(
   dc.clear();
   const grouped = buildCoverageParseDiagnostics(parseErrors as { file: string; path?: string; type?: string; message: string; line?: number; column?: number }[]);
   for (const { file, diagnostics } of grouped) {
-    const abs = path.isAbsolute(file)
-      ? file
-      : path.resolve(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '', file);
+    // AC-54: parse-error paths arrive absolute — normalized against the
+    // OWNING folder at report-ingestion time (AC-33). resolveWorkspacePath
+    // is a no-op for absolute paths; it remains only as a safety net for
+    // a path that somehow skipped ingestion.
+    const abs = resolveWorkspacePath(file);
     const uri = vscode.Uri.file(abs);
     const vsDiags = diagnostics.map(d => {
       const range = new vscode.Range(
@@ -596,8 +618,8 @@ function updateSpecIndex(report: CoverageReport): void {
   }
 }
 
-function updateStatusBar(report: CoverageReport): void {
-  if (!statusBarItem) return;
+function updateStatusBar(report: CoverageReport | null): void {
+  if (!statusBarItem || !report) return;
   const entries = report.entries ?? [];
   const hasT1OrT2Failure = entries.some(
     e => !e.passesThreshold && (e.tier === 1 || e.tier === 2),
@@ -685,7 +707,7 @@ function registerProviders(ctx: vscode.ExtensionContext): void {
         // which made every `@ac` hover display as "uncovered" — a UX
         // regression caught by the quality audit (H3).
         const coveredByFiles = resolveCoveringFiles(
-          coverageReport,
+          coverageReports.merged(),
           specID,
           m[1],
           doc.uri.fsPath,
@@ -869,6 +891,7 @@ function registerProviders(ctx: vscode.ExtensionContext): void {
     vscode.window.registerFileDecorationProvider({
       provideFileDecoration(uri) {
         if (!uri.fsPath.endsWith('.spec.yaml')) return;
+        const coverageReport = coverageReports.merged();
         if (!coverageReport) return;
 
         const specID = guessSpecIDFromFile(uri.fsPath);
@@ -891,6 +914,7 @@ function registerProviders(ctx: vscode.ExtensionContext): void {
   ctx.subscriptions.push(
     vscode.languages.registerCodeLensProvider(specYamlSelector, {
       provideCodeLenses(doc) {
+        const coverageReport = coverageReports.merged();
         if (!coverageReport) return [];
         const specID = guessSpecIDFromFile(doc.uri.fsPath);
         if (!specID) return [];
@@ -995,29 +1019,32 @@ function registerDiagnosticHooks(ctx: vscode.ExtensionContext): void {
         });
         replacer.replace(doc.uri.fsPath, diags.map(d => toVscodeDiagnostic(d)));
 
-        // Scoped coverage run
-        const specIDs = shouldRunCoverageForFile(doc.getText());
-        for (const specID of specIDs) {
-          const result = await client.coverage(specID);
-          if (coverageReport) {
-            if (!coverageReport.entries) coverageReport.entries = [];
-            const idx = coverageReport.entries.findIndex(e => e.specID === specID);
-            const newEntry = (result as any).entries?.[0];
-            if (newEntry) {
-              if (idx >= 0) coverageReport.entries[idx] = newEntry;
-              else coverageReport.entries.push(newEntry);
-            }
-            updateStatusBar(coverageReport);
-            treeProvider?.refresh();
+        // AC-55: whole-report refresh for the saved file's folder — the
+        // same ingestion path the initial activation load uses (path
+        // normalization, parse-error diagnostics, status bar and tree
+        // refresh). The pre-1.7.0 implementation regex-scanned the saved
+        // YAML for `// @spec` slash comments (a shape normal #-commented
+        // spec files never match) and spliced the fresh report's
+        // entries[0] into the matched spec's slot — corrupting the report
+        // whenever the saved spec wasn't the report's first entry.
+        const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+        if (folder) {
+          const key = createClientKey(folder.uri.fsPath);
+          await runCoverageForFolder(key, client);
 
-            // Notification discipline (AC-18)
-            if (newEntry && !newEntry.passesThreshold) {
-              const kind = classifyNotification({
-                tier: newEntry.tier,
-                droppedBelowThreshold: true,
-              });
-              maybeNotify(specID, kind.kind, newEntry.tier);
-            }
+          // Notification discipline (AC-18), evaluated against the fresh
+          // report's entry for the saved spec — located by specFile, not
+          // by position or regex-derived ID (AC-55).
+          const fresh = coverageReports.get(key);
+          const entry = fresh
+            ? findEntryBySpecFile(fresh.entries ?? [], doc.uri.fsPath)
+            : undefined;
+          if (entry && !entry.passesThreshold) {
+            const kind = classifyNotification({
+              tier: entry.tier,
+              droppedBelowThreshold: true,
+            });
+            maybeNotify(entry.specID, kind.kind, entry.tier);
           }
         }
 
@@ -1097,6 +1124,8 @@ function registerCommands(ctx: vscode.ExtensionContext): void {
   // AC-13: Insights panel
   ctx.subscriptions.push(
     vscode.commands.registerCommand('specter.openInsights', () => {
+      // AC-54: aggregate view across all folders' reports.
+      const coverageReport = coverageReports.merged();
       if (!coverageReport) {
         vscode.window.showInformationMessage('Specter coverage not yet loaded.');
         return;
@@ -1577,11 +1606,15 @@ type TreeElement = { kind: 'spec'; specID: string; file: string; children: TreeE
   | { kind: 'parseErrorFile'; file: string; message: string; line?: number };
 
 /**
- * AC-33 (v0.9.0): resolve a CLI-emitted relative path against the first
- * workspace folder so `vscode.Uri.file` produces an openable absolute URI.
- * Passing a relative path directly to `Uri.file` treats it as absolute from
- * '/' and silently yields a non-existent URI — the "file not found" path
- * users hit when clicking a leaf in the Coverage sidebar.
+ * AC-33 (v1.7.0): report paths are normalized to absolute against the
+ * OWNING folder's CLI cwd at ingestion time (see CoverageReportStore), so
+ * this is a no-op for everything read from the store. It remains as a
+ * safety net for a relative path that somehow skipped ingestion: passing
+ * a relative path directly to `Uri.file` treats it as absolute from '/'
+ * and silently yields a non-existent URI — the "file not found" path
+ * users hit when clicking a leaf in the Coverage sidebar (v0.9.0). The
+ * first-folder fallback here is only correct for single-root workspaces,
+ * which is exactly the case ingestion-time normalization can't get wrong.
  */
 function resolveWorkspacePath(p: string): string {
   const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
@@ -1691,7 +1724,7 @@ class SpecterTreeProvider implements vscode.TreeDataProvider<TreeElement> {
       this.parentMap = new WeakMap<object, TreeElement>();
       this.fileIndex = new Map<string, TreeElement>();
 
-      const roots = buildCoverageTreeRoot(coverageReport);
+      const roots = buildCoverageTreeRoot(coverageReports.merged());
       const built: TreeElement[] = roots.map(n => {
         if (n.kind === 'message') {
           return { kind: 'message' as const, label: n.label, detail: n.detail, iconId: n.iconId };


### PR DESCRIPTION
## Summary

Fixes findings 3 + 4 of the 2026-06-11 six-finding review — both extension-state bugs:

- **Finding 3 (save splice):** the on-save handler regex-scanned saved spec YAML for `// @spec` slash comments (a shape normal `#`-commented spec files never match — but all 5 of Specter's own specs do, in prose) and spliced the fresh whole-workspace report's `entries[0]` into the matched spec's slot — corrupting coverage, status bar, and notifications whenever the saved spec wasn't the report's first entry, and pushing duplicates when the ID matched nothing.
- **Finding 4 (multi-root, AC-22):** clients/diagnostic collections were keyed per folder, but the coverage report was a single module-global (last folder wins), and relative diagnostic/sidebar paths always resolved against `workspaceFolders[0]` — folder B's parse-error diagnostics pointed into folder A.

## Commits (SDD three-commit cycle)

1. **docs(specs)** — spec-vscode 1.6.0 → 1.7.0: AC-22 and AC-33 amended (per-folder report named explicitly; owning-folder resolution at ingestion time), new AC-54 (per-folder report isolation, merged aggregate views, folder-removal cleanup, single-root unchanged) and AC-55 (on-save whole-report replacement; entries[0] splice and regex trigger prohibited). AC-33's 1.6.0 text did **not** mandate the bug — it underspecified which folder; 1.7.0 makes it explicit.
2. **test(vscode)** — new `coverageIsolation.test.ts` (+22 tests): per-folder isolation, owning-folder path resolution, on-save replacement invariants, single-root regression.
3. **fix(vscode)** — `CoverageReportStore` keyed like the clients map, with **ingestion-time path normalization** (specFile, testFiles, parseErrors[].file resolved absolute against the owning folder's CLI cwd), so downstream consumers need no folder context. Status bar/sidebar/Insights read a merged view — identity-returning for single-root. On-save now re-runs coverage for the saved file's folder through the same path as activation; the AC-18 notification matches the saved spec by `specFile`. `shouldRunCoverageForFile` and `client.coverage`'s dead `specID` param removed.

## Behavior notes

- Single-root report/path machinery is unchanged (regression-tested; merged() returns the lone report by identity).
- Two intentional changes apply in single-root too: on-save now actually refreshes coverage (the old trigger almost never fired on real spec files), and sidebar tooltips show absolute paths (side effect of ingestion-time normalization).
- Pre-existing, out of scope: last-folder-wins status-bar quirk when one folder has parse errors, and drift-scan's first-folder git lookup.

## Stacking

⚠️ **Based on #140** (`fix/strictness-parity`) — builds on its `client.ts --strictness annotation` change. Merge after #140; GitHub will retarget to `main` when the base branch is deleted.

## Verification

`npm run typecheck` clean; jest 14 suites, 268 tests green (was 248); spec parses (`spec-vscode@1.7.0`); `make dogfood` 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)