### PR TITLE
fix(vscode): exclude jest-junit output from the VSIX package

### DIFF
--- a/specter/vscode-extension/.vscodeignore
+++ b/specter/vscode-extension/.vscodeignore
@@ -7,3 +7,4 @@ jest.config.js
 tsconfig.json
 .gitignore
 *.vsix
+junit.xml


### PR DESCRIPTION
One-line packaging fix: `junit.xml` (jest-junit's report, regenerated by every `npm test` and `make dogfood-strict`) was not in `.vscodeignore`, so any VSIX packaged after a test run shipped ~46 KB of test output to users. Caught in the v0.14.0 `release-check` package listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)